### PR TITLE
bring in libstdc++-static for EL7 where libstdc++.a is needed

### DIFF
--- a/build/packaging/srpm/condor.spec
+++ b/build/packaging/srpm/condor.spec
@@ -241,6 +241,10 @@ BuildRequires: cmake >= 2.8
 BuildRequires: gcc-c++
 %if 0%{?rhel} >= 6
 BuildRequires: glibc-static
+%if 0%{?rhel} >= 7
+# libstdc++.a moved to a separate -static package in EL7
+BuildRequires: libstdc++-static
+%endif
 BuildRequires: libuuid-devel
 %else
 BuildRequires: glibc-devel


### PR DESCRIPTION
Without this, i get a `/bin/ld: cannot find -lstdc++` error for the `-static` targets.

Note the conditional section here is under `%if %uw_build || %std_univ`, so it may continue to be relevant after std_univ goes away.  (For static shadow?)