### PR TITLE
Add Checkpoint Role

### DIFF
--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -8402,6 +8402,13 @@ default : @end
 @end
 review=?
 
+[$ROLE.Checkpoint]
+friendly_name=Settings for HTCondor Checkpoint Server
+default : @end
+	DAEMON_LIST=$(DAEMON_LIST) CKPT_SERVER
+@end
+review=?
+
 # default security policy
 [$SECURITY.HOST_BASED]
 friendly_name=Default (host based) Authorization policy based on IPs and DNS names


### PR DESCRIPTION
I am updating my pool's config to 8.5 syntax and am making use of "use ROLE:" where I can. This is an instance where I cannot.