### PR TITLE
Several fixes to parallel universe

### DIFF
--- a/src/condor_scripts/sshd.sh
+++ b/src/condor_scripts/sshd.sh
@@ -48,7 +48,9 @@ _CONDOR_NPROCS=$2
 
 # make a tmp dir to store keys, etc, that
 # wont get transfered back
-mkdir $_CONDOR_SCRATCH_DIR/tmp
+if [ ! -d  $_CONDOR_SCRATCH_DIR/tmp ] ; then
+    mkdir $_CONDOR_SCRATCH_DIR/tmp
+fi
 
 # Create the host keys
 

--- a/src/condor_scripts/sshd.sh
+++ b/src/condor_scripts/sshd.sh
@@ -114,7 +114,7 @@ done
 rm $_CONDOR_SCRATCH_DIR/tmp/sshd.out
 
 # create contact file
-hostname=`hostname`
+hostname=`hostname -i`
 currentDir=`pwd`
 user=`whoami`
 

--- a/src/condor_starter.V6.1/parallel_proc.cpp
+++ b/src/condor_starter.V6.1/parallel_proc.cpp
@@ -95,8 +95,7 @@ ParallelProc::addEnvVars()
 	sprintf(buf, "%d", Node);
 	env.SetEnv("_CONDOR_PROCNO", buf);
 
-
-		// And put the total number of nodes into CONDOR_NPROC
+		// Put the total number of nodes into CONDOR_NPROC
 	int machine_count;
 	if ( JobAd->LookupInteger( ATTR_CURRENT_HOSTS, machine_count ) !=  1 ) {
 		dprintf( D_ALWAYS, "%s not found in JobAd.  Aborting.\n", 
@@ -106,6 +105,17 @@ ParallelProc::addEnvVars()
 
 	sprintf(buf, "%d", machine_count);
 	env.SetEnv("_CONDOR_NPROCS", buf);
+
+		// And put the number of CPUs into CONDOR_NCPUS
+	int cpu_count;
+	if ( JobAd->LookupInteger( ATTR_REQUEST_CPUS, cpu_count ) !=  1 ) {
+		dprintf( D_ALWAYS, "%s not found in JobAd.  Aborting.\n", 
+				 ATTR_REQUEST_CPUS);
+		return 0;
+	}
+
+	sprintf(buf, "%d", cpu_count);
+	env.SetEnv("_CONDOR_NCPUS", buf);
 
 		// Now stick the condor bin directory in front of the path,
 		// so user scripts can call condor_config_val


### PR DESCRIPTION
These changes fix a few issues that I have encountered using the parallel universe with dynamic slots. The main issue is that the startd does not tell the MPI wrapper scripts how many cores have been requested on a node with ``request_cpus`` in the submit file. A submit file containing:
```
machine_count = 6
request_cpus  = 5
request_memory = 35G
```
will only start 6 MPI jobs, with the documentation saying:

> It is presumed that the executable will take care of invoking processes that are to run on the other seven CPUs (cores) associated with the slot.

However, there is no easy way to figure out how many slots there are from the program's perspective. Commit https://github.com/duncan-brown/htcondor/commit/22c06e83d26f52c01b19726a50122960a02e200d stores the number of CPUs requested on a machine in the environment variable ``_CONDOR_NCPUS`` so that it available for the MPI wrapper scripts to use. In a 8.6.6 environment, I modified ``openmpiscript`` to add ``slots=${_CONDOR_NCPUS}`` to the ``machines`` file and then start ``mpirun`` with ``-n $(( $_CONDOR_NPROCS * $_CONDOR_NCPUS ))``

There are two other minor fixes, but these may be deprecated now that the ssh wrapper is being retired in favor of starting orted directly with chirp:

 * https://github.com/duncan-brown/htcondor/commit/34ff22936dc5073be75a158d5b16898f0735695f fixes a bug that causes ``mkdir`` to print a (harmless) error if more than one slot is requested.
 * https://github.com/duncan-brown/htcondor/commit/27d6cf2be925252f933429a327e8e52cd7496378 builds the ``contacts`` file using IP addresses not hostnames, as internal cluster nodes may not have DNS set up.

@jasoncpatton does the new orted scheme support dynamic slot provisioning of multiple MPI jobs on one machine?