### PR TITLE
Windows and no openssl build fixes

### DIFF
--- a/externals/bundles/openssl/1.0.1j/CMakeLists.txt
+++ b/externals/bundles/openssl/1.0.1j/CMakeLists.txt
@@ -24,9 +24,9 @@ if (WITH_OPENSSL)
 
   if ( NOT OPENSSL_FOUND AND NOT PROPER AND NOT LINUX AND NOT DARWIN )
   
-    set (OPENSSL_DOWNLOAD ${OPENSSL_VER}.tar.gz)
-
     condor_pre_external( OPENSSL openssl-1.0.1j "lib;include" "include/openssl/ssl.h")
+
+    set (OPENSSL_DOWNLOAD ${OPENSSL_VER}.tar.gz)
 
     if (WINDOWS)
       set (OPENSSL_INSTALL cp *.lib ${OPENSSL_INSTALL_LOC}/lib \r\n

--- a/externals/bundles/pcre/8.33/CMakeLists.txt
+++ b/externals/bundles/pcre/8.33/CMakeLists.txt
@@ -18,9 +18,9 @@
 
 if ( NOT PROPER AND NOT LINUX )
 
-  set (PCRE_DOWNLOAD ${PCRE_VER}.tar.gz)
   if (WINDOWS)
     condor_pre_external( PCRE pcre-8.33 "lib;include" "include/pcre.h")
+    set (PCRE_DOWNLOAD ${PCRE_VER}.tar.gz)
 		set (PCRE_INSTALL cp pcre.lib ${PCRE_INSTALL_LOC}/lib \r\n
 						  cp pcre.dll ${PCRE_INSTALL_LOC}/lib \r\n
 						  cp pcre.h ${PCRE_INSTALL_LOC}/include )
@@ -36,6 +36,7 @@ if ( NOT PROPER AND NOT LINUX )
     set (PCRE_CONFIGURE echo "No configuration necessary")
     set (PCRE_MAKE echo "No make necessary")
   else()
+    set (PCRE_DOWNLOAD ${PCRE_VER}.tar.gz)
     # Currently not attempting to deal with newer version of PCRE on other platforms
   endif()
 

--- a/src/classad/classad/common.h
+++ b/src/classad/classad/common.h
@@ -79,7 +79,7 @@
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
 #define strtoll _strtoi64
-#ifndef rint
+#if _MSC_VER < 1800 // Added to the standard library in VS 2013
 #define rint(num) floor(num + .5)
 #endif
 #define isnan _isnan

--- a/src/condor_ft-gahp/io_loop.cpp
+++ b/src/condor_ft-gahp/io_loop.cpp
@@ -28,7 +28,9 @@
 #include "globus_utils.h"
 #include "subsystem_info.h"
 #include "file_transfer.h"
-#include "openssl/md5.h"
+#ifdef HAVE_EXT_OPENSSL
+#include <openssl/md5.h>
+#endif
 #include "directory.h"
 #include "_unordered_map.h"
 #include "basename.h"
@@ -950,6 +952,7 @@ define_sandbox_path(std::string sid, std::string &path)
 	free(t_path);
 
 
+#ifdef HAVE_EXT_OPENSSL
 	// hash the id into ascii.  MD5 is fine here, because we use the actual
 	// sandbox id as part of the path, thus making it immune to MD5 collisions.
 	// we're only using it to keep filesystems free of directories that contain
@@ -981,6 +984,7 @@ define_sandbox_path(std::string sid, std::string &path)
 	path += c_hex_md5[5];
 	path += c_hex_md5[6];
 	path += c_hex_md5[7];
+#endif // ifdef HAVE_EXT_OPENSSL
 	path += DIR_DELIM_CHAR;
 	path += sid;
 

--- a/src/condor_includes/condor_ipv6.WINDOWS.h
+++ b/src/condor_includes/condor_ipv6.WINDOWS.h
@@ -20,6 +20,10 @@
 #ifndef CONDOR_WIN_IPV6_H
 #define CONDOR_WIN_IPV6_H
 
+#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS // Shut up Visual Studio 2013+
+#define _WINSOCK_DEPRECATED_NO_WARNINGS
+#endif
+
 #include "winsock2.h"
 #include "ws2tcpip.h"
 

--- a/src/condor_includes/condor_snutils.h
+++ b/src/condor_includes/condor_snutils.h
@@ -40,12 +40,14 @@
 BEGIN_C_DECLS
 
 #ifdef WIN32
+#ifndef HAVE_WORKING_SNPRINTF
 int snprintf(char *str, size_t size, const char *format, ...);
 /**	Disable the warning about the number of formal parameters 
 	differing from a previous declaration */
 #pragma warning(suppress: 4273) // inconsistent dll linkage
 #pragma warning(suppress: 28251) // inconsistent annotations
 int __cdecl vsnprintf(char *str, size_t size, const char *format, va_list args);
+#endif
 #endif
 
 int printf_length(const char *format, ...);

--- a/src/condor_includes/condor_sys_nt.h
+++ b/src/condor_includes/condor_sys_nt.h
@@ -69,6 +69,9 @@
 // the ordering of the two following header files 
 // is important! Starting with the new SDK, we want 
 // winsock2.h not winsock.h, so we include it first. 
+#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS // Shut up Visual Studio 2013+
+#define _WINSOCK_DEPRECATED_NO_WARNINGS
+#endif
 #include <winsock2.h>
 #include <windows.h>
 

--- a/src/condor_includes/condor_sys_nt.h
+++ b/src/condor_includes/condor_sys_nt.h
@@ -164,7 +164,9 @@ DLL_IMPORT_MAGIC int __cdecl access(const char *, int);
 #define S_IRWXO 2
 #define S_ISDIR(mode) (((mode)&_S_IFDIR) == _S_IFDIR)
 #define S_ISREG(mode) (((mode)&_S_IFREG) == _S_IFREG)
+#if _MSC_VER < 1800 // Added to the standard library in VS 2013
 #define rint(num) ((num<0.)? -floor(-num+.5):floor(num+.5))
+#endif
 
 #ifndef ETIMEDOUT
 #define ETIMEDOUT ERROR_TIMEOUT

--- a/src/condor_includes/safe_sock.h
+++ b/src/condor_includes/safe_sock.h
@@ -22,6 +22,9 @@
 #define SAFE_SOCK_H
 
 #if defined(WIN32)
+#ifndef _WINSOCK_DEPRECATED_NO_WARNINGS // Shut up Visual Studio 2013+
+#define _WINSOCK_DEPRECATED_NO_WARNINGS
+#endif
 #include <winsock2.h>
 #else
 #include <netinet/in.h>

--- a/src/condor_io/authentication.cpp
+++ b/src/condor_io/authentication.cpp
@@ -1003,7 +1003,12 @@ int Authentication::handshake(MyString my_methods, bool non_blocking) {
 			dprintf (D_SECURITY, "HANDSHAKE: excluding KERBEROS: %s\n", "Initialization failed");
 			method_bitmask &= ~CAUTH_KERBEROS;
 		}
-		if ( (method_bitmask & CAUTH_SSL) && Condor_Auth_SSL::Initialize() == false ) {
+#ifdef HAVE_EXT_OPENSSL
+		if ( (method_bitmask & CAUTH_SSL) && Condor_Auth_SSL::Initialize() == false )
+#else
+		if (method_bitmask & CAUTH_SSL)
+#endif
+		{
 			dprintf (D_SECURITY, "HANDSHAKE: excluding SSL: %s\n", "Initialization failed");
 			method_bitmask &= ~CAUTH_SSL;
 		}
@@ -1058,7 +1063,12 @@ Authentication::handshake_continue(MyString my_methods, bool non_blocking)
 		dprintf (D_SECURITY, "HANDSHAKE: excluding KERBEROS: %s\n", "Initialization failed");
 		shouldUseMethod &= ~CAUTH_KERBEROS;
 	}
-	if ( (shouldUseMethod & CAUTH_SSL) && Condor_Auth_SSL::Initialize() == false ) {
+#ifdef HAVE_EXT_OPENSSL
+	if ( (shouldUseMethod & CAUTH_SSL) && Condor_Auth_SSL::Initialize() == false )
+#else
+	if (shouldUseMethod & CAUTH_SSL)
+#endif
+	{
 		dprintf (D_SECURITY, "HANDSHAKE: excluding SSL: %s\n", "Initialization failed");
 		shouldUseMethod &= ~CAUTH_SSL;
 	}

--- a/src/condor_submit.V6/submit.cpp
+++ b/src/condor_submit.V6/submit.cpp
@@ -85,7 +85,6 @@
 #include "vm_univ_utils.h"
 #include "condor_md.h"
 #include "my_popen.h"
-#include "condor_base64.h"
 #include "zkm_base64.h"
 
 #include <algorithm>
@@ -9722,7 +9721,7 @@ int SendJobCredential()
 			}
 
 			// immediately convert to base64
-			char* ut64 = condor_base64_encode(uber_ticket, bytes_read);
+			char* ut64 = zkm_base64_encode(uber_ticket, bytes_read);
 
 			// sanity check:  convert it back.
 			//unsigned char *zkmbuf = 0;

--- a/src/condor_tools/soap_setupStub.cpp
+++ b/src/condor_tools/soap_setupStub.cpp
@@ -1,4 +1,11 @@
+#ifdef HAVE_EXT_GSOAP
 #include "stdsoap2.h"
+#else
+#include <stddef.h>
+struct soap;
+#define SOAP_FMAC1
+#define SOAP_FMAC2
+#endif
 
 SOAP_FMAC1 const char** SOAP_FMAC2 soap_faultcode(struct soap*)
 { return NULL; }

--- a/src/condor_utils/condor_snutils.cpp
+++ b/src/condor_utils/condor_snutils.cpp
@@ -28,6 +28,7 @@
 */
 
 #ifdef WIN32
+#ifndef HAVE_WORKING_SNPRINTF
 int 
 snprintf(
 	char       *str, 
@@ -65,6 +66,7 @@ vsnprintf(
 
 	return length;
 }
+#endif /* ifndef HAVE_WORKING_SNPRINTF */
 		  
 
 // Returns the number of characters that a printf would return,

--- a/src/condor_utils/misc_utils.cpp
+++ b/src/condor_utils/misc_utils.cpp
@@ -117,6 +117,9 @@ my_timezone(int isdst)
 	  return tzname[0];
   }
 #else
+#ifndef timezone
+#define timezone _timezone
+#endif
 	// On Win32, tzname is useless.  It return a string like
 	// "Central Standard Time", which doesn't follow any standard,
 	// and thus cannot be used in things like valid SQL statements.

--- a/src/defrag/defrag.h
+++ b/src/defrag/defrag.h
@@ -20,6 +20,7 @@
 #ifndef _DEFRAG_H
 #define _DEFRAG_H
 
+#include <iterator>
 #include <set>
 #include "condor_common.h"
 #include "condor_daemon_core.h"


### PR DESCRIPTION
This patchset fixes a variety of build issues encountered when build without openssl and without gsoap using Visual Studio 2015.