### PR TITLE
Improve token location algorithm. #7092

### DIFF
--- a/src/condor_io/condor_auth_passwd.cpp
+++ b/src/condor_io/condor_auth_passwd.cpp
@@ -216,12 +216,19 @@ findTokens(const std::string &issuer,
 
 	const char *file;
 	std::vector<std::string> tokens;
+	std::string subsys_token_file;
+	std::string subsys = get_mySubSystemName();
+	subsys += "_auto_generated_token";
+
 	while ( (file = dir.Next()) ) {
 		if (dir.IsDirectory()) {
 			continue;
 		}
 		if(!excludeFilesRegex.match(file)) {
 			tokens.emplace_back(dir.GetFullPath());
+			if (!strcasecmp(file, subsys.c_str())) {
+				subsys_token_file = dir.GetFullPath();
+			}
 		} else {
 			dprintf(D_FULLDEBUG|D_SECURITY, "Ignoring token file "
 				"based on LOCAL_CONFIG_DIR_EXCLUDE_REGEXP: "
@@ -229,6 +236,13 @@ findTokens(const std::string &issuer,
 		}
 	}
 	std::sort(tokens.begin(), tokens.end());
+
+	if (!subsys_token_file.empty() && findToken(subsys_token_file, issuer,
+		server_key_ids, username, token, signature))
+	{
+		return true;
+	}
+
 	for (const auto &token_filename : tokens) {
 		if (findToken(token_filename, issuer, server_key_ids,
 			username, token, signature))


### PR DESCRIPTION
Prefer using the auto-generated token first for the corresponding
subsystem type (i.e., STARTD uses `startd_auto_generated_token`).

This way we avoid the startd using the schedd's auto-generated token
when utilizing a personal condor setup.