### PR TITLE
Enable TOKEN auth by default.  #7070

### DIFF
--- a/src/condor_daemon_core.V6/daemon_core_main.cpp
+++ b/src/condor_daemon_core.V6/daemon_core_main.cpp
@@ -1874,6 +1874,9 @@ dc_reconfig()
 	// Allow us to retry setting the pool password.
 	Condor_Auth_Passwd::retry_pool_password();
 
+	// Allow us to search for new tokens
+	Condor_Auth_Passwd::retry_token_search();
+
 	// Re-drop the address file, if it's defined, just to be safe.
 	drop_addr_file();
 

--- a/src/condor_includes/condor_auth_passwd.h
+++ b/src/condor_includes/condor_auth_passwd.h
@@ -154,6 +154,13 @@ class Condor_Auth_Passwd : public Condor_Auth_Base {
 
 	static void retry_pool_password() {m_attempt_pool_password = true;}
 
+	/** Determines if any credentials (tokens, master passwords) are available;
+	 *  if not, then there's no point in trying auth'n. */
+	static bool should_try_auth();
+
+	/** Retry search for tokens */
+	static void retry_token_search() {m_should_search_for_tokens = true;}
+
  private:
 
 	/** If we are the collector, we may check & generate a pool password */
@@ -349,6 +356,10 @@ class Condor_Auth_Passwd : public Condor_Auth_Base {
 	std::set<std::string> m_server_keys;
 
 	CondorAuthPasswordState m_state;
+
+		// Status of token auth.
+	static bool m_should_search_for_tokens; // Should we search for tokens?
+	static bool m_tokens_avail; // Are any tokens known to be available?
 };
 
 #endif /* SKIP_AUTHENTICATION */


### PR DESCRIPTION
TOKEN auth is enabled by default _unless_ there are no tokens or credentials present.

TOKEN is always tried if explicitly set by the sysadmin.