### PR TITLE
[condor_pigeon] Compare to `None` using identity `is` operator

### DIFF
--- a/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/API/darwin.py
+++ b/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/API/darwin.py
@@ -26,7 +26,7 @@ class Carbon(object):
 
     def __init__(self):
         path = find_library('Carbon')
-        if path == None:
+        if path is None:
             raise ImportError('Could not find Carbon.framework')
         self.lib = cdll.LoadLibrary(path)
         self.lib.RunCurrentEventLoop.argtypes = (c_double,)
@@ -59,7 +59,7 @@ class CoreFoundation(object):
 
     def __init__(self):
         path = find_library('CoreFoundation')
-        if path == None:
+        if path is None:
             raise ImportError('Could not find CoreFoundation.framework')
         self.lib = cdll.LoadLibrary(path)
         self.cfstrs = []

--- a/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/API/posix_dbus.py
+++ b/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/API/posix_dbus.py
@@ -67,14 +67,14 @@ class _ISkypeAPI(_ISkypeAPIBase):
             if self.bus != None:
                 raise TypeError('Bus and MainLoop cannot be used at the same time!')
         except KeyError:
-            if self.bus == None:
+            if self.bus is None:
                 import dbus.mainloop.glib
                 import gobject
                 gobject.threads_init()
                 dbus.mainloop.glib.threads_init()
                 mainloop = dbus.mainloop.glib.DBusGMainLoop()
                 self.mainloop = gobject.MainLoop()
-        if self.bus == None:
+        if self.bus is None:
             from dbus import SessionBus
             self.bus = SessionBus(private=True, mainloop=mainloop)
         if opts:

--- a/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/API/posix_x11.py
+++ b/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/API/posix_x11.py
@@ -296,7 +296,7 @@ class _ISkypeAPI(_ISkypeAPIBase):
         fail = self.x11.XGetWindowProperty(self.disp, self.win_root, skype_inst,
                             0, 1, False, 33, byref(type_ret), byref(format_ret),
                             byref(nitems_ret), byref(bytes_after_ret), byref(winp))
-        if not fail and self.error == None and format_ret.value == 32 and nitems_ret.value == 1:
+        if not fail and self.error is None and format_ret.value == 32 and nitems_ret.value == 1:
             return winp.contents.value
 
     def Close(self):

--- a/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/application.py
+++ b/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/application.py
@@ -75,7 +75,7 @@ class IApplication(Cached):
         @param Streams: Streams to send the datagram to or None if all currently connected streams should be used.
         @type Streams: sequence of L{IApplicationStream}
         '''
-        if Streams == None:
+        if Streams is None:
             Streams = self.Streams
         for s in Streams:
             s.SendDatagram(Text)

--- a/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/call.py
+++ b/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/call.py
@@ -52,12 +52,12 @@ class ICall(Cached):
 
         @note: This command functions for active calls only.
         '''
-        if Set == None: # get
+        if Set is None: # get
             args = args2dict(self._Property('CAPTURE_MIC', Cache=False))
             for t in args:
                 if t == callIoDeviceTypePort:
                     args[t] = int(args[t])
-            if DeviceType == None: # get active devices
+            if DeviceType is None: # get active devices
                 return args
             return args.get(DeviceType, None)
         elif DeviceType != None: # set
@@ -95,12 +95,12 @@ class ICall(Cached):
 
         @note: This command functions for active calls only.
         '''
-        if Set == None: # get
+        if Set is None: # get
             args = args2dict(self._Property('INPUT', Cache=False))
             for t in args:
                 if t == callIoDeviceTypePort:
                     args[t] = int(args[t])
-            if DeviceType == None: # get active devices
+            if DeviceType is None: # get active devices
                 return args
             return args.get(DeviceType, None)
         elif DeviceType != None: # set
@@ -140,12 +140,12 @@ class ICall(Cached):
         
         @note: This command functions for active calls only.
         '''
-        if Set == None: # get
+        if Set is None: # get
             args = args2dict(self._Property('OUTPUT', Cache=False))
             for t in args:
                 if t == callIoDeviceTypePort:
                     args[t] = int(args[t])
-            if DeviceType == None: # get active devices
+            if DeviceType is None: # get active devices
                 return args
             return args.get(DeviceType, None)
         elif DeviceType != None: # set

--- a/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/callchannel.py
+++ b/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/callchannel.py
@@ -169,7 +169,7 @@ class ICallChannelManager(EventHandlingBase):
 
     def _OnCallStatus(self, pCall, Status):
         if Status == clsRinging:
-            if self._Application == None:
+            if self._Application is None:
                 self.CreateApplication()
             self._Application.Connect(pCall.PartnerHandle, True)
             for stream in self._Application.Streams:

