### PR TITLE
Fix documentation grammatical error

### DIFF
--- a/docs/misc-concepts/classad-mechanism.rst
+++ b/docs/misc-concepts/classad-mechanism.rst
@@ -10,7 +10,7 @@ resources, submitters and other HTCondor daemons. An understanding of
 this mechanism is required to harness the full flexibility of the
 HTCondor system.
 
-A ClassAd is is a set of uniquely named expressions. Each named
+A ClassAd is a set of uniquely named expressions. Each named
 expression is called an attribute. The following shows
 ten attributes, a portion of an example ClassAd.
 


### PR DESCRIPTION
Small documentation change:

- [https://htcondor.readthedocs.io/en/v8_9_2/misc-concepts/classad-mechanism.html](url)
`Example: A ClassAd is is a set to Example: A ClassAd is a set`