### PR TITLE
Increase TasksMax to workaround systemd's default 512 limit

### DIFF
--- a/src/condor_examples/condor.service
+++ b/src/condor_examples/condor.service
@@ -20,6 +20,7 @@ StandardOutput=syslog
 NotifyAccess=main
 KillSignal=SIGQUIT
 LimitNOFILE=16384
+TasksMax=16384
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
systemd >= 228 has a default limit of 512 on the number of subtasks created in a unit. The default is too low for large clusters.