### PR TITLE
explicitly specify perl Data::Dumper build req

### DIFF
--- a/build/packaging/srpm/condor.spec
+++ b/build/packaging/srpm/condor.spec
@@ -244,6 +244,7 @@ BuildRequires: python-devel
 BuildRequires: boost-devel
 BuildRequires: redhat-rpm-config
 BuildRequires: sqlite-devel
+BuildRequires: perl(Data::Dumper)
 
 %if %uw_build || %std_univ
 BuildRequires: cmake >= 2.8


### PR DESCRIPTION
without this our el7 builds break