### PR TITLE
Override boolean coercion of `Value` to do something reasonable.  #7109

### DIFF
--- a/src/python-bindings/classad.cpp
+++ b/src/python-bindings/classad.cpp
@@ -366,7 +366,27 @@ boost::python::object ExprTreeHolder::getItem(boost::python::object input)
 ExprTreeHolder
 ExprTreeHolder::apply_this_operator(classad::Operation::OpKind kind, boost::python::object obj) const
 {
-    classad::ExprTree *right = convert_python_to_exprtree(obj);
+    classad::ExprTree *right = nullptr;
+    try
+    {
+        right = convert_python_to_exprtree(obj);
+    }
+    catch (boost::python::error_already_set &)
+    {
+        if (PyErr_ExceptionMatches(PyExc_TypeError))
+        {
+                if (kind == classad::Operation::OpKind::EQUAL_OP || kind == classad::Operation::OpKind::IS_OP) {
+                    PyErr_Clear();
+                    ExprTreeHolder holder(classad::Literal::MakeBool(false));
+                    return holder;
+                } else if (kind == classad::Operation::OpKind::NOT_EQUAL_OP || kind == classad::Operation::OpKind::ISNT_OP) {
+                    PyErr_Clear();
+                    ExprTreeHolder holder(classad::Literal::MakeBool(true));
+                    return holder;
+                }
+        }
+        throw;
+    }
     classad::ExprTree *expr = classad::Operation::MakeOperation(kind, get(), right);
     ExprTreeHolder holder(expr);
     return holder;
@@ -929,7 +949,7 @@ convert_python_to_exprtree(boost::python::object value)
     {
         PyErr_Clear();
     }
-    PyErr_SetString(PyExc_TypeError, "Unknown ClassAd value type.");
+    PyErr_SetString(PyExc_TypeError, "Unable to convert Python object to a ClassAd expression.");
     boost::python::throw_error_already_set();
     return NULL;
 }

--- a/src/python-bindings/classad_module_impl.cpp
+++ b/src/python-bindings/classad_module_impl.cpp
@@ -155,6 +155,15 @@ boost::python::object Value__eq__(classad::Value::ValueType val, boost::python::
     if (right == boost::python::object()) {
         return boost::python::object(false);
     }
+        // For backward compatibility, make `Undefined == Undefined` evaluate to true; making
+        // it false is probably more correct in the ClassAd language, but too many unit tests
+        // have been written at this point.
+    boost::python::extract<classad::Value::ValueType> right_val(right);
+    if (right_val.check() && right_val() == classad::Value::ValueType::UNDEFINED_VALUE)
+    {
+        return boost::python::object(true);
+    }
+
     ExprTreeHolder tmp(val == classad::Value::ValueType::UNDEFINED_VALUE ? classad::Literal::MakeUndefined() : classad::Literal::MakeError());
     boost::python::object left(tmp);
     return left.attr("__eq__")(right);

--- a/src/python-bindings/tests/classad_tests.py
+++ b/src/python-bindings/tests/classad_tests.py
@@ -231,8 +231,8 @@ class TestClassad(unittest.TestCase):
         ad = classad.ClassAd()
         ad["foo"] = classad.ExprTree('regexp(12, 34)')
         ad["bar"] = classad.Value.Undefined
-        self.assertEqual(ad["foo"].eval(), classad.Value.Error)
-        self.assertNotEqual(ad["foo"].eval(), ad["bar"])
+        self.assertTrue(ad["foo"].eval() is classad.Value.Error)
+        self.assertFalse(ad["foo"].eval() is ad["bar"])
         self.assertEqual(classad.Value.Undefined, ad["bar"])
 
     def test_ad_iterator(self):
@@ -252,7 +252,7 @@ class TestClassad(unittest.TestCase):
         ad = classad.ClassAd()
         ad["foo"] = classad.Value.Error
         self.assertTrue(isinstance(ad.lookup("foo"), classad.ExprTree))
-        self.assertEqual(ad.lookup("foo").eval(), classad.Value.Error)
+        self.assertTrue(ad.lookup("foo").eval() is classad.Value.Error)
 
     def test_get(self):
         ad = classad.ClassAd()
@@ -360,7 +360,7 @@ class TestClassad(unittest.TestCase):
         self.assertTrue(isinstance(expr, classad.ExprTree))
         self.assertEqual(expr.eval(), "hello world")
         expr = classad.Function("regexp", ".*")
-        self.assertEqual(expr.eval(), classad.Value.Error)
+        self.assertTrue(expr.eval() is classad.Value.Error)
 
     def test_flatten(self):
         expr = classad.Attribute("foo") == classad.Attribute("bar")

--- a/src/python-bindings/tests/htcondor_version_tests.py
+++ b/src/python-bindings/tests/htcondor_version_tests.py
@@ -46,7 +46,7 @@ class TestClassadExtensions(unittest.TestCase):
         self.assertEqual(classad.ExprTree('userHome(undefined)').eval(), classad.Value.Undefined)
         self.assertEqual(classad.ExprTree('userHome(undefined, "foo")').eval(), "foo")
         self.assertEqual(classad.ExprTree('userHome(1, "foo")').eval(), "foo")
-        self.assertEqual(classad.ExprTree('userHome(1)').eval(), classad.Value.Error)
+        self.assertTrue(classad.ExprTree('userHome(1)').eval() is classad.Value.Error)
         htcondor.param['CLASSAD_ENABLE_USER_HOME'] = 'false'
         self.assertEqual(classad.ExprTree('userHome(%s)' % classad.quote(user)).eval(), classad.Value.Undefined)
 


### PR DESCRIPTION
The boolean coercion of `Value`, as it is a boost enum, defaulted to integer coercion.  Thus, `bool(classad.Value.Undefined)` returns `True` - a horribly surprising result.

It turns out that it is not overly difficult to overload operators for enums; it's just not well-advertised.  This does the overload in the case of boolean coercion.  Others may be reasonable in the future.