### PR TITLE
[campus_factory] Compare to `None` using identity `is` operator

### DIFF
--- a/src/condor_contrib/campus_factory/python-lib/campus_factory/Cluster.py
+++ b/src/condor_contrib/campus_factory/python-lib/campus_factory/Cluster.py
@@ -25,7 +25,7 @@ class Cluster:
             self.offline = OfflineAds()
         
         self.cluster_entry, self.cluster_type = self._ParseClusterId(cluster_unique)
-        if self.cluster_type == None:
+        if self.cluster_type is None:
             self.cluster_type = "pbs"
         
         
@@ -57,7 +57,7 @@ class Cluster:
     
     def ClusterMeetPreferences(self):
         idleslots = self.status.GetIdleGlideins()
-        if idleslots == None:
+        if idleslots is None:
             logging.info("Received None from idle glideins, going to try later")
             raise ClusterPreferenceException("Received None from idle glideins")
         logging.debug("Idle glideins = %i" % idleslots)
@@ -67,7 +67,7 @@ class Cluster:
 
         # Check for idle glidein jobs
         idlejobs = self.status.GetIdleGlideinJobs()
-        if idlejobs == None:
+        if idlejobs is None:
             logging.info("Received None from idle glidein jobs, going to try later")
             raise ClusterPreferenceException("Received None from idle glidein jobs")
         logging.debug("Queued jobs = %i" % idlejobs)
@@ -77,7 +77,7 @@ class Cluster:
         
         # Check for held jobs
         heldjobs = self.status.GetHeldGlideins()
-        if heldjobs == None:
+        if heldjobs is None:
             logging.info("Received None from held glidein jobs, going to try later")
             raise ClusterPreferenceException("Received None from held glidein jobs")
         logging.debug("Held jobs = %i" % heldjobs)

--- a/src/condor_contrib/campus_factory/python-lib/campus_factory/ClusterStatus.py
+++ b/src/condor_contrib/campus_factory/python-lib/campus_factory/ClusterStatus.py
@@ -45,7 +45,7 @@ class CondorConfig:
         config_dict = {}
         for line in stdout.split('\n'):
             match = line_re.search(line)
-            if match == None:
+            if match is None:
                 continue
             (key, value) = match.groups()
             config_dict[key] = value
@@ -133,7 +133,7 @@ class ClusterStatus:
         @return: [(ClusterID, ProcID): [classad,...]]
         
         """
-        if constraint == None:
+        if constraint is None:
             constraint = self.status_constraint
         
         # Refresh the condor_status, if necessary

--- a/src/condor_contrib/campus_factory/python-lib/campus_factory/Factory.py
+++ b/src/condor_contrib/campus_factory/python-lib/campus_factory/Factory.py
@@ -199,7 +199,7 @@ class Factory:
             # Check if there are any idle jobs
             if not self.UseOffline:
                 user_idle = self.GetIdleJobs(ClusterStatus())
-                if user_idle == None:
+                if user_idle is None:
                     logging.info("Received None from idle jobs")
                     self.SleepFactory()
                     continue
@@ -231,7 +231,7 @@ class Factory:
                     idleslots = idlejobs = None
                 
                 # If the cluster preferences weren't met, then move on
-                if idleslots == None or idlejobs == None:
+                if idleslots is None or idlejobs is None:
                     continue
 
                 # Get the offline ads to update.
@@ -309,7 +309,7 @@ class Factory:
             
             
             idleuserjobs = status.GetIdleJobs(schedds)
-            if idleuserjobs == None:
+            if idleuserjobs is None:
                 logging.info("Received None from idle user jobs, going to try later")
                 return None
             

--- a/src/condor_contrib/campus_factory/python-lib/campus_factory/util/CampusConfig.py
+++ b/src/condor_contrib/campus_factory/python-lib/campus_factory/util/CampusConfig.py
@@ -80,7 +80,7 @@ def _get_option_env(option):
     
 def _get_config_option (option, section="general"):
     global parsed_config_file
-    if parsed_config_file == None:
+    if parsed_config_file is None:
         return None
     
     if parsed_config_file.has_option(section, option):

--- a/src/condor_contrib/campus_factory/python-lib/campus_factory/util/DaemonWrangler.py
+++ b/src/condor_contrib/campus_factory/python-lib/campus_factory/util/DaemonWrangler.py
@@ -22,7 +22,7 @@ class DaemonWrangler:
         """
         @param daemons: A list of daemons that will be included in the package
         """
-        if daemons == None:
+        if daemons is None:
             self.daemons = DEFAULT_GLIDEIN_DAEMONS
         else:
             self.daemons = daemons
@@ -42,7 +42,7 @@ class DaemonWrangler:
         
         # See if the daemons exist
         daemon_paths = self._CheckDaemons()
-        if daemon_paths == None:
+        if daemon_paths is None:
             logging.error("Unable to read all daemons, not packaging...")
             raise Exception("Unable to check all daemons")
         


### PR DESCRIPTION
This is a trivial change that replaces `==` operator with `is` operator, following PEP 8 guideline:

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.

https://legacy.python.org/dev/peps/pep-0008/#programming-recommendations