### PR TITLE
Compare to `None` using identity `is` operator

### DIFF
--- a/externals/bundles/blahp/1.16.5.1/pbs_status.py
+++ b/externals/bundles/blahp/1.16.5.1/pbs_status.py
@@ -407,7 +407,7 @@ def parse_qstat_fd(fd):
             #print cur_job_id, line
             cur_job_info = {"BatchJobId": '"%s"' % cur_job_id.split(".")[0]}
             continue
-        if cur_job_id == None:
+        if cur_job_id is None:
             continue
         m = exec_host_re.match(line)
         if m:

--- a/nmi_tools/glue/build/email_on_failure.py
+++ b/nmi_tools/glue/build/email_on_failure.py
@@ -93,7 +93,7 @@ def check_runid(config, runid):
     #     Pending - NULL
     if this_result == 0:
         die_nice("This script was called for a run that succeeded", runid)
-    elif prev_result == None:
+    elif prev_result is None:
         die_nice("The previous run is not complete yet", runid)
     elif prev_result == 0:
         # We have a failure and the previous run succeeded.  Now is our time to shine!

--- a/src/condor_contrib/triggerd/src/condor_trigger_config.py
+++ b/src/condor_contrib/triggerd/src/condor_trigger_config.py
@@ -301,7 +301,7 @@ class TriggerConfig(Session):
             return 1
         
     def _get_condortriggerservice(self):
-        if self.cts == None:
+        if self.cts is None:
             try:
                 self.cts = self.getObjects(_class="condortriggerservice")[0]
             except IndexError:

--- a/src/condor_gridmanager/slurm_status.py
+++ b/src/condor_gridmanager/slurm_status.py
@@ -387,7 +387,7 @@ def parse_scontrol_fd(fd):
             #print cur_job_id, line
             cur_job_info = {"BatchJobId": '"%s"' % cur_job_id}
             continue
-        if cur_job_id == None:
+        if cur_job_id is None:
             continue
         m = exec_host_re.match(line)
         if m:


### PR DESCRIPTION
This is a trivial change that replaces `==` operator with `is` operator, following PEP 8 guideline:

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.

https://legacy.python.org/dev/peps/pep-0008/#programming-recommendations