--- a/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/client.py
+++ b/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/client.py
@@ -333,7 +333,7 @@ class IPluginMenuItem(Cached):
             self._CacheDict['ENABLED'] = cndexp(Enabled, u'TRUE', u'FALSE')
 
     def _Property(self, PropName, Set=None):
-        if Set == None:
+        if Set is None:
             return self._CacheDict[PropName]
         self._Skype._Property('MENU_ITEM', self._Id, PropName, Set)
         self._CacheDict[PropName] = unicode(Set)

--- a/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/settings.py
+++ b/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/settings.py
@@ -29,7 +29,7 @@ class ISettings(object):
         '''
         from warnings import warn
         warn('ISettings.Avatar: Use ISettings.LoadAvatarFromFile instead.', DeprecationWarning, stacklevel=2)
-        if Set == None:
+        if Set is None:
             raise TypeError('Argument \'Set\' is mandatory!')
         self.LoadAvatarFromFile(Set, Id)
 
@@ -72,7 +72,7 @@ class ISettings(object):
         @return: Current status if Set=None, None otherwise.
         @rtype: bool
         '''
-        if Set == None:
+        if Set is None:
             return self._Skype._Property('RINGTONE', Id, 'STATUS') == 'ON'
         return self._Skype._Property('RINGTONE', Id, 'STATUS', cndexp(Set, 'ON', 'OFF'))
 

--- a/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/skype.py
+++ b/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/skype.py
@@ -373,7 +373,7 @@ class ISkype(EventHandlingBase):
         while '' in arg:
             arg.remove('')
         jarg = ' '.join(arg)
-        if Set == None: # Get
+        if Set is None: # Get
             if Cache and self._Cache and h in self._CacheDict:
                 return self._CacheDict[h]
             Value = self._DoCommand('GET %s' % jarg, jarg)
@@ -397,7 +397,7 @@ class ISkype(EventHandlingBase):
 
     def _Alter(self, ObjectType, ObjectId, AlterName, Args=None, Reply=None):
         com = 'ALTER %s %s %s' % (str(ObjectType), str(ObjectId), str(AlterName))
-        if Reply == None:
+        if Reply is None:
             Reply = com
         if Args != None:
             com = '%s %s' % (com, Args)

--- a/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/utils.py
+++ b/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/utils.py
@@ -150,7 +150,7 @@ class _WeakMethod(object):
     def __call__(self):
         if self.weak_im_self:
             im_self = self.weak_im_self()
-            if im_self == None:
+            if im_self is None:
                 return None
         else:
             im_self = None
@@ -159,7 +159,7 @@ class _WeakMethod(object):
     def __repr__(self):
         obj = self()
         objrepr = repr(obj)
-        if obj == None:
+        if obj is None:
             objrepr = 'dead'
         return '<weakref at 0x%x; %s>' % (id(self), objrepr)
     def _dies(self, ref):

--- a/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/voicemail.py
+++ b/src/condor_contrib/condor_pigeon/src/condor_pigeon_client/skype_linux_tools/Skype4Py/voicemail.py
@@ -35,12 +35,12 @@ class IVoicemail(Cached):
         None if the device wasn't set. If Set is not None, sets a new value for the device.
         @rtype: unicode, dict or None
         '''
-        if Set == None: # get
+        if Set is None: # get
             args = args2dict(self._Property('CAPTURE_MIC', Cache=False))
             for t in args:
                 if t == callIoDeviceTypePort:
                     args[t] = int(args[t])
-            if DeviceType == None: # get active devices
+            if DeviceType is None: # get active devices
                 return args
             return args.get(DeviceType, None)
         elif DeviceType != None: # set
@@ -71,12 +71,12 @@ class IVoicemail(Cached):
         None if the device wasn't set. If Set is not None, sets a new value for the device.
         @rtype: unicode, dict or None
         '''
-        if Set == None: # get
+        if Set is None: # get
             args = args2dict(self._Property('INPUT', Cache=False))
             for t in args:
                 if t == callIoDeviceTypePort:
                     args[t] = int(args[t])
-            if DeviceType == None: # get active devices
+            if DeviceType is None: # get active devices
                 return args
             return args.get(DeviceType, None)
         elif DeviceType != None: # set
@@ -102,12 +102,12 @@ class IVoicemail(Cached):
         None if the device wasn't set. If Set is not None, sets a new value for the device.
         @rtype: unicode, dict or None
         '''
-        if Set == None: # get
+        if Set is None: # get
             args = args2dict(self._Property('OUTPUT', Cache=False))
             for t in args:
                 if t == callIoDeviceTypePort:
                     args[t] = int(args[t])
-            if DeviceType == None: # get active devices
+            if DeviceType is None: # get active devices
                 return args
             return args.get(DeviceType, None)
         elif DeviceType != None: # set


### PR DESCRIPTION
This is a trivial change that replaces `==` operator with `is` operator, following PEP 8 guideline:

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.

https://legacy.python.org/dev/peps/pep-0008/#programming-recommendations