### PR TITLE
Fixes needed to allow build with HAVE_EXT_POSTGRESQL

### DIFF
--- a/src/condor_q.V6/queue.cpp
+++ b/src/condor_q.V6/queue.cpp
@@ -926,7 +926,7 @@ int main (int argc, char **argv)
 
 			/* If the quill information is available, try to use it first */
 			useDB = TRUE;
-	    	if (ad->LookupString(ATTR_SCHEDD_NAME, daemonAdName)) {
+	    	if (ad->LookupString(ATTR_SCHEDD_NAME, daemonAdName, 128)) {
 				Q.addSchedd(daemonAdName);
 			} else {
 				Q.addSchedd(scheddName);
@@ -3218,7 +3218,7 @@ show_db_queue( const char* quill_name, const char* db_ipAddr, const char* db_nam
 
 	if (better_analyze) {
 		print_full_header(source_label.c_str());
-		return print_jobs_analysis(jobs, NULL);
+		return print_jobs_analysis(jobs, NULL, NULL);
 	}
 
 	// at this point we either have a populated jobs list, or a populated dag_map

--- a/src/condor_tools/history.cpp
+++ b/src/condor_tools/history.cpp
@@ -130,6 +130,7 @@ main(int argc, char* argv[])
   char *quillName=NULL;
   AttrList *ad=0;
   int flag = 1;
+  char tmp[128];
 #endif /* HAVE_EXT_POSTGRESQL */
 
   void **parameters;
@@ -147,8 +148,6 @@ main(int argc, char* argv[])
 
   std::string constraint;
   ExprTree *constraintExpr=NULL;
-
-  std::string tmp;
 
   int i;
   parameters = (void **) malloc(NUM_PARAMETERS * sizeof(void *));
@@ -233,8 +232,8 @@ main(int argc, char* argv[])
 */
 		quillName = argv[i];
 
-		sprintf (tmp, "%s == \"%s\"", ATTR_SCHEDD_NAME, quillName);
-		quillQuery.addORConstraint (tmp.c_str());
+		snprintf (tmp, 128, "%s == \"%s\"", ATTR_SCHEDD_NAME, quillName);
+		quillQuery.addORConstraint (tmp);
 
 		remotequill = false;
 		readfromfile = false;

--- a/src/condor_utils/MyString.cpp
+++ b/src/condor_utils/MyString.cpp
@@ -630,6 +630,22 @@ MyString::formatstr(const char *format,...)
 	return succeeded;
 }
 
+#ifdef HAVE_EXT_POSTGRESQL
+// An sprintf alias for formatstr, used by various PostgreSQL modules
+bool
+MyString::sprintf(const char *format,...)
+{
+	bool    succeeded;
+	va_list args;
+
+	va_start(args, format);
+	succeeded = vformatstr(format,args);
+	va_end(args);
+
+	return succeeded;
+}
+#endif // HAVE_EXT_POSTGRESQL
+
 void
 MyString::lower_case(void)
 {

--- a/src/condor_utils/MyString.h
+++ b/src/condor_utils/MyString.h
@@ -250,6 +250,10 @@ class MyString
 	 */
 	bool formatstr(const char *format, ...) CHECK_PRINTF_FORMAT(2,3);
 
+#ifdef HAVE_EXT_POSTGRESQL
+	bool sprintf(const char *format, ...) CHECK_PRINTF_FORMAT(2,3);
+#endif
+
 	/** Fills a MyString with what you would have gotten from vsprintf.
 	 *  This is handy if you define your own printf-like functions.
 	 */

--- a/src/condor_utils/condor_q.cpp
+++ b/src/condor_utils/condor_q.cpp
@@ -447,7 +447,7 @@ CondorQ::fetchQueueFromDBAndProcess ( const char *dbconn,
 	
 	while (ad != (ClassAd *) 0) {
 			// Process the data and insert it into the list
-		if ((*process_func) (ad, process_func_data) ) {
+		if ((*process_func) (ad, (ClassAd*)process_func_data) ) {
 			ad->Clear();
 			delete ad;
 		}

--- a/src/condor_utils/file_transfer_db.cpp
+++ b/src/condor_utils/file_transfer_db.cpp
@@ -134,7 +134,7 @@ void file_transfer_db(file_transfer_record *rp, ClassAd *ad)
 	} else {
 		InputFiles = new StringList(NULL,",");
 	}
-	if (ad->LookupString(ATTR_JOB_INPUT, buf) == 1) {
+	if (ad->LookupString(ATTR_JOB_INPUT, buf, ATTRLIST_MAX_EXPRESSION) == 1) {
         // only add to list if not NULL_FILE (i.e. /dev/null)
         if ( ! nullFile(buf) ) {
             if ( !InputFiles->file_contains(buf) )


### PR DESCRIPTION
This commit provides changes needed to allow a build with HAVE_EXT_POSTGRESQL defined. 

The DB components use sprintf in MyString rather than formatstr, so to limit the scope of the changes I added an "sprintf" function as a duplicate of the formatstr function, rather than rewriting dozens of sprintf references in multiple files.

Config for successful build was:

cmake cmake -DWANT_CONTRIB:BOOL=TRUE -DWANT_QUILL:BOOL=TRUE -DWITH_POSTGRESQL:BOOL=TRUE .