### PR TITLE
[azure] Compare to `None` using identity `is` operator

### DIFF
--- a/src/azure_gahp/AzureGAHPServer.py
+++ b/src/azure_gahp/AzureGAHPServer.py
@@ -722,7 +722,7 @@ class AzureGAHPCommandExec():
                 )
             vnet = network_client.virtual_networks.get(
                 cmd_params.vnet_rg_name, cmd_params.vnet_name)
-            if(subnet == None):
+            if(subnet is None):
                 subnets_of_vnet = vnet.subnets
                 if len(subnets_of_vnet) > 0:
                     # use first subnet of the vnet


### PR DESCRIPTION
This is a trivial change that replaces `==` operator with `is` operator, following PEP 8 guideline:

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.

https://legacy.python.org/dev/peps/pep-0008/#programming-recommendations