### PR TITLE
(#6326) python3 fixes for classad_tests.py

### DIFF
--- a/build/cmake/CondorConfigure.cmake
+++ b/build/cmake/CondorConfigure.cmake
@@ -82,7 +82,11 @@ message(STATUS "********* BEGINNING CONFIGURATION *********")
 
 # To find python in Windows we will use alternate technique
 if(NOT WINDOWS AND NOT CONDOR_PLATFORM MATCHES "Fedora19")
+	if (DEFINED PYTHON_VERSION)
+		set(Python_ADDITIONAL_VERSIONS ${PYTHON_VERSION})
+	endif()
 	include (FindPythonLibs)
+	message(STATUS "Got PYTHONLIBS_VERSION_STRING = ${PYTHONLIBS_VERSION_STRING}")
 	# As of cmake 2.8.8, the variable below is defined by FindPythonLibs.
 	# This helps ensure we get the same version of the libraries and python
 	# on systems with both python2 and python3.
@@ -90,6 +94,7 @@ if(NOT WINDOWS AND NOT CONDOR_PLATFORM MATCHES "Fedora19")
 		set(PythonInterp_FIND_VERSION "${PYTHONLIBS_VERSION_STRING}")
 	endif()
 	include (FindPythonInterp)
+	message(STATUS "Got PYTHON_VERSION_STRING = ${PYTHON_VERSION_STRING}")
 else()
 	if(WINDOWS)
 		#only for Visual Studio 2012

--- a/src/classad/lexerSource.cpp
+++ b/src/classad/lexerSource.cpp
@@ -65,6 +65,7 @@ FileLexerSource::ReadCharacter(void)
 void 
 FileLexerSource::UnreadCharacter(void)
 {
+	// keep FILE pos in sync with fd, for the sake of Python 3 objects
 	fseek(_file, -1, SEEK_CUR);
 	//ungetc(_previous_character, _file);
 	return;

--- a/src/classad/lexerSource.cpp
+++ b/src/classad/lexerSource.cpp
@@ -65,8 +65,8 @@ FileLexerSource::ReadCharacter(void)
 void 
 FileLexerSource::UnreadCharacter(void)
 {
-	//fseek(_file, -1, SEEK_CUR);
-	ungetc(_previous_character, _file);
+	fseek(_file, -1, SEEK_CUR);
+	//ungetc(_previous_character, _file);
 	return;
 }
 

--- a/src/condor_includes/condor_sys_linux.h
+++ b/src/condor_includes/condor_sys_linux.h
@@ -22,7 +22,9 @@
 
 #ifndef _BSD_SOURCE
 #define _BSD_SOURCE
-#define _DEFAULT_SOURCE
+# ifndef _DEFAULT_SOURCE
+#  define _DEFAULT_SOURCE
+# endif
 #endif
 
 #if defined(GLIBC)

--- a/src/python-bindings/bulk_query_iterator.cpp
+++ b/src/python-bindings/bulk_query_iterator.cpp
@@ -31,7 +31,7 @@ public:
         }
         boost::python::object iterable = input.attr("__iter__")();
 
-        bool input_has_next = py_hasattr(iterable, "next");
+        bool input_has_next = py_hasattr(iterable, NEXT_FN);
         while (true)
         {
             boost::python::object next_obj;
@@ -39,7 +39,7 @@ public:
             {
                 if (input_has_next)
                 {
-                    next_obj = iterable.attr("next")();
+                    next_obj = iterable.attr(NEXT_FN)();
                 }
                 else if (iterable.ptr() && iterable.ptr()->ob_type && iterable.ptr()->ob_type->tp_iternext)
                 {
@@ -174,7 +174,7 @@ export_query_iterator()
 
     boost::python::class_<BulkQueryIterator>("BulkQueryIterator", "A bulk interface for schedd queryies.", boost::python::no_init)
         .def("__iter__", &BulkQueryIterator::pass_through)
-        .def("next", &BulkQueryIterator::next, "Return the next ready QueryIterator object.\n")
+        .def(NEXT_FN, &BulkQueryIterator::next, "Return the next ready QueryIterator object.\n")
         ;
 
     boost::python::def("poll", pollAllAds,

--- a/src/python-bindings/classad.cpp
+++ b/src/python-bindings/classad.cpp
@@ -783,7 +783,8 @@ pythonFunctionTrampoline_internal(const char *name, const classad::ArgumentList&
         pyKw["state"] = wrapper;
     }
 
-    boost::python::object pyResult = py_import("__main__").attr("__builtins__").attr("apply")(pyFunc, pyArgs, pyKw);
+    boost::python::object pyResult = boost::python::eval("lambda f,a,kw: f(*a,**kw)")(pyFunc, pyArgs, pyKw);
+
     classad::ExprTree* exprTreeResult = convert_python_to_exprtree(pyResult);
     if (!exprTreeResult || !exprTreeResult->Evaluate(state, result))
     {

--- a/src/python-bindings/classad.cpp
+++ b/src/python-bindings/classad.cpp
@@ -896,20 +896,23 @@ convert_python_to_exprtree(boost::python::object value)
     if (PyMapping_Check(value.ptr()))
     {
         PyObject *keys = PyMapping_Keys(value.ptr());
-        if (!keys) {THROW_EX(RuntimeError, "Unable to convert mapping to keys");}
-        ClassAdWrapper *ad = new ClassAdWrapper();
-        boost::python::object iter = boost::python::object(boost::python::handle<>(keys));
-        while (true)
-        {
-            PyObject *pyobj = PyIter_Next(iter.ptr());
-            if (!pyobj) {break;}
-            boost::python::object key_obj = boost::python::object(boost::python::handle<>(pyobj));
-            std::string key_str = boost::python::extract<std::string>(key_obj);
-            boost::python::object val = value[key_obj];
-            classad::ExprTree *val_expr = convert_python_to_exprtree(val);
-            ad->Insert(key_str, val_expr);
+        if (!keys) {
+            PyErr_Clear();
+        } else {
+            ClassAdWrapper *ad = new ClassAdWrapper();
+            boost::python::object iter = boost::python::object(boost::python::handle<>(keys));
+            while (true)
+            {
+                PyObject *pyobj = PyIter_Next(iter.ptr());
+                if (!pyobj) {break;}
+                boost::python::object key_obj = boost::python::object(boost::python::handle<>(pyobj));
+                std::string key_str = boost::python::extract<std::string>(key_obj);
+                boost::python::object val = value[key_obj];
+                classad::ExprTree *val_expr = convert_python_to_exprtree(val);
+                ad->Insert(key_str, val_expr);
+            }
+            return ad;
         }
-        return ad;
     }
     PyObject *py_iter = PyObject_GetIter(value.ptr());
     if (py_iter)

--- a/src/python-bindings/classad.cpp
+++ b/src/python-bindings/classad.cpp
@@ -394,7 +394,7 @@ ExprTreeHolder::apply_unary_operator(classad::Operation::OpKind kind) const
 }
 
 bool
-ExprTreeHolder::__nonzero__()
+ExprTreeHolder::__bool__()
 {
     boost::python::object result = Evaluate();
     boost::python::extract<classad::Value::ValueType> value_extract(result);

--- a/src/python-bindings/classad.cpp
+++ b/src/python-bindings/classad.cpp
@@ -19,12 +19,6 @@
 #include "exprtree_wrapper.h"
 #include "old_boost.h"
 
-// http://docs.python.org/3/c-api/apiabiversion.html#apiabiversion
-#if PY_MAJOR_VERSION >= 3
-   #define PyInt_Check(op)  PyNumber_Check(op)
-   #define PyString_Check(op)  PyBytes_Check(op)
-#endif
-
 
 void
 ExprTreeHolder::init()
@@ -851,7 +845,7 @@ convert_python_to_exprtree(boost::python::object value)
         classad::Value val; val.SetBooleanValue(cppvalue);
         return classad::Literal::MakeLiteral(val);
     }
-    if (PyString_Check(value.ptr()) || PyUnicode_Check(value.ptr()))
+    if (PyBytes_Check(value.ptr()) || PyUnicode_Check(value.ptr()))
     {
         std::string cppvalue = boost::python::extract<std::string>(value);
         classad::Value val; val.SetStringValue(cppvalue);

--- a/src/python-bindings/classad.cpp
+++ b/src/python-bindings/classad.cpp
@@ -777,6 +777,7 @@ pythonFunctionTrampoline_internal(const char *name, const classad::ArgumentList&
         pyKw["state"] = wrapper;
     }
 
+    // the `apply` builtin is unavailable in python3; hack it with a lambda
     boost::python::object pyResult = boost::python::eval("lambda f,a,kw: f(*a,**kw)")(pyFunc, pyArgs, pyKw);
 
     classad::ExprTree* exprTreeResult = convert_python_to_exprtree(pyResult);

--- a/src/python-bindings/classad_module.cpp
+++ b/src/python-bindings/classad_module.cpp
@@ -80,6 +80,7 @@ void *convert_to_FILEptr(PyObject* obj) {
     }
     const char * file_flags = (flags&O_RDWR) ? "w+" : ( (flags&O_WRONLY) ? "w" : "r" );
     FILE* fp = fdopen(fd, file_flags);
+    setbuf(fp, NULL);
     return fp;
 }
 #else

--- a/src/python-bindings/classad_module.cpp
+++ b/src/python-bindings/classad_module.cpp
@@ -236,7 +236,11 @@ BOOST_PYTHON_MODULE(classad)
         .def("__getitem__", &ExprTreeHolder::getItem, condor::classad_expr_return_policy<>())
         .def("_get", &ExprTreeHolder::subscript, condor::classad_expr_return_policy<>())
         .def("eval", &ExprTreeHolder::Evaluate, evaluate_overloads("Evalaute the expression, possibly within context of a ClassAd"))
-        .def("__nonzero__", &ExprTreeHolder::__nonzero__)
+#if PY_MAJOR_VERSION >= 3
+        .def("__bool__", &ExprTreeHolder::__bool__)
+#else
+        .def("__nonzero__", &ExprTreeHolder::__bool__)
+#endif
         .def("sameAs", &ExprTreeHolder::SameAs, "Returns true if given ExprTree is same as this one.")
         .def("and_", &ExprTreeHolder::__land__)
         .def("or_", &ExprTreeHolder::__lor__)

--- a/src/python-bindings/classad_module.cpp
+++ b/src/python-bindings/classad_module.cpp
@@ -275,17 +275,17 @@ BOOST_PYTHON_MODULE(classad)
         ;
 
     class_<OldClassAdIterator>("OldClassAdIterator", no_init)
-        .def("next", &OldClassAdIterator::next)
+        .def(NEXT_FN, &OldClassAdIterator::next)
         .def("__iter__", &OldClassAdIterator::pass_through)
         ;
 
     class_<ClassAdStringIterator>("ClassAdStringIterator", no_init)
-        .def("next", &ClassAdStringIterator::next)
+        .def(NEXT_FN, &ClassAdStringIterator::next)
         .def("__iter__", &OldClassAdIterator::pass_through)
         ;
 
     class_<ClassAdFileIterator>("ClassAdFileIterator")
-        .def("next", &ClassAdFileIterator::next)
+        .def(NEXT_FN, &ClassAdFileIterator::next)
         .def("__iter__", &OldClassAdIterator::pass_through)
         ;
 

--- a/src/python-bindings/classad_parsers.cpp
+++ b/src/python-bindings/classad_parsers.cpp
@@ -258,10 +258,7 @@ OldClassAdIterator::next()
                 m_ad.reset();
                 if (reset_ptr && py_hasattr(m_source, "seek"))
                 {
-                    PyObject *ptype, *pvalue, *ptraceback;
-                    PyErr_Fetch(&ptype, &pvalue, &ptraceback);
                     m_source.attr("seek")(end_ptr);
-                    PyErr_Restore(ptype, pvalue, ptraceback);
                 }
                 PyErr_Clear();
                 return result;

--- a/src/python-bindings/classad_parsers.cpp
+++ b/src/python-bindings/classad_parsers.cpp
@@ -263,9 +263,7 @@ OldClassAdIterator::next()
                     m_source.attr("seek")(end_ptr);
                     PyErr_Restore(ptype, pvalue, ptraceback);
                 }
-#if PY_MAJOR_VERSION >= 3
                 PyErr_Clear();
-#endif
                 return result;
             }
             boost::python::throw_error_already_set();

--- a/src/python-bindings/classad_parsers.cpp
+++ b/src/python-bindings/classad_parsers.cpp
@@ -145,7 +145,7 @@ boost::shared_ptr<ClassAdWrapper> parseOne(boost::python::object input, ParserTy
     }
     boost::shared_ptr<ClassAdWrapper> result_ad(new ClassAdWrapper());
     input = parseAds(input, type);
-    bool input_has_next = py_hasattr(input, "next");
+    bool input_has_next = py_hasattr(input, NEXT_FN);
     while (true)
     {
         boost::python::object next_obj;
@@ -153,7 +153,7 @@ boost::shared_ptr<ClassAdWrapper> parseOne(boost::python::object input, ParserTy
         {
             if (input_has_next)
             {
-                next_obj = input.attr("next")();
+                next_obj = input.attr(NEXT_FN)();
             }
             else if (input.ptr() && input.ptr()->ob_type && input.ptr()->ob_type->tp_iternext)
             {
@@ -183,9 +183,9 @@ boost::shared_ptr<ClassAdWrapper> parseOne(boost::python::object input, ParserTy
 boost::python::object parseNext(boost::python::object source, ParserType type)
 {
     boost::python::object ad_iter = parseAds(source, type);
-    if (py_hasattr(ad_iter, "next"))
+    if (py_hasattr(ad_iter, NEXT_FN))
     {
-        return ad_iter.attr("next")();
+        return ad_iter.attr(NEXT_FN)();
     }
     if (source.ptr() && source.ptr()->ob_type && source.ptr()->ob_type->tp_iternext)
     {
@@ -200,7 +200,7 @@ boost::python::object parseNext(boost::python::object source, ParserType type)
 }
 
 OldClassAdIterator::OldClassAdIterator(boost::python::object source)
-    : m_done(false), m_source_has_next(py_hasattr(source, "next")),
+    : m_done(false), m_source_has_next(py_hasattr(source, NEXT_FN)),
       m_ad(new ClassAdWrapper()), m_source(source)
 {
     if (!m_source_has_next && !PyIter_Check(m_source.ptr()))
@@ -240,7 +240,7 @@ OldClassAdIterator::next()
         {
             if (m_source_has_next)
             {
-                next_obj = m_source.attr("next")();
+                next_obj = m_source.attr(NEXT_FN)();
             }
             else
             {
@@ -435,8 +435,8 @@ obj_iternext(PyObject *self)
         try
         {
             boost::python::object obj(boost::python::borrowed(self));
-            if (!py_hasattr(obj, "next")) THROW_EX(TypeError, "instance has no next() method");
-            boost::python::object result = obj.attr("next")();
+            if (!py_hasattr(obj, NEXT_FN)) THROW_EX(TypeError, "instance has no " NEXT_FN "() method");
+            boost::python::object result = obj.attr(NEXT_FN)();
             return boost::python::incref(result.ptr());
         }
         catch (...)

--- a/src/python-bindings/classad_parsers.cpp
+++ b/src/python-bindings/classad_parsers.cpp
@@ -6,12 +6,6 @@
 
 #include "classad_parsers.h"
 
-// http://docs.python.org/3/c-api/apiabiversion.html#apiabiversion
-#if PY_MAJOR_VERSION >= 3
-   #define PyInt_Check(op)  PyNumber_Check(op)
-   #define PyString_Check(op)  PyBytes_Check(op)
-#endif
-
 static OldClassAdIterator parseOldAds_impl(boost::python::object input);
 
 ClassAdWrapper *parseString(const std::string &str)
@@ -343,7 +337,7 @@ static
 OldClassAdIterator
 parseOldAds_impl(boost::python::object input)
 {
-    boost::python::object input_iter = (PyString_Check(input.ptr()) || PyUnicode_Check(input.ptr())) ?
+    boost::python::object input_iter = (PyBytes_Check(input.ptr()) || PyUnicode_Check(input.ptr())) ?
           input.attr("splitlines")().attr("__iter__")()
         : input.attr("__iter__")();
 

--- a/src/python-bindings/classad_parsers.cpp
+++ b/src/python-bindings/classad_parsers.cpp
@@ -269,6 +269,9 @@ OldClassAdIterator::next()
                     m_source.attr("seek")(end_ptr);
                     PyErr_Restore(ptype, pvalue, ptraceback);
                 }
+#if PY_MAJOR_VERSION >= 3
+                PyErr_Clear();
+#endif
                 return result;
             }
             boost::python::throw_error_already_set();

--- a/src/python-bindings/classad_python_user.cpp
+++ b/src/python-bindings/classad_python_user.cpp
@@ -48,7 +48,11 @@ extern "C"
     {
         if (!Py_IsInitialized())
         {
+#if PY_MAJOR_VERSION >= 3
+            wchar_t pname[] = L"htcondor";
+#else
             char pname[] = "htcondor";
+#endif
             Py_SetProgramName(pname);
             Py_InitializeEx(0);
         }

--- a/src/python-bindings/collector.cpp
+++ b/src/python-bindings/collector.cpp
@@ -113,7 +113,7 @@ struct Collector {
             {
                 try
                 {
-                    boost::python::object next_obj = my_iter.attr("next")();
+                    boost::python::object next_obj = my_iter.attr(NEXT_FN)();
                     std::string pool_str = boost::python::extract<std::string>(next_obj);
                     collector_list.append(pool_str.c_str());
                 }

--- a/src/python-bindings/collector.cpp
+++ b/src/python-bindings/collector.cpp
@@ -14,6 +14,12 @@
 
 #include "module_lock.h"
 
+// http://docs.python.org/3/c-api/apiabiversion.html#apiabiversion
+#if PY_MAJOR_VERSION >= 3
+   #define PyInt_Check(op)  PyNumber_Check(op)
+   #define PyString_Check(op)  PyBytes_Check(op)
+#endif
+
 using namespace boost::python;
 
 

--- a/src/python-bindings/collector.cpp
+++ b/src/python-bindings/collector.cpp
@@ -14,12 +14,6 @@
 
 #include "module_lock.h"
 
-// http://docs.python.org/3/c-api/apiabiversion.html#apiabiversion
-#if PY_MAJOR_VERSION >= 3
-   #define PyInt_Check(op)  PyNumber_Check(op)
-   #define PyString_Check(op)  PyBytes_Check(op)
-#endif
-
 using namespace boost::python;
 
 
@@ -85,7 +79,7 @@ struct Collector {
             m_collectors = CollectorList::create();
             m_default = true;
         }
-        else if (PyString_Check(pool.ptr()) || PyUnicode_Check(pool.ptr()))
+        else if (PyBytes_Check(pool.ptr()) || PyUnicode_Check(pool.ptr()))
         {
             std::string pool_str = boost::python::extract<std::string>(pool);
             if (pool_str.size())

--- a/src/python-bindings/collector_plugin.cpp
+++ b/src/python-bindings/collector_plugin.cpp
@@ -69,7 +69,11 @@ PythonCollectorPlugin::initialize()
 {
     if (!Py_IsInitialized())
     {
+#if PY_MAJOR_VERSION >= 3
+        wchar_t pname[] = L"condor_collector";
+#else
         char pname[] = "condor_collector";
+#endif
         Py_SetProgramName(pname);
         Py_InitializeEx(0);
     }

--- a/src/python-bindings/event.cpp
+++ b/src/python-bindings/event.cpp
@@ -337,7 +337,7 @@ void export_event_reader()
         .value("WriteLock", WRITE_LOCK);
 
     boost::python::class_<EventIterator>("EventIterator", boost::python::no_init)
-        .def("next", &EventIterator::next, "Returns the next event; whether this blocks indefinitely for new events is controlled by setBlocking().\n"
+        .def(NEXT_FN, &EventIterator::next, "Returns the next event; whether this blocks indefinitely for new events is controlled by setBlocking().\n"
             ":return: The next event in the log.")
         .def("__iter__", &EventIterator::pass_through)
         .def("wait", &EventIterator::wait, "Wait until a new event is available.  No value is returned.\n")

--- a/src/python-bindings/exprtree_wrapper.h
+++ b/src/python-bindings/exprtree_wrapper.h
@@ -67,7 +67,7 @@ struct ExprTreeHolder
     UNARY_OPERATOR(BITWISE_NOT_OP, invert)
     UNARY_OPERATOR(LOGICAL_NOT_OP, not)
 
-    bool __nonzero__();
+    bool __bool__();
 
     static void init();
 

--- a/src/python-bindings/log_reader.cpp
+++ b/src/python-bindings/log_reader.cpp
@@ -168,7 +168,7 @@ void export_log_reader()
         ;
 
     boost::python::class_<LogReader>("LogReader", "A class for reading or tailing ClassAd logs", boost::python::init<const std::string &>(":param filename: The filename to read."))
-        .def("next", &LogReader::next, "Returns the next event; whether this blocks indefinitely for new events is controlled by setBlocking().\n"
+        .def(NEXT_FN, &LogReader::next, "Returns the next event; whether this blocks indefinitely for new events is controlled by setBlocking().\n"
             ":return: The next event in the log.")
         .def("__iter__", &LogReader::pass_through)
         .def("wait", &LogReader::wait, "Wait until a new event is available.  No value is returned.\n")

--- a/src/python-bindings/python_bindings_common.h
+++ b/src/python-bindings/python_bindings_common.h
@@ -55,3 +55,12 @@
  // to the Windows-only <io.h>.
  #undef HAVE_IO_H
 #endif // _MSC_VER
+
+// the "next" method for iterators in python3 is "__next__"
+// https://docs.python.org/2/library/functions.html#next
+// https://docs.python.org/3/library/functions.html#next
+#if PY_MAJOR_VERSION >= 3
+   #define NEXT_FN "__next__"
+#else
+   #define NEXT_FN "next"
+#endif

--- a/src/python-bindings/schedd.cpp
+++ b/src/python-bindings/schedd.cpp
@@ -2222,16 +2222,16 @@ void export_schedd()
         ;
 
     class_<RequestIterator>("ResourceRequestIterator", no_init)
-        .def("next", &RequestIterator::next, "Get next resource request.")
+        .def(NEXT_FN, &RequestIterator::next, "Get next resource request.")
         ;
 
     class_<HistoryIterator>("HistoryIterator", no_init)
-        .def("next", &HistoryIterator::next)
+        .def(NEXT_FN, &HistoryIterator::next)
         .def("__iter__", &HistoryIterator::pass_through)
         ;
 
     class_<QueryIterator>("QueryIterator", no_init)
-        .def("next", &QueryIterator::next, "Return the next ad from the query results.\n"
+        .def(NEXT_FN, &QueryIterator::next, "Return the next ad from the query results.\n"
             ":param mode: One of the BlockingMode enum; Blocking or NonBlocking.\n"
             ":return: The next ad in the query results.  If NonBlocking mode is used, returns None if no ad is available..\n"
             "Throws a StopIterator exception if no results are available..\n",

--- a/src/python-bindings/tests/classad_tests.py
+++ b/src/python-bindings/tests/classad_tests.py
@@ -69,7 +69,7 @@ class TestClassad(unittest.TestCase):
         tf.write(b"[foo = 1] [bar = 2]")
         tf.seek(0)
         ad_iter = classad.parseAds(tf)
-        ad = ad_iter.next()
+        ad = next(ad_iter)
         self.assertEqual(len(ad), 1)
         self.assertEqual(ad["foo"], 1)
         self.assertEqual(" [bar = 2]", tf.read())
@@ -79,7 +79,7 @@ class TestClassad(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             ad_iter = classad.parseOldAds(tf)
-        ad = ad_iter.next()
+        ad = next(ad_iter)
         self.assertEqual(len(ad), 1)
         self.assertEqual(ad["foo"], 1)
         self.assertEqual("bar = 2\n", tf.read())

--- a/src/python-bindings/tests/classad_tests.py
+++ b/src/python-bindings/tests/classad_tests.py
@@ -14,8 +14,8 @@ class TestClassad(unittest.TestCase):
 
     def test_classad_constructor(self):
         ad = classad.ClassAd('[foo = "1"; bar = 2]')
-        self.assertEquals(ad['foo'], "1")
-        self.assertEquals(ad['bar'], 2)
+        self.assertEqual(ad['foo'], "1")
+        self.assertEqual(ad['bar'], 2)
         self.assertRaises(KeyError, ad.__getitem__, 'baz')
 
     def test_pickle(self):
@@ -25,8 +25,8 @@ class TestClassad(unittest.TestCase):
         pexpr = pickle.dumps(expr)
         ad2 = pickle.loads(pad)
         expr2 = pickle.loads(pexpr)
-        self.assertEquals(ad2.__repr__(), "[ one = 1 ]")
-        self.assertEquals(expr2.__repr__(), "2 + 2")
+        self.assertEqual(ad2.__repr__(), "[ one = 1 ]")
+        self.assertEqual(expr2.__repr__(), "2 + 2")
 
     def test_load_classad_from_file(self):
         with warnings.catch_warnings():
@@ -69,7 +69,7 @@ class TestClassad(unittest.TestCase):
         ad = ad_iter.next()
         self.assertEqual(len(ad), 1)
         self.assertEqual(ad["foo"], 1)
-        self.assertEquals(" [bar = 2]", tf.read())
+        self.assertEqual(" [bar = 2]", tf.read())
         tf = tempfile.TemporaryFile()
         tf.write("-----\nfoo = 1\n\nbar = 2\n")
         tf.seek(0)
@@ -79,7 +79,7 @@ class TestClassad(unittest.TestCase):
         ad = ad_iter.next()
         self.assertEqual(len(ad), 1)
         self.assertEqual(ad["foo"], 1)
-        self.assertEquals("bar = 2\n", tf.read())
+        self.assertEqual("bar = 2\n", tf.read())
 
     def test_parse_next(self):
         tf = tempfile.TemporaryFile()
@@ -88,14 +88,14 @@ class TestClassad(unittest.TestCase):
         ad = classad.parseNext(tf)
         self.assertEqual(len(ad), 1)
         self.assertEqual(ad["foo"], 1)
-        self.assertEquals(" [bar = 2]", tf.read())
+        self.assertEqual(" [bar = 2]", tf.read())
         tf = tempfile.TemporaryFile()
         tf.write("-----\nfoo = 1\n\nbar = 2\n")
         tf.seek(0)
         ad = classad.parseNext(tf)
         self.assertEqual(len(ad), 1)
         self.assertEqual(ad["foo"], 1)
-        self.assertEquals("bar = 2\n", tf.read())
+        self.assertEqual("bar = 2\n", tf.read())
 
     def new_ads_verify(self, ads):
         ads = list(ads)
@@ -241,84 +241,84 @@ class TestClassad(unittest.TestCase):
         ad = classad.ClassAd()
         ad["foo"] = classad.Value.Error
         self.assertTrue(isinstance(ad.lookup("foo"), classad.ExprTree))
-        self.assertEquals(ad.lookup("foo").eval(), classad.Value.Error)
+        self.assertEqual(ad.lookup("foo").eval(), classad.Value.Error)
 
     def test_get(self):
         ad = classad.ClassAd()
-        self.assertEquals(ad.get("foo"), None)
-        self.assertEquals(ad.get("foo", "bar"), "bar")
+        self.assertEqual(ad.get("foo"), None)
+        self.assertEqual(ad.get("foo", "bar"), "bar")
         ad["foo"] = "baz"
-        self.assertEquals(ad.get("foo"), "baz")
-        self.assertEquals(ad.get("foo", "bar"), "baz")
+        self.assertEqual(ad.get("foo"), "baz")
+        self.assertEqual(ad.get("foo", "bar"), "baz")
 
     def test_setdefault(self):
         ad = classad.ClassAd()
-        self.assertEquals(ad.setdefault("foo", "bar"), "bar")
-        self.assertEquals(ad.get("foo"), "bar")
+        self.assertEqual(ad.setdefault("foo", "bar"), "bar")
+        self.assertEqual(ad.get("foo"), "bar")
         ad["bar"] = "baz"
-        self.assertEquals(ad.setdefault("bar", "foo"), "baz")
+        self.assertEqual(ad.setdefault("bar", "foo"), "baz")
 
     def test_update(self):
         ad = classad.ClassAd()
         ad.update({"1": 2})
         self.assertTrue("1" in ad)
-        self.assertEquals(ad["1"], 2)
+        self.assertEqual(ad["1"], 2)
         ad.update([("1",3)])
-        self.assertEquals(ad["1"], 3)
+        self.assertEqual(ad["1"], 3)
         other = classad.ClassAd({"3": "5"})
         ad.update(other)
         del other
         self.assertTrue("3" in ad)
-        self.assertEquals(ad["3"], "5")
+        self.assertEqual(ad["3"], "5")
 
     def test_invalid_ref(self):
         expr = classad.ExprTree("foo")
-        self.assertEquals(classad.Value.Undefined, expr.eval())
+        self.assertEqual(classad.Value.Undefined, expr.eval())
 
     def test_temp_scope(self):
         expr = classad.ExprTree("foo")
-        self.assertEquals("bar", expr.eval({"foo": "bar"}))
+        self.assertEqual("bar", expr.eval({"foo": "bar"}))
         ad = classad.ClassAd({"foo": "baz", "test": classad.ExprTree("foo")})
         expr = ad["test"]
-        self.assertEquals("baz", expr.eval())
-        self.assertEquals("bar", expr.eval({"foo": "bar"}))
-        self.assertEquals("bar", expr.eval({"foo": "bar"}))
-        self.assertEquals("baz", expr.eval())
+        self.assertEqual("baz", expr.eval())
+        self.assertEqual("bar", expr.eval({"foo": "bar"}))
+        self.assertEqual("bar", expr.eval({"foo": "bar"}))
+        self.assertEqual("baz", expr.eval())
 
     def test_abstime(self):
         expr = classad.ExprTree('absTime("2013-11-12T07:50:23")')
         dt = expr.eval()
         self.assertTrue(isinstance(dt, datetime.datetime))
-        self.assertEquals(dt.year, 2013)
-        self.assertEquals(dt.month, 11)
-        self.assertEquals(dt.day, 12)
-        self.assertEquals(dt.hour, 7)
-        self.assertEquals(dt.minute, 50)
-        self.assertEquals(dt.second, 23)
+        self.assertEqual(dt.year, 2013)
+        self.assertEqual(dt.month, 11)
+        self.assertEqual(dt.day, 12)
+        self.assertEqual(dt.hour, 7)
+        self.assertEqual(dt.minute, 50)
+        self.assertEqual(dt.second, 23)
 
         ad = classad.ClassAd({"foo": dt})
         dt2 = ad["foo"]
         self.assertTrue(isinstance(dt2, datetime.datetime))
-        self.assertEquals(dt, dt2)
+        self.assertEqual(dt, dt2)
 
         ad = classad.ClassAd({"foo": datetime.datetime.now()});
         td = (datetime.datetime.now()-ad["foo"])
-        self.assertEquals(td.days, 0)
+        self.assertEqual(td.days, 0)
         self.assertTrue(td.seconds < 300)
 
     def test_reltime(self):
         expr = classad.ExprTree('relTime(5)')
-        self.assertEquals(expr.eval(), 5)
+        self.assertEqual(expr.eval(), 5)
 
     def test_quote(self):
-        self.assertEquals(classad.quote("foo"), '"foo"')
-        self.assertEquals(classad.quote('"foo'), '"\\"foo"')
+        self.assertEqual(classad.quote("foo"), '"foo"')
+        self.assertEqual(classad.quote('"foo'), '"\\"foo"')
         for i in ["foo", '"foo', '"\\"foo']:
-            self.assertEquals(i, classad.unquote(classad.quote(i)))
+            self.assertEqual(i, classad.unquote(classad.quote(i)))
 
     def test_literal(self):
-        self.assertEquals(classad.ExprTree('"foo"'), classad.Literal("foo"))
-        self.assertEquals(classad.Literal(1).eval(), 1)
+        self.assertEqual(classad.ExprTree('"foo"'), classad.Literal("foo"))
+        self.assertEqual(classad.Literal(1).eval(), 1)
 
     def test_operator(self):
         expr = classad.Literal(1) + 2
@@ -327,7 +327,7 @@ class TestClassad(unittest.TestCase):
         self.assertTrue(expr.sameAs(classad.ExprTree('1 + 2')))
         expr = classad.Literal(1) & 2
         self.assertTrue(isinstance(expr, classad.ExprTree))
-        self.assertEquals(expr.eval(), 0)
+        self.assertEqual(expr.eval(), 0)
         self.assertTrue(expr.sameAs(classad.ExprTree('1 & 2')))
         expr = classad.Attribute("foo").is_(classad.Value.Undefined)
         self.assertTrue(expr.eval())
@@ -341,15 +341,15 @@ class TestClassad(unittest.TestCase):
         ad = classad.ClassAd({'foo': [0,1,2,3]})
         expr = classad.Attribute("foo")._get(2)
         self.assertTrue(isinstance(expr, classad.ExprTree))
-        self.assertEquals(expr.eval(), classad.Value.Undefined)
-        self.assertEquals(expr.eval(ad), 2)
+        self.assertEqual(expr.eval(), classad.Value.Undefined)
+        self.assertEqual(expr.eval(ad), 2)
 
     def test_function(self):
         expr = classad.Function("strcat", "hello", " ", "world")
         self.assertTrue(isinstance(expr, classad.ExprTree))
-        self.assertEquals(expr.eval(), "hello world")
+        self.assertEqual(expr.eval(), "hello world")
         expr = classad.Function("regexp", ".*")
-        self.assertEquals(expr.eval(), classad.Value.Error)
+        self.assertEqual(expr.eval(), classad.Value.Error)
 
     def test_flatten(self):
         expr = classad.Attribute("foo") == classad.Attribute("bar")
@@ -387,53 +387,53 @@ class TestClassad(unittest.TestCase):
         classad.register(myExpr)
         classad.register(myFoo)
         classad.register(myIntersect)
-        self.assertEquals(3, classad.ExprTree('myAdd(1, 2)').eval())
-        self.assertEquals(3, classad.ExprTree('myAdd2(1, 2)').eval())
+        self.assertEqual(3, classad.ExprTree('myAdd(1, 2)').eval())
+        self.assertEqual(3, classad.ExprTree('myAdd2(1, 2)').eval())
         self.assertRaises(BadException, classad.ExprTree('myBad(1, 2)').eval)
         self.assertRaises(TypeError, classad.ExprTree('myComplex(1)').eval)
-        self.assertEquals(classad.Value.Undefined, classad.ExprTree('myExpr()').eval())
-        self.assertEquals(classad.ExprTree('myExpr()').eval({"foo": 2}), 2)
+        self.assertEqual(classad.Value.Undefined, classad.ExprTree('myExpr()').eval())
+        self.assertEqual(classad.ExprTree('myExpr()').eval({"foo": 2}), 2)
         self.assertRaises(TypeError, classad.ExprTree('myAdd(1)').eval) # myAdd requires 2 arguments; only one is given.
-        self.assertEquals(classad.ExprTree('myFoo([foo = 1])').eval(), 1)
-        self.assertEquals(classad.ExprTree('size(myIntersect({1, 2}, {2, 3}))').eval(), 1)
-        self.assertEquals(classad.ExprTree('myIntersect({1, 2}, {2, 3})[0]').eval(), 2)
+        self.assertEqual(classad.ExprTree('myFoo([foo = 1])').eval(), 1)
+        self.assertEqual(classad.ExprTree('size(myIntersect({1, 2}, {2, 3}))').eval(), 1)
+        self.assertEqual(classad.ExprTree('myIntersect({1, 2}, {2, 3})[0]').eval(), 2)
 
     def test_state(self):
         def myFunc(state): return 1 if state else 0
         classad.register(myFunc)
-        self.assertEquals(0, classad.ExprTree('myFunc(false)').eval())
-        self.assertEquals(1, classad.ExprTree('myFunc("foo")').eval())
+        self.assertEqual(0, classad.ExprTree('myFunc(false)').eval())
+        self.assertEqual(1, classad.ExprTree('myFunc("foo")').eval())
         ad = classad.ClassAd("""[foo = myFunc(); bar = 2]""")
-        self.assertEquals(1, ad.eval('foo'))
+        self.assertEqual(1, ad.eval('foo'))
         ad['foo'] = classad.ExprTree('myFunc(1)')
         self.assertRaises(TypeError, ad.eval, ('foo',))
         def myFunc(arg1, **kw): return kw['state']['bar']
         classad.register(myFunc)
-        self.assertEquals(2, ad.eval('foo'))
+        self.assertEqual(2, ad.eval('foo'))
 
     def test_refs(self):
         ad = classad.ClassAd({"bar": 2})
         expr = classad.ExprTree("foo =?= bar")
-        self.assertEquals(ad.externalRefs(expr), ["foo"])
-        self.assertEquals(ad.internalRefs(expr), ["bar"])
+        self.assertEqual(ad.externalRefs(expr), ["foo"])
+        self.assertEqual(ad.internalRefs(expr), ["bar"])
 
     def test_cast(self):
-        self.assertEquals(4, int(classad.ExprTree('1+3')))
-        self.assertEquals(4.5, float(classad.ExprTree('1.0+3.5')))
-        self.assertEquals(34, int(classad.ExprTree('strcat("3", "4")')))
-        self.assertEquals(34.5, float(classad.ExprTree('"34.5"')))
+        self.assertEqual(4, int(classad.ExprTree('1+3')))
+        self.assertEqual(4.5, float(classad.ExprTree('1.0+3.5')))
+        self.assertEqual(34, int(classad.ExprTree('strcat("3", "4")')))
+        self.assertEqual(34.5, float(classad.ExprTree('"34.5"')))
         self.assertRaises(ValueError, float, classad.ExprTree('"34.foo"'))
         self.assertRaises(ValueError, int, classad.ExprTree('"12 "'))
         ad = classad.ClassAd("""[foo = 2+5; bar = foo]""")
         expr = ad['bar']
-        self.assertEquals(7, int(expr))
-        self.assertEquals(7, int(ad.lookup('bar')))
-        self.assertEquals(0, int(classad.ExprTree('false')))
-        self.assertEquals(0.0, float(classad.ExprTree('false')))
-        self.assertEquals(1, int(classad.ExprTree('true')))
-        self.assertEquals(1.0, float(classad.ExprTree('true')))
-        self.assertEquals(3, int(classad.ExprTree('3.99')))
-        self.assertEquals(3.0, float(classad.ExprTree('1+2')))
+        self.assertEqual(7, int(expr))
+        self.assertEqual(7, int(ad.lookup('bar')))
+        self.assertEqual(0, int(classad.ExprTree('false')))
+        self.assertEqual(0.0, float(classad.ExprTree('false')))
+        self.assertEqual(1, int(classad.ExprTree('true')))
+        self.assertEqual(1.0, float(classad.ExprTree('true')))
+        self.assertEqual(3, int(classad.ExprTree('3.99')))
+        self.assertEqual(3.0, float(classad.ExprTree('1+2')))
         self.assertRaises(ValueError, int, classad.ExprTree('undefined'))
         self.assertRaises(ValueError, float, classad.ExprTree('error'))
         self.assertRaises(ValueError, float, classad.ExprTree('foo'))
@@ -447,7 +447,7 @@ class TestClassad(unittest.TestCase):
         wfd.write("[foo = 1]")
         wfd.close()
         ad = classad.parseNext(rfd ,parser=classad.Parser.New)
-        self.assertEquals(tuple(dict(ad).items()), (('foo', 1),))
+        self.assertEqual(tuple(dict(ad).items()), (('foo', 1),))
         self.assertRaises(StopIteration, classad.parseNext, rfd, classad.Parser.New)
         rfd.close()
         r, w = os.pipe()

--- a/src/python-bindings/tests/classad_tests.py
+++ b/src/python-bindings/tests/classad_tests.py
@@ -68,6 +68,8 @@ class TestClassad(unittest.TestCase):
         tf = tempfile.TemporaryFile()
         tf.write(b"[foo = 1] [bar = 2]")
         tf.seek(0)
+        if sys.version_info > (3,):
+            tf,tf_ = open(tf.fileno()), tf
         ad_iter = classad.parseAds(tf)
         ad = next(ad_iter)
         self.assertEqual(len(ad), 1)
@@ -76,6 +78,8 @@ class TestClassad(unittest.TestCase):
         tf = tempfile.TemporaryFile()
         tf.write(b"-----\nfoo = 1\n\nbar = 2\n")
         tf.seek(0)
+        if sys.version_info > (3,):
+            tf,tf_ = open(tf.fileno()), tf
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             ad_iter = classad.parseOldAds(tf)
@@ -88,6 +92,8 @@ class TestClassad(unittest.TestCase):
         tf = tempfile.TemporaryFile()
         tf.write(b"[foo = 1] [bar = 2]")
         tf.seek(0)
+        if sys.version_info > (3,):
+            tf,tf_ = open(tf.fileno()), tf
         ad = classad.parseNext(tf)
         self.assertEqual(len(ad), 1)
         self.assertEqual(ad["foo"], 1)
@@ -95,6 +101,8 @@ class TestClassad(unittest.TestCase):
         tf = tempfile.TemporaryFile()
         tf.write(b"-----\nfoo = 1\n\nbar = 2\n")
         tf.seek(0)
+        if sys.version_info > (3,):
+            tf,tf_ = open(tf.fileno()), tf
         ad = classad.parseNext(tf)
         self.assertEqual(len(ad), 1)
         self.assertEqual(ad["foo"], 1)

--- a/src/python-bindings/tests/classad_tests.py
+++ b/src/python-bindings/tests/classad_tests.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import sys
 import types
 import pickle
 import classad
@@ -9,6 +10,8 @@ import datetime
 import unittest
 import warnings
 import tempfile
+
+_long_type = int if sys.version_info > (3,) else long
 
 class TestClassad(unittest.TestCase):
 
@@ -181,8 +184,8 @@ class TestClassad(unittest.TestCase):
 
     def test_list_conversion(self):
         ad = dict(classad.ClassAd("[a = {1,2,3}]"))
-        self.assertTrue(isinstance(ad["a"], types.ListType))
-        self.assertTrue(isinstance(ad["a"][0], types.LongType))
+        self.assertTrue(isinstance(ad["a"], list))
+        self.assertTrue(isinstance(ad["a"][0], _long_type))
         def listAdd(a, b): return a+b
         classad.register(listAdd)
         self.assertEqual(classad.ExprTree("listAdd({1,2}, {3,4})")[0], 1)
@@ -190,13 +193,13 @@ class TestClassad(unittest.TestCase):
     def test_dict_conversion(self):
         ad = classad.ClassAd({'a': [1,2, {}]})
         dict_ad = dict(ad)
-        self.assertTrue(isinstance(dict_ad["a"][2], types.DictType))
+        self.assertTrue(isinstance(dict_ad["a"][2], dict))
         self.assertEqual(classad.ClassAd(dict_ad).__repr__(), "[ a = { 1,2,[  ] } ]")
         ad = classad.ClassAd("[a = [b = {1,2,3}]]")
         inner_list = dict(ad)['a']['b']
-        self.assertTrue(isinstance(inner_list, types.ListType))
-        self.assertTrue(isinstance(inner_list[0], types.LongType))
-        self.assertTrue(isinstance(ad['a'], types.DictType))
+        self.assertTrue(isinstance(inner_list, list))
+        self.assertTrue(isinstance(inner_list[0], _long_type))
+        self.assertTrue(isinstance(ad['a'], dict))
 
     def test_ad_assignment(self):
         ad = classad.ClassAd()

--- a/src/python-bindings/tests/classad_tests.py
+++ b/src/python-bindings/tests/classad_tests.py
@@ -66,7 +66,7 @@ class TestClassad(unittest.TestCase):
 
     def test_parse_iter(self):
         tf = tempfile.TemporaryFile()
-        tf.write("[foo = 1] [bar = 2]")
+        tf.write(b"[foo = 1] [bar = 2]")
         tf.seek(0)
         ad_iter = classad.parseAds(tf)
         ad = ad_iter.next()
@@ -74,7 +74,7 @@ class TestClassad(unittest.TestCase):
         self.assertEqual(ad["foo"], 1)
         self.assertEqual(" [bar = 2]", tf.read())
         tf = tempfile.TemporaryFile()
-        tf.write("-----\nfoo = 1\n\nbar = 2\n")
+        tf.write(b"-----\nfoo = 1\n\nbar = 2\n")
         tf.seek(0)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -86,14 +86,14 @@ class TestClassad(unittest.TestCase):
 
     def test_parse_next(self):
         tf = tempfile.TemporaryFile()
-        tf.write("[foo = 1] [bar = 2]")
+        tf.write(b"[foo = 1] [bar = 2]")
         tf.seek(0)
         ad = classad.parseNext(tf)
         self.assertEqual(len(ad), 1)
         self.assertEqual(ad["foo"], 1)
         self.assertEqual(" [bar = 2]", tf.read())
         tf = tempfile.TemporaryFile()
-        tf.write("-----\nfoo = 1\n\nbar = 2\n")
+        tf.write(b"-----\nfoo = 1\n\nbar = 2\n")
         tf.seek(0)
         ad = classad.parseNext(tf)
         self.assertEqual(len(ad), 1)

--- a/src/python-bindings/tests/delayed_update_tests.py
+++ b/src/python-bindings/tests/delayed_update_tests.py
@@ -43,12 +43,12 @@ class TestChirp(htcondor_tests.WithDaemons):
         result_ad = self.getLastHistory(cluster)
         attr = "%sFoo" % prefix
         self.assertTrue("ExitCode" in result_ad)
-        self.assertEquals(result_ad["ExitCode"], 0)
+        self.assertEqual(result_ad["ExitCode"], 0)
         last_line = open(output_file).readlines()[-1]
-        self.assertEquals(last_line, "SUCCESS\n")
+        self.assertEqual(last_line, "SUCCESS\n")
         if shouldwork:
             self.assertTrue(attr in result_ad)
-            self.assertEquals(result_ad[attr], 2)
+            self.assertEqual(result_ad[attr], 2)
 
     def tryIO(self, shouldwork=True, wantio=None):
         open(os.path.join(htcondor_tests.testdir, "test_chirp_io"), "w").write("hello world")
@@ -64,9 +64,9 @@ class TestChirp(htcondor_tests.WithDaemons):
         cluster = self.runJob(ad)
         result_ad = self.getLastHistory(cluster)
         self.assertTrue("ExitCode" in result_ad)
-        self.assertEquals(result_ad["ExitCode"], 0)
+        self.assertEqual(result_ad["ExitCode"], 0)
         last_line = open(output_file).readlines()[-1]
-        self.assertEquals(last_line, "SUCCESS\n")
+        self.assertEqual(last_line, "SUCCESS\n")
 
     def tryUpdate(self, shouldwork=True, wantio = None, wantupdate=None, prefix="NonChirp"):
         output_file = os.path.join(htcondor_tests.testdir, "test.out")
@@ -85,13 +85,13 @@ class TestChirp(htcondor_tests.WithDaemons):
         cluster = self.runJob(ad)
         result_ad = self.getLastHistory(cluster)
         self.assertTrue("ExitCode" in result_ad)
-        self.assertEquals(result_ad["ExitCode"], 0)
+        self.assertEqual(result_ad["ExitCode"], 0)
         last_line = open(output_file).readlines()[-1]
-        self.assertEquals(last_line, "SUCCESS\n")
+        self.assertEqual(last_line, "SUCCESS\n")
         if shouldwork:
             attr = "%sFoo" % prefix
             self.assertTrue(attr in result_ad)
-            self.assertEquals(result_ad[attr], 2)
+            self.assertEqual(result_ad[attr], 2)
 
     def testDelayedUpdate(self):
         self.launch_daemons(["SCHEDD", "COLLECTOR", "STARTD", "NEGOTIATOR"])
@@ -148,11 +148,11 @@ class TestChirp(htcondor_tests.WithDaemons):
         cluster = self.runJob(ad)
         result_ad = self.getLastHistory(cluster)
         self.assertTrue("ExitCode" in result_ad)
-        self.assertEquals(result_ad["ExitCode"], 0)
+        self.assertEqual(result_ad["ExitCode"], 0)
         last_line = open(output_file).readlines()[-1]
-        self.assertEquals(last_line, "SUCCESS\n")
+        self.assertEqual(last_line, "SUCCESS\n")
         self.assertTrue("ChirpFoo" in result_ad)
-        self.assertEquals(result_ad["ChirpFoo"], "0" * 990)
+        self.assertEqual(result_ad["ChirpFoo"], "0" * 990)
         self.assertFalse("ChirpBar" in result_ad)
         for i in range(1, 50):
             self.assertTrue(("ChirpFoo%d" % i) in result_ad)

--- a/src/python-bindings/tests/event_tests.py
+++ b/src/python-bindings/tests/event_tests.py
@@ -43,7 +43,7 @@ class TestEventReader(unittest.TestCase):
     def test_event_count(self):
         events = list(self.reader)
         #for event in events: print event
-        self.assertEquals(len(events), 6)
+        self.assertEqual(len(events), 6)
 
     def test_block(self):
         events = list(self.reader)
@@ -62,7 +62,7 @@ class TestEventReader(unittest.TestCase):
 
     def test_wait(self):
         events = list(self.reader)
-        self.assertEquals(len(events), 6)
+        self.assertEqual(len(events), 6)
         t = threading.Thread(target=self.targetSleepAndWrite, name="Sleep and write event")
         t.setDaemon(True)
         t.start()
@@ -83,7 +83,7 @@ class TestEventReader(unittest.TestCase):
 
     def test_poll(self):
         events = list(self.reader)
-        self.assertEquals(self.reader.poll(1000), None)
+        self.assertEqual(self.reader.poll(1000), None)
 
     def targetSleepAndWrite(self):
         time.sleep(.4)
@@ -94,7 +94,7 @@ class TestEventReader(unittest.TestCase):
 
     def test_invalid(self):
         events = list(self.reader)
-        self.assertEquals(len(events), 6)
+        self.assertEqual(len(events), 6)
         file2 = open(self.testname, "a")
         file2.write("...\n...\n")
         file2.flush()
@@ -108,11 +108,11 @@ class TestEventReader(unittest.TestCase):
         keys2 = list(two.keys())
         keys2.sort()
         keys2 = tuple(keys2)
-        self.assertEquals(keys1, keys2)
+        self.assertEqual(keys1, keys2)
         for key in keys1:
             if key in ['EventTime', 'CurrentTime']:
                 continue
-            self.assertEquals(one[key], two[key])
+            self.assertEqual(one[key], two[key])
 
 
 if __name__ == '__main__':

--- a/src/python-bindings/tests/htcondor_tests.py
+++ b/src/python-bindings/tests/htcondor_tests.py
@@ -413,7 +413,7 @@ class TestPythonBindings(WithDaemons):
                         ctrs[pos] += 1
                     except StopIteration:
                         iters.remove((it, pos))
-            print ctrs
+            print(ctrs)
             if ctrs[0] == 0:
                 break
             if i % 2 == 0:
@@ -429,13 +429,13 @@ class TestPythonBindings(WithDaemons):
         ads = []
         cluster = schedd.submit(submit_ad, 300, False, ads)
         ads = schedd.xquery("ClusterId == %d" % cluster)
-        print str(datetime.datetime.now())
-        print str(datetime.datetime.now())
+        print(str(datetime.datetime.now()))
+        print(str(datetime.datetime.now()))
         schedd.act(htcondor.JobAction.Remove, "ClusterId == %d" % cluster)
         time.sleep(3)
-        print str(datetime.datetime.now())
-        print len(list(ads))
-        print str(datetime.datetime.now())
+        print(str(datetime.datetime.now()))
+        print(len(list(ads)))
+        print(str(datetime.datetime.now()))
 
     def testScheddNonblockingQueryCount(self):
         os.environ["_condor_SCHEDD_DEBUG"] = "D_FULLDEBUG|D_NETWORK"
@@ -450,7 +450,7 @@ class TestPythonBindings(WithDaemons):
             ads = schedd.query("true")
         #print ads
         for i in range(1, 60):
-            print "Testing querying %d jobs in queue." % i
+            print("Testing querying %d jobs in queue." % i)
             schedd.submit(submit_ad, i, True, ads)
             ads = schedd.query("true", ["ClusterID", "ProcID"])
             ads2 = list(schedd.xquery("true", ["ClusterID", "ProcID", "a1", "a2", "a3", "a4"]))

--- a/src/python-bindings/tests/htcondor_tests.py
+++ b/src/python-bindings/tests/htcondor_tests.py
@@ -143,7 +143,7 @@ class WithDaemons(unittest.TestCase):
             pid, exit_status = os.waitpid(self.pid, 0)
             self.assertTrue(os.WIFEXITED(exit_status))
             code = os.WEXITSTATUS(exit_status)
-            self.assertEquals(code, 0)
+            self.assertEqual(code, 0)
 
     def waitLocalDaemon(self, daemon, timeout=5):
         address_file = htcondor.param[daemon + "_ADDRESS_FILE"]
@@ -177,7 +177,7 @@ class TestPythonBindings(WithDaemons):
         coll_ad = coll.locate(htcondor.DaemonTypes.Collector)
         rparam = htcondor.RemoteParam(coll_ad)
         self.assertTrue("FOO" in rparam)
-        self.assertEquals(rparam["FOO"], "BAR")
+        self.assertEqual(rparam["FOO"], "BAR")
         self.assertTrue(len(rparam.keys()) > 100)
 
     def testRemoteSetParam(self):
@@ -196,7 +196,7 @@ class TestPythonBindings(WithDaemons):
         rparam2 = htcondor.RemoteParam(coll_ad)
         self.assertTrue(rparam2.get("FOO"))
         self.assertTrue("FOO" in rparam2)
-        self.assertEquals(rparam2["FOO"], "BAR")
+        self.assertEqual(rparam2["FOO"], "BAR")
         del rparam["FOO"]
         rparam2.refresh()
         htcondor.send_command(coll_ad, htcondor.DaemonCommands.Reconfig)
@@ -211,14 +211,14 @@ class TestPythonBindings(WithDaemons):
         coll = htcondor.Collector()
         coll_ad = coll.locate(htcondor.DaemonTypes.Collector)
         self.assertTrue("MyAddress" in coll_ad)
-        self.assertEquals(coll_ad["Name"].split(":")[-1], os.environ["_condor_PORT"])
+        self.assertEqual(coll_ad["Name"].split(":")[-1], os.environ["_condor_PORT"])
 
     def testLocateList(self):
         self.launch_daemons(["COLLECTOR"])
         coll = htcondor.Collector()
         coll_ad = coll.locate(htcondor.DaemonTypes.Collector)
         self.assertTrue("MyAddress" in coll_ad)
-        self.assertEquals(coll_ad["Name"].split(":")[-1], os.environ["_condor_PORT"])
+        self.assertEqual(coll_ad["Name"].split(":")[-1], os.environ["_condor_PORT"])
         # Make sure we can pass a list of addresses
         coll = htcondor.Collector(["collector.example.com", coll_ad['Name']])
         coll_ad = coll.locate(htcondor.DaemonTypes.Collector)
@@ -230,14 +230,14 @@ class TestPythonBindings(WithDaemons):
         remote_ad = self.waitRemoteDaemon(htcondor.DaemonTypes.Collector, "%s@%s" % (htcondor.param["COLLECTOR_NAME"], htcondor.param["CONDOR_HOST"]))
         remote_address = remote_ad["MyAddress"].split(">")[0].split("?")[0].lower()
         coll_address = coll_ad["MyAddress"].split(">")[0].split("?")[0].lower()
-        self.assertEquals(remote_address, coll_address)
+        self.assertEqual(remote_address, coll_address)
 
     def testScheddLocate(self):
         self.launch_daemons(["SCHEDD", "COLLECTOR"])
         coll = htcondor.Collector()
         name = "%s@%s" % (htcondor.param["SCHEDD_NAME"], htcondor.param["CONDOR_HOST"])
         schedd_ad = self.waitRemoteDaemon(htcondor.DaemonTypes.Schedd, name, timeout=10)
-        self.assertEquals(schedd_ad.eval("Name").lower(), name.lower())
+        self.assertEqual(schedd_ad.eval("Name").lower(), name.lower())
 
     def testCollectorAdvertise(self):
         self.launch_daemons(["COLLECTOR"])
@@ -249,9 +249,9 @@ class TestPythonBindings(WithDaemons):
             ads = coll.query(htcondor.AdTypes.Any, 'Name =?= "Foo"', ["Bar"])
             if ads: break
             time.sleep(1)
-        self.assertEquals(len(ads), 1)
+        self.assertEqual(len(ads), 1)
         self.assertTrue(isinstance(ads[0]["Bar"], types.FloatType))
-        self.assertEquals(ads[0]["Bar"], now)
+        self.assertEqual(ads[0]["Bar"], now)
         self.assertTrue("Foo" not in ads[0])
 
     def testScheddSubmit(self):
@@ -272,7 +272,7 @@ class TestPythonBindings(WithDaemons):
             if i % 2 == 0:
                 schedd.reschedule()
             time.sleep(1)
-        self.assertEquals(open(output_file).read(), "hello world\n");
+        self.assertEqual(open(output_file).read(), "hello world\n");
 
     def testScheddSubmitMany(self):
         self.launch_daemons(["SCHEDD", "COLLECTOR", "STARTD", "NEGOTIATOR"])
@@ -293,7 +293,7 @@ class TestPythonBindings(WithDaemons):
             if i % 2 == 0:
                 schedd.reschedule()
             time.sleep(1)
-        self.assertEquals(open(output_file).read(), "hello world\n");
+        self.assertEqual(open(output_file).read(), "hello world\n");
 
     def testScheddSubmitMany2(self):
         self.launch_daemons(["SCHEDD", "COLLECTOR", "STARTD", "NEGOTIATOR"])
@@ -310,14 +310,14 @@ class TestPythonBindings(WithDaemons):
             ads = list(ads)
             #print ads
             for ad in ads:
-                if ad['ProcId'] < 5: self.assertEquals(ad['foo'], 1)
-                else: self.assertEquals(ad['foo'], 2)
+                if ad['ProcId'] < 5: self.assertEqual(ad['foo'], 1)
+                else: self.assertEqual(ad['foo'], 2)
             if len(ads) == 0:
                 break
             if i % 2 == 0:
                 schedd.reschedule()
             time.sleep(1)
-        self.assertEquals(open(output_file).read(), "hello world\n");
+        self.assertEqual(open(output_file).read(), "hello world\n");
 
     def testScheddQueryPoll(self):
         self.launch_daemons(["SCHEDD", "COLLECTOR", "STARTD", "NEGOTIATOR"])
@@ -366,20 +366,20 @@ class TestPythonBindings(WithDaemons):
                 time.sleep(1)
                 continue
             break
-        self.assertEquals(len(startd_ads), len(private_ads))
-        self.assertEquals(len(startd_ads), htcondor.param['NUM_CPUS'])
+        self.assertEqual(len(startd_ads), len(private_ads))
+        self.assertEqual(len(startd_ads), htcondor.param['NUM_CPUS'])
         for ad in htcondor.Collector().locateAll(htcondor.DaemonTypes.Startd):
             for pvt_ad in private_ads:
                 if pvt_ad.get('Name') == ad['Name']:
                     ad['ClaimId'] = pvt_ad['Capability']
                     claim_ads.append(ad)
-        self.assertEquals(len(claim_ads), len(startd_ads))
+        self.assertEqual(len(claim_ads), len(startd_ads))
         claim = claim_ads[0]
 
         me = "%s@%s" % (pwd.getpwuid(os.geteuid()).pw_name, htcondor.param['UID_DOMAIN'])
         with schedd.negotiate(me) as session:
             requests = list(session)
-            self.assertEquals(len(requests), 1)
+            self.assertEqual(len(requests), 1)
             request = requests[0]
             self.assertTrue(request.symmetricMatch(claim))
             session.sendClaim(claim['ClaimId'], claim, request)
@@ -390,7 +390,7 @@ class TestPythonBindings(WithDaemons):
             if len(ads) == 0:
                 break
             time.sleep(1)
-        self.assertEquals(open(output_file).read(), "hello world\n");
+        self.assertEqual(open(output_file).read(), "hello world\n");
 
     def testScheddNonblockingQuery(self):
         self.launch_daemons(["SCHEDD", "COLLECTOR", "STARTD", "NEGOTIATOR"])
@@ -419,7 +419,7 @@ class TestPythonBindings(WithDaemons):
             if i % 2 == 0:
                 schedd.reschedule()
             time.sleep(1)
-        self.assertEquals(open(output_file).read(), "hello world\n");
+        self.assertEqual(open(output_file).read(), "hello world\n");
 
     def testScheddNonblockingQueryRemove(self):
         os.environ["_condor_SCHEDD_DEBUG"] = "D_FULLDEBUG|D_NETWORK"
@@ -464,8 +464,8 @@ class TestPythonBindings(WithDaemons):
                         found_ad = True
                         break
                 self.assertTrue(found_ad, msg="Ad %s missing from xquery results: %s" % (ad, ads2))
-            self.assertEquals(len(ads), i, msg="Old query protocol gives incorrect number of results (expected %d, got %d)" % (i, len(ads)))
-            self.assertEquals(len(ads2), i, msg="New query protocol gives incorrect number of results (expected %d, got %d)" % (i, len(ads2)))
+            self.assertEqual(len(ads), i, msg="Old query protocol gives incorrect number of results (expected %d, got %d)" % (i, len(ads)))
+            self.assertEqual(len(ads2), i, msg="New query protocol gives incorrect number of results (expected %d, got %d)" % (i, len(ads2)))
             schedd.act(htcondor.JobAction.Remove, "true")
             while ads:
                 time.sleep(.2)
@@ -485,7 +485,7 @@ class TestPythonBindings(WithDaemons):
         for i in range(60):
             ads = schedd.query("ClusterId == %d" % cluster, ["JobStatus"])
             #print ads
-            self.assertEquals(len(ads), 1)
+            self.assertEqual(len(ads), 1)
             if ads[0]["JobStatus"] == 4:
                 break
             if i % 5 == 0:
@@ -495,8 +495,8 @@ class TestPythonBindings(WithDaemons):
         #print "Final status:", schedd.query("ClusterId == %d" % cluster)[0];
         schedd.act(htcondor.JobAction.Remove, ["%d.0" % cluster])
         ads = schedd.query("ClusterId == %d" % cluster, ["JobStatus"])
-        self.assertEquals(len(ads), 0)
-        self.assertEquals(open(output_file).read(), "hello world\n")
+        self.assertEqual(len(ads), 0)
+        self.assertEqual(open(output_file).read(), "hello world\n")
 
 
     def testScheddSubmitFile(self):
@@ -506,15 +506,15 @@ class TestPythonBindings(WithDaemons):
         submit_obj['foo'] = '$(bar) 1'
         submit_obj['bar'] = '2'
 
-        self.assertEquals(str(submit_obj), "foo = $(bar) 1\nbar = 2\nqueue")
-        self.assertEquals(submit_obj.expand('foo'), "2 1")
-        self.assertEquals(set(submit_obj.keys()), set(['foo', 'bar']))
-        self.assertEquals(set(submit_obj.values()), set(['$(bar) 1', '2']))
-        self.assertEquals(set(submit_obj.items()), set([('foo', '$(bar) 1'), ('bar', '2')]))
+        self.assertEqual(str(submit_obj), "foo = $(bar) 1\nbar = 2\nqueue")
+        self.assertEqual(submit_obj.expand('foo'), "2 1")
+        self.assertEqual(set(submit_obj.keys()), set(['foo', 'bar']))
+        self.assertEqual(set(submit_obj.values()), set(['$(bar) 1', '2']))
+        self.assertEqual(set(submit_obj.items()), set([('foo', '$(bar) 1'), ('bar', '2')]))
         d = dict(submit_obj)
-        self.assertEquals(set(d.items()), set([('foo', '$(bar) 1'), ('bar', '2')]))
+        self.assertEqual(set(d.items()), set([('foo', '$(bar) 1'), ('bar', '2')]))
 
-        self.assertEquals(str(htcondor.Submit(d)), str(submit_obj))
+        self.assertEqual(str(htcondor.Submit(d)), str(submit_obj))
 
         submit_obj = htcondor.Submit({"executable": "/bin/sh",
                                       "arguments":  "-c ps faux",
@@ -527,16 +527,16 @@ class TestPythonBindings(WithDaemons):
         with schedd.transaction() as txn:
              cluster_id = submit_obj.queue(txn, ad_results=ads)
 
-        self.assertEquals(len(ads), 1)
+        self.assertEqual(len(ads), 1)
         ad = ads[0]
-        self.assertEquals(cluster_id, ad['ClusterId'])
-        self.assertEquals(ad['In'], '/dev/null')
-        self.assertEquals(ad['Args'], "-c ps faux")
+        self.assertEqual(cluster_id, ad['ClusterId'])
+        self.assertEqual(ad['In'], '/dev/null')
+        self.assertEqual(ad['Args'], "-c ps faux")
         outfile = "test.out.%d.0" % ad['ClusterId']
-        self.assertEquals(ad['Out'], outfile)
-        self.assertEquals(ad['foo'], True)
-        self.assertEquals(ad['baz_bar'], False)
-        self.assertEquals(ad['qux'], 1)
+        self.assertEqual(ad['Out'], outfile)
+        self.assertEqual(ad['foo'], True)
+        self.assertEqual(ad['baz_bar'], False)
+        self.assertEqual(ad['qux'], 1)
 
         finished = False
         for i in range(60):
@@ -578,7 +578,7 @@ class TestPythonBindings(WithDaemons):
         for i in range(10):
             if os.path.exists(output_file): break
             time.sleep(1)
-        self.assertEquals(open(output_file).read(), "hello world\n")
+        self.assertEqual(open(output_file).read(), "hello world\n")
         sleep_job = dict(job_common)
         sleep_job['Args'] = "-c 'sleep 5m'"
         claim.activate(sleep_job)
@@ -611,25 +611,25 @@ class TestPythonBindings(WithDaemons):
         secman = htcondor.SecMan()
         authz_ad = secman.ping(coll_ad, "WRITE")
         self.assertTrue("AuthCommand" in authz_ad)
-        self.assertEquals(authz_ad['AuthCommand'], 60021)
+        self.assertEqual(authz_ad['AuthCommand'], 60021)
         self.assertTrue("AuthorizationSucceeded" in authz_ad)
         self.assertTrue(authz_ad['AuthorizationSucceeded'])
 
         authz_ad = secman.ping(coll_ad["MyAddress"], "WRITE")
         self.assertTrue("AuthCommand" in authz_ad)
-        self.assertEquals(authz_ad['AuthCommand'], 60021)
+        self.assertEqual(authz_ad['AuthCommand'], 60021)
         self.assertTrue("AuthorizationSucceeded" in authz_ad)
         self.assertTrue(authz_ad['AuthorizationSucceeded'])
 
         authz_ad = secman.ping(coll_ad["MyAddress"])
         self.assertTrue("AuthCommand" in authz_ad)
-        self.assertEquals(authz_ad['AuthCommand'], 60011)
+        self.assertEqual(authz_ad['AuthCommand'], 60011)
         self.assertTrue("AuthorizationSucceeded" in authz_ad)
         self.assertTrue(authz_ad['AuthorizationSucceeded'])
 
     def testEventLog(self):
         events = list(htcondor.read_events(open("tests/test_log.txt")))
-        self.assertEquals(len(events), 4)
+        self.assertEqual(len(events), 4)
         a = dict(events[0])
         if 'CurrentTime' in a:
             del a['CurrentTime']
@@ -642,9 +642,9 @@ class TestPythonBindings(WithDaemons):
              "EventTime": "%d-11-15T17:05:55" % datetime.datetime.now().year,
              "SubmitHost": "<169.228.38.38:9615?sock=18627_6227_3>",
             }
-        self.assertEquals(set(a.keys()), set(b.keys()))
+        self.assertEqual(set(a.keys()), set(b.keys()))
         for key, val in a.items():
-            self.assertEquals(val, b[key])
+            self.assertEqual(val, b[key])
 
     def testTransaction(self):
         self.launch_daemons(["SCHEDD", "COLLECTOR", "STARTD", "NEGOTIATOR"])
@@ -663,9 +663,9 @@ class TestPythonBindings(WithDaemons):
             schedd.edit(["%d.0" % cluster], 'foo', classad.Literal(1))
             schedd.edit(["%d.0" % cluster], 'bar', classad.Literal(2))
         ads = schedd.query("ClusterId == %d" % cluster, ["JobStatus", 'foo', 'bar'])
-        self.assertEquals(len(ads), 1)
-        self.assertEquals(ads[0]['foo'], 1)
-        self.assertEquals(ads[0]['bar'], 2)
+        self.assertEqual(len(ads), 1)
+        self.assertEqual(ads[0]['foo'], 1)
+        self.assertEqual(ads[0]['bar'], 2)
 
         with schedd.transaction() as txn:
             schedd.edit(["%d.0" % cluster], 'baz', classad.Literal(3))
@@ -673,10 +673,10 @@ class TestPythonBindings(WithDaemons):
                 schedd.edit(["%d.0" % cluster], 'foo', classad.Literal(4))
                 schedd.edit(["%d.0" % cluster], 'bar', classad.Literal(5))
         ads = schedd.query("ClusterId == %d" % cluster, ["JobStatus", 'foo', 'bar', 'baz'])
-        self.assertEquals(len(ads), 1)
-        self.assertEquals(ads[0]['foo'], 4)
-        self.assertEquals(ads[0]['bar'], 5)
-        self.assertEquals(ads[0]['baz'], 3)
+        self.assertEqual(len(ads), 1)
+        self.assertEqual(ads[0]['foo'], 4)
+        self.assertEqual(ads[0]['bar'], 5)
+        self.assertEqual(ads[0]['baz'], 3)
 
         try:
             with schedd.transaction() as txn:
@@ -687,11 +687,11 @@ class TestPythonBindings(WithDaemons):
             exctype, e = sys.exc_info()[:2]
             if not issubclass(exctype, Exception):
                 raise
-            self.assertEquals(str(e), "force abort")
+            self.assertEqual(str(e), "force abort")
         ads = schedd.query("ClusterId == %d" % cluster, ["JobStatus", 'foo', 'bar'])
-        self.assertEquals(len(ads), 1)
-        self.assertEquals(ads[0]['foo'], 4)
-        self.assertEquals(ads[0]['bar'], 5)
+        self.assertEqual(len(ads), 1)
+        self.assertEqual(ads[0]['foo'], 4)
+        self.assertEqual(ads[0]['bar'], 5)
 
         try:
             with schedd.transaction() as txn:
@@ -704,16 +704,16 @@ class TestPythonBindings(WithDaemons):
             exctype, e = sys.exc_info()[:2]
             if not issubclass(exctype, Exception): 
                 raise
-            self.assertEquals(str(e), "force abort")
+            self.assertEqual(str(e), "force abort")
         ads = schedd.query("ClusterId == %d" % cluster, ["JobStatus", 'foo', 'bar', 'baz'])
-        self.assertEquals(len(ads), 1)
-        self.assertEquals(ads[0]['foo'], 4)
-        self.assertEquals(ads[0]['bar'], 5)
-        self.assertEquals(ads[0]['baz'], 3)
+        self.assertEqual(len(ads), 1)
+        self.assertEqual(ads[0]['foo'], 4)
+        self.assertEqual(ads[0]['bar'], 5)
+        self.assertEqual(ads[0]['baz'], 3)
 
         schedd.act(htcondor.JobAction.Remove, ["%d.0" % cluster])
         ads = schedd.query("ClusterId == %d" % cluster, ["JobStatus"])
-        self.assertEquals(len(ads), 0)
+        self.assertEqual(len(ads), 0)
 
 
 if __name__ == '__main__':

--- a/src/python-bindings/tests/htcondor_version_tests.py
+++ b/src/python-bindings/tests/htcondor_version_tests.py
@@ -13,21 +13,21 @@ class TestConfig(unittest.TestCase):
         htcondor.reload_config()
 
     def test_config(self):
-        self.assertEquals(htcondor.param["FOO"], "BAR")
+        self.assertEqual(htcondor.param["FOO"], "BAR")
 
     def test_reconfig(self):
         htcondor.param["FOO"] = "BAZ"
-        self.assertEquals(htcondor.param["FOO"], "BAZ")
+        self.assertEqual(htcondor.param["FOO"], "BAZ")
         os.environ["_condor_FOO"] = "1"
         htcondor.reload_config()
-        self.assertEquals(htcondor.param["FOO"], "1")
+        self.assertEqual(htcondor.param["FOO"], "1")
 
 
 class TestClassadExtensions(unittest.TestCase):
 
     def test_user_home(self):
         if platform.system() == 'Windows':
-            self.assertEquals(classad.ExprTree('userHome("foo","bar")').eval(), classad.Value.Error)
+            self.assertEqual(classad.ExprTree('userHome("foo","bar")').eval(), classad.Value.Error)
             return
         import pwd
         pw = pwd.getpwuid(os.geteuid())
@@ -37,18 +37,18 @@ class TestClassadExtensions(unittest.TestCase):
         htcondor.param['CLASSAD_ENABLE_USER_HOME'] = 'true'
         self.assertRaises(TypeError, classad.ExprTree('userHome()').eval)
         self.assertRaises(TypeError, classad.ExprTree('userHome("a", "b", "c")').eval)
-        self.assertEquals(classad.ExprTree('userHome("", "")').eval(), classad.Value.Undefined)
-        self.assertEquals(classad.ExprTree('userHome("", 1)').eval(), classad.Value.Undefined)
-        self.assertEquals(classad.ExprTree('userHome("")').eval(), classad.Value.Undefined)
-        self.assertEquals(classad.ExprTree('userHome(%s)' % classad.quote(user)).eval(), home)
-        self.assertEquals(classad.ExprTree('userHome(%s, "foo")' % classad.quote(user)).eval(), home)
-        self.assertEquals(classad.ExprTree('userHome("", "foo")').eval(), "foo")
-        self.assertEquals(classad.ExprTree('userHome(undefined)').eval(), classad.Value.Undefined)
-        self.assertEquals(classad.ExprTree('userHome(undefined, "foo")').eval(), "foo")
-        self.assertEquals(classad.ExprTree('userHome(1, "foo")').eval(), "foo")
-        self.assertEquals(classad.ExprTree('userHome(1)').eval(), classad.Value.Error)
+        self.assertEqual(classad.ExprTree('userHome("", "")').eval(), classad.Value.Undefined)
+        self.assertEqual(classad.ExprTree('userHome("", 1)').eval(), classad.Value.Undefined)
+        self.assertEqual(classad.ExprTree('userHome("")').eval(), classad.Value.Undefined)
+        self.assertEqual(classad.ExprTree('userHome(%s)' % classad.quote(user)).eval(), home)
+        self.assertEqual(classad.ExprTree('userHome(%s, "foo")' % classad.quote(user)).eval(), home)
+        self.assertEqual(classad.ExprTree('userHome("", "foo")').eval(), "foo")
+        self.assertEqual(classad.ExprTree('userHome(undefined)').eval(), classad.Value.Undefined)
+        self.assertEqual(classad.ExprTree('userHome(undefined, "foo")').eval(), "foo")
+        self.assertEqual(classad.ExprTree('userHome(1, "foo")').eval(), "foo")
+        self.assertEqual(classad.ExprTree('userHome(1)').eval(), classad.Value.Error)
         htcondor.param['CLASSAD_ENABLE_USER_HOME'] = 'false'
-        self.assertEquals(classad.ExprTree('userHome(%s)' % classad.quote(user)).eval(), classad.Value.Undefined)
+        self.assertEqual(classad.ExprTree('userHome(%s)' % classad.quote(user)).eval(), classad.Value.Undefined)
 
 
 class TestVersion(unittest.TestCase):
@@ -62,10 +62,10 @@ class TestVersion(unittest.TestCase):
             raise RuntimeError("Unable to invoke condor_version")
 
     def test_version(self):
-        self.assertEquals(htcondor.version(), self.lines[0])
+        self.assertEqual(htcondor.version(), self.lines[0])
 
     def test_platform(self):
-        self.assertEquals(htcondor.platform(), self.lines[1])
+        self.assertEqual(htcondor.platform(), self.lines[1])
 
 
 def makedirs_ignore_exist(directory):

--- a/src/python-bindings/tests/htcondor_version_tests.py
+++ b/src/python-bindings/tests/htcondor_version_tests.py
@@ -34,7 +34,7 @@ class TestClassadExtensions(unittest.TestCase):
         user = pw.pw_name
         home = pw.pw_dir
 
-	htcondor.param['CLASSAD_ENABLE_USER_HOME'] = 'true'
+        htcondor.param['CLASSAD_ENABLE_USER_HOME'] = 'true'
         self.assertRaises(TypeError, classad.ExprTree('userHome()').eval)
         self.assertRaises(TypeError, classad.ExprTree('userHome("a", "b", "c")').eval)
         self.assertEquals(classad.ExprTree('userHome("", "")').eval(), classad.Value.Undefined)
@@ -47,8 +47,8 @@ class TestClassadExtensions(unittest.TestCase):
         self.assertEquals(classad.ExprTree('userHome(undefined, "foo")').eval(), "foo")
         self.assertEquals(classad.ExprTree('userHome(1, "foo")').eval(), "foo")
         self.assertEquals(classad.ExprTree('userHome(1)').eval(), classad.Value.Error)
-	htcondor.param['CLASSAD_ENABLE_USER_HOME'] = 'false'
-	self.assertEquals(classad.ExprTree('userHome(%s)' % classad.quote(user)).eval(), classad.Value.Undefined)
+        htcondor.param['CLASSAD_ENABLE_USER_HOME'] = 'false'
+        self.assertEquals(classad.ExprTree('userHome(%s)' % classad.quote(user)).eval(), classad.Value.Undefined)
 
 
 class TestVersion(unittest.TestCase):

--- a/src/python-bindings/tests/log_reader_tests.py
+++ b/src/python-bindings/tests/log_reader_tests.py
@@ -20,7 +20,7 @@ class TestLogReader(unittest.TestCase):
     def test_event_count(self):
         events = list(self.reader)
         #for event in events: print event
-        self.assertEquals(len(events), 16)
+        self.assertEqual(len(events), 16)
 
     def test_block(self):
         events = list(self.reader)
@@ -43,7 +43,7 @@ class TestLogReader(unittest.TestCase):
         t.setDaemon(True)
         t.start()
         self.reader.wait()
-        self.assertEquals(self.reader.next(), self.sampleEvent)
+        self.assertEqual(self.reader.next(), self.sampleEvent)
 
     def test_wait2(self):
         events = list(self.reader)
@@ -59,7 +59,7 @@ class TestLogReader(unittest.TestCase):
 
     def test_poll(self):
         events = list(self.reader)
-        self.assertEquals(self.reader.poll(1000), None)
+        self.assertEqual(self.reader.poll(1000), None)
 
     def targetSleepAndWrite(self):
         time.sleep(.4)
@@ -72,7 +72,7 @@ class TestLogReader(unittest.TestCase):
         self.testfile.flush()
         events = list(self.reader)
         #print "LastEvent", events[-1]
-        self.assertEquals(classad.Function("isError", events[-1]['value']).eval(), True)
+        self.assertEqual(classad.Function("isError", events[-1]['value']).eval(), True)
 
     def compareEvents(self, one, two):
         keys1 = one.keys()
@@ -81,9 +81,9 @@ class TestLogReader(unittest.TestCase):
         keys2 = two.keys()
         keys2.sort()
         keys2 = tuple(keys2)
-        self.assertEquals(keys1, keys2)
+        self.assertEqual(keys1, keys2)
         for key in keys1:
-            self.assertEquals(one[key], two[key])
+            self.assertEqual(one[key], two[key])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This contains various fixes to get `src/python-bindings/tests/classad_tests.py` working when building against python3 (3.6.1 on fedora-26).

All tests for `classad_tests.py` still pass for python2 on RHEL 6.