### PR TITLE
Properly document Environment Job ClassAd attributes

### DIFF
--- a/doc/misc/jobad.tex
+++ b/doc/misc/jobad.tex
@@ -575,15 +575,15 @@ will equal the number of seconds that the job has been on hold.
 
 %%% ClassAd attribute: Env
 \index{ClassAd job attribute!Env}
-\index{Args!job ClassAd attribute}
-\item[\AdAttr{Args}:]  A string representing the environment variables 
+\index{Env!job ClassAd attribute}
+\item[\AdAttr{Env}:]  A string representing the environment variables 
 passed to the job, when those arguments are specified using the
 \emph{old} syntax, as specified in section~\ref{man-condor-submit-environment}.
 
 %%% ClassAd attribute: Environment
 \index{ClassAd job attribute!Environment}
-\index{Arguments!job ClassAd attribute}
-\item[\AdAttr{Arguments}:]  A string representing the environment variables
+\index{Environment!job ClassAd attribute}
+\item[\AdAttr{Environment}:]  A string representing the environment variables
 passed to the job, when those arguments are specified using the
 \emph{new} syntax, as specified in section~\ref{man-condor-submit-environment}.
 


### PR DESCRIPTION
Env and Environment ClassAd attributes have been misdocumented as Args and Arguments since at least v8.
