### PR TITLE
Refactor (and re-enable) token requests #7093

### DIFF
--- a/src/ccb/ccb_listener.cpp
+++ b/src/ccb/ccb_listener.cpp
@@ -180,7 +180,7 @@ CCBListener::WriteMsgToCCB(ClassAd &msg)
 }
 
 void
-CCBListener::CCBConnectCallback(bool success,Sock *sock,CondorError * /*errstack*/,void *misc_data)
+CCBListener::CCBConnectCallback(bool success,Sock *sock,CondorError * /*errstack*/, const std::string & /*trust_domain*/, bool /*should_try_token_auth*/, void *misc_data)
 {
 	CCBListener *self = (CCBListener *)misc_data;
 

--- a/src/ccb/ccb_listener.h
+++ b/src/ccb/ccb_listener.h
@@ -68,7 +68,7 @@ class CCBListener: public Service, public ClassyCountedPtr {
 
 	bool SendMsgToCCB(ClassAd &msg,bool blocking);
 	bool WriteMsgToCCB(ClassAd &msg);
-	static void CCBConnectCallback(bool success,Sock *sock,CondorError *errstack,void *misc_data);
+	static void CCBConnectCallback(bool success,Sock *sock,CondorError *errstack, const std::string &, bool, void *misc_data);
 	void ReconnectTime();
 	void Connected();
 	void Disconnected();

--- a/src/condor_daemon_client/daemon.cpp
+++ b/src/condor_daemon_client/daemon.cpp
@@ -605,7 +605,7 @@ Daemon::startCommand( int cmd, Stream::stream_type st,Sock **sock,int timeout, C
 	*sock = makeConnectedSocket(st,timeout,0,errstack,nonblocking);
 	if( ! *sock ) {
 		if ( callback_fn ) {
-			(*callback_fn)( false, NULL, errstack, misc_data );
+			(*callback_fn)( false, NULL, errstack, "", false, misc_data );
 			return StartCommandSucceeded;
 		} else {
 			return StartCommandFailed;

--- a/src/condor_daemon_client/daemon.cpp
+++ b/src/condor_daemon_client/daemon.cpp
@@ -541,7 +541,7 @@ Daemon::connectSock(Sock *sock, int sec, CondorError* errstack, bool non_blockin
 
 
 StartCommandResult
-Daemon::startCommand_internal( int cmd, Sock* sock, int timeout, CondorError *errstack, int subcmd, StartCommandCallbackType *callback_fn, void *misc_data, bool nonblocking, char const *cmd_description, SecMan *sec_man, bool raw_protocol, char const *sec_session_id )
+Daemon::startCommand_internal( const SecMan::StartCommandRequest &req, int timeout, SecMan *sec_man )
 {
 	// This function may be either blocking or non-blocking, depending
 	// on the flag that is passed in.  All versions of Daemon::startCommand()
@@ -550,20 +550,18 @@ Daemon::startCommand_internal( int cmd, Sock* sock, int timeout, CondorError *er
 	// NOTE: if there is a callback function, we _must_ guarantee that it is
 	// eventually called in all code paths.
 
-	StartCommandResult start_command_result = StartCommandFailed;
-
-	ASSERT(sock);
+	ASSERT(req.m_sock);
 
 	// If caller wants non-blocking with no callback function,
 	// we _must_ be using UDP.
-	ASSERT(!nonblocking || callback_fn || sock->type() == Stream::safe_sock);
+	ASSERT(!req.m_nonblocking || req.m_callback_fn || req.m_sock->type() == Stream::safe_sock);
 
 	// set up the timeout
 	if( timeout ) {
-		sock->timeout( timeout );
+		req.m_sock->timeout( timeout );
 	}
 
-	start_command_result = sec_man->startCommand(cmd, sock, raw_protocol, errstack, subcmd, callback_fn, misc_data, nonblocking, cmd_description, sec_session_id);
+	auto start_command_result = sec_man->startCommand(req);
 	// when sec_man->startCommand returns, sock may have been closed and the sock object deleted.
 	// do NOT add code referencing the sock here!!!
 	return start_command_result;
@@ -614,28 +612,41 @@ Daemon::startCommand( int cmd, Stream::stream_type st,Sock **sock,int timeout, C
 		}
 	}
 
-	return startCommand_internal (
-						 cmd,
-						 *sock,
-						 timeout,
-						 errstack,
-						 subcmd,
-						 callback_fn,
-						 misc_data,
-						 nonblocking,
-						 cmd_description,
-						 &_sec_man,
-						 raw_protocol,
-						 sec_session_id);
+	// Prepare the request.
+	SecMan::StartCommandRequest req;
+	req.m_cmd = cmd;
+	req.m_sock = *sock;
+	req.m_raw_protocol = raw_protocol;
+	req.m_errstack = errstack;
+	req.m_subcmd = subcmd;
+	req.m_callback_fn = callback_fn;
+	req.m_misc_data = misc_data;
+	req.m_nonblocking = nonblocking;
+	req.m_cmd_description = cmd_description;
+	req.m_sec_session_id = sec_session_id;
+
+	return startCommand_internal( req, timeout, &_sec_man );
 }
 
 
 bool
 Daemon::startSubCommand( int cmd, int subcmd, Sock* sock, int timeout, CondorError *errstack, char const *cmd_description,bool raw_protocol, char const *sec_session_id )
 {
+	SecMan::StartCommandRequest req;
+	req.m_cmd = cmd;
+	req.m_sock = sock;
+	req.m_raw_protocol = raw_protocol;
+	req.m_errstack = errstack;
+	req.m_subcmd = subcmd;
+	req.m_callback_fn = nullptr;
+	req.m_misc_data = nullptr;
 	// This is a blocking version of startCommand().
-	const bool nonblocking = false;
-	StartCommandResult rc = startCommand_internal(cmd,sock,timeout,errstack,subcmd,NULL,NULL,nonblocking,cmd_description,&_sec_man,raw_protocol,sec_session_id);
+	req.m_nonblocking = false;
+	req.m_cmd_description = cmd_description;
+	req.m_sec_session_id = sec_session_id;
+
+	auto rc = startCommand_internal(req, timeout, &_sec_man);
+
 	switch(rc) {
 	case StartCommandSucceeded:
 		return true;
@@ -714,17 +725,39 @@ Daemon::startCommand_nonblocking( int cmd, Stream::stream_type st, int timeout, 
 StartCommandResult
 Daemon::startCommand_nonblocking( int cmd, Sock* sock, int timeout, CondorError *errstack, StartCommandCallbackType *callback_fn, void *misc_data, char const *cmd_description, bool raw_protocol, char const *sec_session_id )
 {
+	SecMan::StartCommandRequest req;
+	req.m_cmd = cmd;
+	req.m_sock = sock;
+	req.m_raw_protocol = raw_protocol;
+	req.m_errstack = errstack;
+	req.m_subcmd = 0; // no sub-command
+	req.m_callback_fn = callback_fn;
+	req.m_misc_data = misc_data;
 	// This is the nonblocking version of startCommand().
-	const bool nonblocking = true;
-	return startCommand_internal(cmd,sock,timeout,errstack,0,callback_fn,misc_data,nonblocking,cmd_description,&_sec_man,raw_protocol,sec_session_id);
+	req.m_nonblocking = true;
+	req.m_cmd_description = cmd_description;
+	req.m_sec_session_id = sec_session_id;
+
+	return startCommand_internal(req, timeout, &_sec_man);
 }
 
 bool
 Daemon::startCommand( int cmd, Sock* sock, int timeout, CondorError *errstack, char const *cmd_description,bool raw_protocol, char const *sec_session_id )
 {
-	// This is a blocking version of startCommand().
-	const bool nonblocking = false;
-	StartCommandResult rc = startCommand_internal(cmd,sock,timeout,errstack,0,NULL,NULL,nonblocking,cmd_description,&_sec_man,raw_protocol,sec_session_id);
+	SecMan::StartCommandRequest req;
+	req.m_cmd = cmd;
+	req.m_sock = sock;
+	req.m_raw_protocol = raw_protocol;
+	req.m_errstack = errstack;
+	req.m_subcmd = 0; // no sub-command
+	req.m_callback_fn = nullptr;
+	req.m_misc_data = nullptr;
+	// This is the blocking version of startCommand().
+	req.m_nonblocking = false;
+	req.m_cmd_description = cmd_description;
+	req.m_sec_session_id = sec_session_id;
+
+	StartCommandResult rc = startCommand_internal(req, timeout, &_sec_man);
 	switch(rc) {
 	case StartCommandSucceeded:
 		return true;

--- a/src/condor_daemon_client/daemon.h
+++ b/src/condor_daemon_client/daemon.h
@@ -898,7 +898,7 @@ protected:
 		   differentiate between the 6 different variants (besides the
 		   13 argument signature!).
 		 */
-	static StartCommandResult startCommand_internal( int cmd, Sock* sock, int timeout, CondorError *errstack, int subcmd, StartCommandCallbackType *callback_fn, void *misc_data, bool nonblocking, char const *cmd_description, SecMan *sec_man, bool raw_protocol, char const *sec_session_id);
+	static StartCommandResult startCommand_internal( const SecMan::StartCommandRequest &req, int timeout, SecMan *sec_man );
 
 		/**
 		   Internal function used by public versions of startCommand().

--- a/src/condor_daemon_client/daemon_list.cpp
+++ b/src/condor_daemon_client/daemon_list.cpp
@@ -298,7 +298,7 @@ CollectorList::sendUpdates (int cmd, ClassAd * ad1, ClassAd* ad2, bool nonblocki
 				 daemon->addr() );
 		void *data = nullptr;
 		if (token_requester) {
-			data = token_requester->createCallbackData(daemon->addr(),
+			data = token_requester->createCallbackData(daemon->name(),
 				identity, authz_name);
 		}
 		if( daemon->sendUpdate(cmd, ad1, *adSeq, ad2, nonblocking,

--- a/src/condor_daemon_client/daemon_list.cpp
+++ b/src/condor_daemon_client/daemon_list.cpp
@@ -25,6 +25,8 @@
 #include "dc_collector.h"
 #include "internet.h"
 #include "ipv6_hostname.h"
+#include "condor_daemon_core.h"
+
 #include <vector>
 
 DaemonList::DaemonList()
@@ -272,7 +274,10 @@ DCCollectorAdSequences & CollectorList::getAdSeq()
 }
 
 int
-CollectorList::sendUpdates (int cmd, ClassAd * ad1, ClassAd* ad2, bool nonblocking) {
+CollectorList::sendUpdates (int cmd, ClassAd * ad1, ClassAd* ad2, bool nonblocking,
+	DCTokenRequester *token_requester, const std::string &identity,
+	const std::string authz_name)
+{
 	int success_count = 0;
 
 	if ( ! adSeq) {
@@ -291,7 +296,14 @@ CollectorList::sendUpdates (int cmd, ClassAd * ad1, ClassAd* ad2, bool nonblocki
 		dprintf( D_FULLDEBUG, 
 				 "Trying to update collector %s\n", 
 				 daemon->addr() );
-		if( daemon->sendUpdate(cmd, ad1, *adSeq, ad2, nonblocking) ) {
+		void *data = nullptr;
+		if (token_requester) {
+			data = token_requester->createCallbackData(daemon->addr(),
+				identity, authz_name);
+		}
+		if( daemon->sendUpdate(cmd, ad1, *adSeq, ad2, nonblocking,
+			DCTokenRequester::daemonUpdateCallback, data) )
+		{
 			success_count++;
 		} 
 	}

--- a/src/condor_daemon_client/daemon_list.h
+++ b/src/condor_daemon_client/daemon_list.h
@@ -28,6 +28,7 @@
 #include "condor_query.h"
 
 
+class DCTokenRequester;
 class DCCollector;
 class CondorQuery;
 
@@ -110,7 +111,9 @@ class CollectorList : public DaemonList {
 
 		// Send updates to all the collectors
 		// return - number of successfull updates
-	int sendUpdates (int cmd, ClassAd* ad1, ClassAd* ad2, bool nonblocking);
+	int sendUpdates (int cmd, ClassAd* ad1, ClassAd* ad2, bool nonblocking,
+		DCTokenRequester *token_requester = nullptr, const std::string &identity = "",
+		const std::string authz_name = "");
 
 		// use this to detach the ad sequence counters before destroying the collector list
 		// we do this when we want to move the sequence counters to a new list

--- a/src/condor_daemon_client/dc_collector.h
+++ b/src/condor_daemon_client/dc_collector.h
@@ -93,7 +93,7 @@ public:
 			@param ad ClassAd you want to use for the update
 			file)
 		*/
-	bool sendUpdate( int cmd, ClassAd* ad1, DCCollectorAdSequences& seq, ClassAd* ad2, bool nonblocking );
+	bool sendUpdate( int cmd, ClassAd* ad1, DCCollectorAdSequences& seq, ClassAd* ad2, bool nonblocking, StartCommandCallbackType=nullptr, void *miscdata=nullptr );
 
 	void reconfig( void );
 
@@ -121,15 +121,15 @@ private:
 	std::deque<class UpdateData*> pending_update_list;
 	friend class UpdateData;
 
-	bool sendTCPUpdate( int cmd, ClassAd* ad1, ClassAd* ad2, bool nonblocking );
-	bool sendUDPUpdate( int cmd, ClassAd* ad1, ClassAd* ad2, bool nonblocking );
+	bool sendTCPUpdate( int cmd, ClassAd* ad1, ClassAd* ad2, bool nonblocking, StartCommandCallbackType callback_fn, void* miscdata );
+	bool sendUDPUpdate( int cmd, ClassAd* ad1, ClassAd* ad2, bool nonblocking, StartCommandCallbackType callback_fn, void *miscdata );
 
-	static bool finishUpdate( DCCollector *self, Sock* sock, ClassAd* ad1, ClassAd* ad2 );
+	static bool finishUpdate( DCCollector *self, Sock* sock, ClassAd* ad1, ClassAd* ad2, StartCommandCallbackType callback_fn, void *miscdata );
 
 	void parseTCPInfo( void );
 	void initDestinationStrings( void );
 
-	bool initiateTCPUpdate( int cmd, ClassAd* ad1, ClassAd* ad2, bool nonblocking );
+	bool initiateTCPUpdate( int cmd, ClassAd* ad1, ClassAd* ad2, bool nonblocking, StartCommandCallbackType callback_fn, void *miscdata );
 
 	char* update_destination;
 

--- a/src/condor_daemon_client/dc_message.cpp
+++ b/src/condor_daemon_client/dc_message.cpp
@@ -401,7 +401,7 @@ DCMessenger::doneWithSock(Stream *sock)
 }
 
 void
-DCMessenger::connectCallback(bool success, Sock *sock, CondorError *, void *misc_data)
+DCMessenger::connectCallback(bool success, Sock *sock, CondorError *, const std::string &trust_domain, bool should_try_token_request, void *misc_data)
 {
 	ASSERT(misc_data);
 
@@ -411,6 +411,8 @@ DCMessenger::connectCallback(bool success, Sock *sock, CondorError *, void *misc
 	self->m_callback_msg = NULL;
 	self->m_callback_sock = NULL;
 	self->m_pending_operation = NOTHING_PENDING;
+	self->m_daemon->m_trust_domain = trust_domain;
+	self->m_daemon->m_should_try_token_request = should_try_token_request;
 
 	if(!success) {
 		if( sock->deadline_expired() ) {

--- a/src/condor_daemon_client/dc_message.h
+++ b/src/condor_daemon_client/dc_message.h
@@ -325,7 +325,7 @@ public:
 	friend class DCMsg;
 private:
 		// This is called by DaemonClient when startCommand has finished.
-	static void connectCallback(bool success, Sock *sock, CondorError *errstack, void *misc_data);
+	static void connectCallback(bool success, Sock *sock, CondorError *errstack, const std::string &trust_domain, bool should_try_token_request, void *misc_data);
 
 		// This is called by DaemonCore when the sock has data.
 	int receiveMsgCallback(Stream *sock);

--- a/src/condor_daemon_core.V6/daemon_core.cpp
+++ b/src/condor_daemon_core.V6/daemon_core.cpp
@@ -10823,7 +10823,8 @@ DaemonCore::getCollectorList() {
 
 
 int
-DaemonCore::sendUpdates( int cmd, ClassAd* ad1, ClassAd* ad2, bool nonblock )
+DaemonCore::sendUpdates( int cmd, ClassAd* ad1, ClassAd* ad2, bool nonblock,
+	DCTokenRequester *token_requester, const std::string &identity, const std::string &authz_name )
 {
 	ASSERT(ad1);
 	ASSERT(m_collector_list);
@@ -10847,7 +10848,8 @@ DaemonCore::sendUpdates( int cmd, ClassAd* ad1, ClassAd* ad2, bool nonblock )
 
 		// Even if we just decided to shut ourselves down, we should
 		// still send the updates originally requested by the caller.
-	return m_collector_list->sendUpdates(cmd, ad1, ad2, nonblock);
+	return m_collector_list->sendUpdates(cmd, ad1, ad2, nonblock, token_requester,
+		identity, authz_name);
 }
 
 

--- a/src/condor_daemon_core.V6/daemon_core_main.cpp
+++ b/src/condor_daemon_core.V6/daemon_core_main.cpp
@@ -623,10 +623,10 @@ DCTokenRequester::createCallbackData(const std::string &daemon_addr, const std::
 void
 DCTokenRequester::tokenRequestCallback(bool success, void *miscdata)
 {
-	auto data = reinterpret_cast<DCTokenRequester *>(miscdata);
-	std::unique_ptr<DCTokenRequester> data_uptr(data);
+	auto data = reinterpret_cast<DCTokenRequester::DCTokenRequesterData *>(miscdata);
+	std::unique_ptr<DCTokenRequester::DCTokenRequesterData> data_uptr(data);
 
-	(*data->m_callback)(success, data->m_callback_data);
+	(*data->m_callback_fn)(success, data->m_callback_data);
 }
 
 

--- a/src/condor_daemon_core.V6/daemon_core_main.cpp
+++ b/src/condor_daemon_core.V6/daemon_core_main.cpp
@@ -43,6 +43,9 @@
 #include "store_cred.h"
 #include "condor_netaddr.h"
 #include "net_string_list.h"
+#include "dc_collector.h"
+#include "condor_netdb.h"
+#include "token_utils.h"
 
 #include <chrono>
 #include <sstream>
@@ -134,9 +137,13 @@ static bool doAuthInit = true;
 // It can be set to false by calling the DC_Skip_Core_Init() function.
 static bool doCoreInit = true;
 
+
+	// Right now, the default ID is simply the empty string.
+const std::string DCTokenRequester::default_identity = "";
+
 namespace {
 
-class TokenRequest {
+class TokenRequest : public Service {
 public:
 
 	enum class State {
@@ -319,7 +326,169 @@ public:
 		);
 	}
 
+		// Callbacks for collector updates; determine whether a token request would be useful!
+	static void
+	daemonUpdateCallback(bool success, Sock *sock, CondorError *, const std::string &trust_domain, bool should_try_token_request, void *miscdata) {
+		if (success || !should_try_token_request || !sock) return;
+
+		auto data = reinterpret_cast<DCTokenRequester::DCTokenRequesterData*>(miscdata);
+		if (!data) {
+			return;
+		}
+
+			// Avoiding requesting tokens for already-pending requests.
+		for (const auto &pending_request : m_token_requests) {
+			if (pending_request.m_identity != data->m_identity) {
+				continue;
+			}
+			if (pending_request.m_trust_domain == trust_domain) {
+				return;
+			}
+		}
+
+		dprintf(D_ALWAYS, "Collector update failed; will try to get a token request for trust domain %s.\n", trust_domain.c_str());
+		m_token_requests.emplace_back();
+		auto &back = m_token_requests.back();
+			// Note that the default identity is simply the empty string in
+			// the token request code.  Distinguishing token requests by identity
+			// will become useful with per-submitter flocking.
+		back.m_identity = DCTokenRequester::default_identity;
+		back.m_trust_domain = trust_domain;
+		back.m_authz_name = data->m_authz_name;
+		back.m_daemon.reset(new DCCollector(data->m_addr.c_str()));
+		back.m_callback_fn = &DCTokenRequester::tokenRequestCallback;
+		back.m_callback_data = data;
+
+		if (m_token_requests_tid == -1) {
+			m_token_requests_tid = daemonCore->Register_Timer( 0,
+			(TimerHandler)&TokenRequest::tryTokenRequests,
+			"TokenRequest::tryTokenRequests" );
+		}
+
+	}
+
+	static void
+	clearTokenRequests() {m_token_requests.clear();}
+
 private:
+	struct PendingRequest {
+			// Request ID sent to the remote server.
+		std::string m_request_id;
+			// My auto-generated client ID; an empty
+			// client ID indicates the token request has not
+			// been sent to the remote daemon yet.
+		std::string m_client_id;
+			// Identity requested for this token
+		std::string m_identity;
+		std::string m_trust_domain;
+			// Authorization level name
+		std::string m_authz_name;
+		std::unique_ptr<Daemon> m_daemon{nullptr};
+		RequestCallbackFn *m_callback_fn{nullptr};
+			// Callback data must be guaranteed to outlive the request;
+			// borrowed reference.
+		void *m_callback_data{nullptr};
+	};
+
+	static void
+	tryTokenRequests() {
+		bool should_reschedule = false;
+		dprintf(D_SECURITY|D_FULLDEBUG, "There are %lu token requests remaining.\n",
+		m_token_requests.size());
+		for (auto & request : m_token_requests)
+		{
+			should_reschedule |= tryTokenRequest(request);
+		}
+		if (should_reschedule) {
+			daemonCore->Reset_Timer(m_token_requests_tid, 5, 1);
+			dprintf(D_SECURITY|D_FULLDEBUG, "Will reschedule another poll of requests.\n");
+		} else {
+			daemonCore->Cancel_Timer(m_token_requests_tid);
+			m_token_requests_tid = -1;
+		}
+		m_token_requests.erase(
+			std::remove_if(m_token_requests.begin(),
+				m_token_requests.end(),
+				[](const PendingRequest &req) {return req.m_client_id.empty();}),
+					m_token_requests.end()
+			);
+	};
+
+	static bool
+	tryTokenRequest(PendingRequest &req) {
+		std::string subsys_name = get_mySubSystemName();
+
+		dprintf(D_SECURITY, "Trying token request to remote host.\n");
+		if (!req.m_daemon) {
+			dprintf(D_FAILURE, "Logic error!  Token request without associated daemon.\n");
+			return false;
+		}
+		std::string token;
+		if (req.m_client_id.empty()) {
+			req.m_request_id = "";
+			std::vector<char> hostname;
+			hostname.reserve(MAXHOSTNAMELEN);
+			if (condor_gethostname(&hostname[0], MAXHOSTNAMELEN)) {
+				dprintf(D_ALWAYS, "Unable to determine hostname; cannot start token request.\n");
+				(*req.m_callback_fn)(false, req.m_callback_data);
+				return false;
+			}
+			req.m_client_id = subsys_name + "-" + std::string(&hostname[0]) + "-" +
+			std::to_string(get_csrng_uint() % 1000);
+
+			std::string request_id;
+			std::vector<std::string> authz_list;
+			authz_list.push_back(req.m_authz_name);
+			int lifetime = -1;
+			CondorError err;
+			if (!req.m_daemon->startTokenRequest(req.m_identity, authz_list, lifetime,
+				req.m_client_id, token, request_id, &err))
+			{
+				dprintf(D_ALWAYS, "Failed to request a new token: %s\n", err.getFullText().c_str());
+				req.m_client_id = "";
+				(*req.m_callback_fn)(false, req.m_callback_data);
+				return false;
+			}
+			if (token.empty()) {
+				req.m_request_id = request_id;
+				dprintf(D_ALWAYS, "Token requested; please ask collector %s admin to approve request ID %s.\n", req.m_daemon->name(), request_id.c_str());
+				return true;
+			} else {
+				dprintf(D_ALWAYS, "Token request auto-approved.\n");
+				Condor_Auth_Passwd::retry_token_search();
+				daemonCore->getSecMan()->reconfig();
+				(*req.m_callback_fn)(true, req.m_callback_data);
+				req.m_client_id = "";
+			}
+		} else {
+			CondorError err;
+			if (!req.m_daemon->finishTokenRequest(req.m_client_id, req.m_request_id, token, &err)) {
+				dprintf(D_ALWAYS, "Failed to retrieve a new token: %s\n", err.getFullText().c_str());
+				req.m_client_id = "";
+				(*req.m_callback_fn)(false, req.m_callback_data);
+				return false;
+			}
+			if (token.empty()) {
+				dprintf(D_FULLDEBUG|D_SECURITY, "Token request not approved; will retry in 5 seconds.\n");
+				dprintf(D_ALWAYS, "Token requested not yet approved; please ask collector %s admin to approve request ID %s.\n", req.m_daemon->name(), req.m_request_id.c_str());
+				return true;
+			} else {
+				dprintf(D_ALWAYS, "Token request approved.\n");
+					// Flush the cached result of the token search.
+				Condor_Auth_Passwd::retry_token_search();
+					// Flush out the security sessions; will need to force a re-auth.
+				daemonCore->getSecMan()->reconfig();
+					// Reset the timeout timer, causing the schedd to advertise itself.
+				(*req.m_callback_fn)(true, req.m_callback_data);
+			}
+			req.m_client_id = "";
+		}
+		if (!token.empty()) {
+			htcondor::write_out_token(subsys_name + "_auto_generated_token", token);
+		}
+		return false;
+	}
+
 	// The initial state of a request should always be pending.
 	State m_state{State::Pending};
 
@@ -342,9 +511,18 @@ private:
 	};
 
 	static std::vector<ApprovalRule> m_approval_rules;
+
+	static std::vector<PendingRequest> m_token_requests;
+	static int m_token_requests_tid;
 };
 
+
+int TokenRequest::m_token_requests_tid{-1};
+
+
 std::vector<TokenRequest::ApprovalRule> TokenRequest::m_approval_rules;
+
+std::vector<TokenRequest::PendingRequest> TokenRequest::m_token_requests;
 
 typedef std::unordered_map<int, std::unique_ptr<TokenRequest>> TokenMap;
 
@@ -425,6 +603,40 @@ void cleanup_request_map() {
 }
 
 }
+
+
+void*
+DCTokenRequester::createCallbackData(const std::string &daemon_addr, const std::string &identity,
+	const std::string &authz_name)
+{
+	DCTokenRequesterData *data = new DCTokenRequesterData();
+	data->m_addr = daemon_addr;
+	data->m_identity = identity;
+	data->m_authz_name = authz_name;
+	data->m_callback_fn = m_callback;
+	data->m_callback_data = m_callback_data;
+
+	return data;
+}
+
+
+void
+DCTokenRequester::tokenRequestCallback(bool success, void *miscdata)
+{
+	auto data = reinterpret_cast<DCTokenRequester *>(miscdata);
+	std::unique_ptr<DCTokenRequester> data_uptr(data);
+
+	(*data->m_callback)(success, data->m_callback_data);
+}
+
+
+void
+DCTokenRequester::daemonUpdateCallback(bool success, Sock *sock, CondorError *errstack, const std::string &trust_domain,
+                bool should_try_token_request, void *miscdata)
+{
+	TokenRequest::daemonUpdateCallback(success, sock, errstack, trust_domain, should_try_token_request, miscdata);
+}
+
 
 #ifndef WIN32
 // This function polls our parent process; if it is gone, shutdown.
@@ -2761,6 +2973,7 @@ dc_reconfig()
 	for (auto &entry : g_request_map) {
 		entry.second->setFailed();
 	}
+	TokenRequest::clearTokenRequests();
 
 	// call this daemon's specific main_config()
 	dc_main_config();

--- a/src/condor_includes/condor_secman.h
+++ b/src/condor_includes/condor_secman.h
@@ -40,7 +40,7 @@
 #include "reli_sock.h"
 
 
-typedef void StartCommandCallbackType(bool success,Sock *sock,CondorError *errstack,void *misc_data);
+typedef void StartCommandCallbackType(bool success, Sock *sock, CondorError *errstack, const std::string &trust_domain, bool should_try_token_request, void *misc_data);
 
 extern char const *USE_TMP_SEC_SESSION;
 

--- a/src/condor_includes/condor_secman.h
+++ b/src/condor_includes/condor_secman.h
@@ -105,6 +105,28 @@ public:
 	~SecMan();
 	const SecMan & operator=(const SecMan &);
 
+		// A struct to order all the startCommand parameters below (as opposed
+		// to having 10 parameters to a single function).
+		//
+		// Mostly a duplicate of the internal "SecManStartCommand" class, except
+		// simpler and stripped down.
+	struct StartCommandRequest {
+
+		StartCommandRequest() {}
+		StartCommandRequest(const StartCommandRequest &) = delete;
+
+		int m_cmd{-1};
+		Sock *m_sock{nullptr};
+		bool m_raw_protocol{false};
+		CondorError *m_errstack{nullptr};
+		int m_subcmd{-1};
+		StartCommandCallbackType *m_callback_fn{nullptr};
+		void *m_misc_data{nullptr};
+		bool m_nonblocking{false};
+		const char *m_cmd_description{nullptr};
+		const char *m_sec_session_id{nullptr};
+	};
+
 		// Prepare a socket for sending a CEDAR command.  This takes
 		// care of security negotiation and authentication.
 		// (If raw_protocol=true, then no security negotiation or
@@ -117,7 +139,7 @@ public:
 		// spawn off a non-blocking attempt to create a security
 		// session so that in the future, a UDP command could succeed
 		// without StartCommandWouldBlock.
-	StartCommandResult startCommand( int cmd, Sock* sock, bool raw_protocol, CondorError* errstack, int subcmd, StartCommandCallbackType *callback_fn, void *misc_data, bool nonblocking,char const *cmd_description,char const *sec_session_id);
+	StartCommandResult startCommand(const StartCommandRequest &req);
 
 		// Authenticate a socket using whatever authentication methods
 		// have been configured for the specified perm level.

--- a/src/condor_io/condor_secman.cpp
+++ b/src/condor_io/condor_secman.cpp
@@ -1146,7 +1146,7 @@ class SecManStartCommand: Service, public ClassyCountedPtr {
 };
 
 StartCommandResult
-SecMan::startCommand( int cmd, Sock* sock, bool raw_protocol, CondorError* errstack, int subcmd, StartCommandCallbackType *callback_fn, void *misc_data, bool nonblocking,char const *cmd_description,char const *sec_session_id_hint)
+SecMan::startCommand(const StartCommandRequest &req)
 {
 	// This function is simply a convenient wrapper around the
 	// SecManStartCommand class, which does the actual work.
@@ -1159,7 +1159,18 @@ SecMan::startCommand( int cmd, Sock* sock, bool raw_protocol, CondorError* errst
 	// The blocking case could avoid use of the heap, but for simplicity,
 	// we just do the same in both cases.
 
-	classy_counted_ptr<SecManStartCommand> sc = new SecManStartCommand(cmd,sock,raw_protocol,errstack,subcmd,callback_fn,misc_data,nonblocking,cmd_description,sec_session_id_hint,this);
+	classy_counted_ptr<SecManStartCommand> sc = new SecManStartCommand(
+		req.m_cmd,
+		req.m_sock,
+		req.m_raw_protocol,
+		req.m_errstack,
+		req.m_subcmd,
+		req.m_callback_fn,
+		req.m_misc_data,
+		req.m_nonblocking,
+		req.m_cmd_description,
+		req.m_sec_session_id,
+		this);
 
 	ASSERT(sc.get());
 

--- a/src/condor_io/condor_secman.cpp
+++ b/src/condor_io/condor_secman.cpp
@@ -1247,7 +1247,8 @@ SecManStartCommand::doCallback( StartCommandResult result )
 		bool success = result == StartCommandSucceeded;
 		CondorError *cb_errstack = m_errstack == &m_internal_errstack ?
 		                           NULL : m_errstack;
-		(*m_callback_fn)(success,m_sock,cb_errstack, m_sock->getTrustDomain(), false, m_misc_data);
+		(*m_callback_fn)(success,m_sock,cb_errstack, m_sock->getTrustDomain(),
+			m_sock->shouldTryTokenRequest(), m_misc_data);
 
 		m_callback_fn = NULL;
 		m_misc_data = NULL;

--- a/src/condor_io/condor_secman.cpp
+++ b/src/condor_io/condor_secman.cpp
@@ -1127,7 +1127,7 @@ class SecManStartCommand: Service, public ClassyCountedPtr {
 	StartCommandResult receivePostAuthInfo_inner();
 
 		// This is called when the TCP auth attempt completes.
-	static void TCPAuthCallback(bool success,Sock *sock,CondorError *errstack,void *misc_data);
+	static void TCPAuthCallback(bool success,Sock *sock,CondorError *errstack, const std::string &trust_domain, bool should_try_token_request, void *misc_data);
 
 		// This is the _inner() function for TCPAuthCallback().
 	StartCommandResult TCPAuthCallback_inner( bool auth_succeeded, Sock *tcp_auth_sock );
@@ -1247,7 +1247,7 @@ SecManStartCommand::doCallback( StartCommandResult result )
 		bool success = result == StartCommandSucceeded;
 		CondorError *cb_errstack = m_errstack == &m_internal_errstack ?
 		                           NULL : m_errstack;
-		(*m_callback_fn)(success,m_sock,cb_errstack,m_misc_data);
+		(*m_callback_fn)(success,m_sock,cb_errstack, m_sock->getTrustDomain(), false, m_misc_data);
 
 		m_callback_fn = NULL;
 		m_misc_data = NULL;
@@ -2449,7 +2449,7 @@ SecManStartCommand::DoTCPAuth_inner()
 }
 
 void
-SecManStartCommand::TCPAuthCallback(bool success,Sock *sock,CondorError * /*errstack*/,void * misc_data)
+SecManStartCommand::TCPAuthCallback(bool success,Sock *sock,CondorError * /*errstack*/, const std::string &, bool, void * misc_data)
 {
 	classy_counted_ptr<SecManStartCommand> self = (SecManStartCommand *)misc_data;
 

--- a/src/condor_negotiator.V6/matchmaker.cpp
+++ b/src/condor_negotiator.V6/matchmaker.cpp
@@ -5499,7 +5499,8 @@ public:
 		m_startd(startdAddr),
 		m_nonblocking(nonblocking) {}
 
-	static void startCommandCallback(bool success,Sock *sock,CondorError * /*errstack*/,void *misc_data)
+	static void startCommandCallback(bool success,Sock *sock,CondorError * /*errstack*/,
+		const std::string & /*trust_domain*/, bool /*should_try_token_request*/, void *misc_data)
 	{
 		NotifyStartdOfMatchHandler *self = (NotifyStartdOfMatchHandler *)misc_data;
 		ASSERT(misc_data);

--- a/src/condor_schedd.V6/schedd.cpp
+++ b/src/condor_schedd.V6/schedd.cpp
@@ -1491,7 +1491,8 @@ Scheduler::count_jobs()
 	ScheddPluginManager::Update(UPDATE_SCHEDD_AD, cad);
 #endif
 
-	int num_updates = daemonCore->sendUpdates(UPDATE_SCHEDD_AD, cad, NULL, true);
+	int num_updates = daemonCore->sendUpdates(UPDATE_SCHEDD_AD, cad, NULL, true,
+		&m_token_requester, DCTokenRequester::default_identity, "ADVERTISE_SCHEDD");
 	dprintf( D_FULLDEBUG,
 			 "Sent HEART BEAT ad to %d collectors. Number of active submittors=%d\n",
 			 num_updates, NumSubmitters );
@@ -1506,8 +1507,9 @@ Scheduler::count_jobs()
 		FlockCollectors->next(d);
 		for(int ii=0; d && ii < FlockLevel; ii++ ) {
 			col = (DCCollector*)d;
-			auto data = m_token_requester.createCallbackData(col->addr(), DCTokenRequester::default_identity, "ADVERTISE_SCHEDD");
-			col->sendUpdate( UPDATE_SCHEDD_AD, cad, adSeq, NULL, true, DCTokenRequester::daemonUpdateCallback, &data );
+			auto data = m_token_requester.createCallbackData(col->name(),
+				DCTokenRequester::default_identity, "ADVERTISE_SCHEDD");
+			col->sendUpdate( UPDATE_SCHEDD_AD, cad, adSeq, NULL, true, DCTokenRequester::daemonUpdateCallback, data );
 			m_flock_collectors_init.insert(d);
 			FlockCollectors->next( d );
 		}

--- a/src/condor_schedd.V6/scheduler.h
+++ b/src/condor_schedd.V6/scheduler.h
@@ -1015,6 +1015,8 @@ private:
 	
 	void			expand_mpi_procs(StringList *, StringList *);
 
+	static void		token_request_callback(bool success, void *miscdata);
+
 	HashTable <std::string, match_rec *> *matches;
 	HashTable <PROC_ID, match_rec *> *matchesByJobID;
 	HashTable <int, shadow_rec *> *shadowsByPid;
@@ -1085,30 +1087,7 @@ private:
 
 	bool m_matchPasswordEnabled;
 
-	// State for token request.
-	void try_token_requests();
-	// Right now, we will at most have one token request in flight;
-	// when we are ready to do this for multiple pools at a time, we
-	// will make these data structs into vectors.
-
-	struct PendingRequest {
-		std::string m_request_id;
-		std::string m_client_id;
-		std::string m_identity;
-		std::string m_trust_domain;
-		Daemon *m_daemon{nullptr};
-	};
-
-		// Try a specific token request; returns True if the timer
-		// should reschedule.
-	bool try_token_request(PendingRequest &);
-	void calc_token_requests(DaemonList *collector_list, const std::string &identity);
-
-	std::vector<PendingRequest> m_token_requests;
-	int m_token_requests_tid{-1};
-
-	bool m_initial_update{true}; // First update to the collector after reconfig blocks so we can trigger
-					// token auth if needed
+	DCTokenRequester m_token_requester;
 
 	friend class DedicatedScheduler;
 };

--- a/src/condor_startd.V6/ResMgr.cpp
+++ b/src/condor_startd.V6/ResMgr.cpp
@@ -30,14 +30,16 @@
 #include "credmon_interface.h"
 #include "condor_auth_passwd.h"
 #include "condor_netdb.h"
+#include "token_utils.h"
 
 #include "slot_builder.h"
 
 #include "strcasestr.h"
 
-extern int write_out_token(const std::string &token_name, const std::string &token);
-
-ResMgr::ResMgr() : extras_classad( NULL ), max_job_retirement_time_override(-1)
+ResMgr::ResMgr() :
+	extras_classad( NULL ),
+	max_job_retirement_time_override(-1),
+	m_token_requester(&ResMgr::token_request_callback, this)
 {
 	totals_classad = NULL;
 	config_classad = NULL;
@@ -1060,18 +1062,9 @@ ResMgr::send_update( int cmd, ClassAd* public_ad, ClassAd* private_ad,
 
 		// Increment the resmgr's count of updates.
 	num_updates++;
-		// Actually do the updates, and return the # of updates sent.
-	int res = daemonCore->sendUpdates(cmd, public_ad, private_ad, first_time ? false : nonblock);
 
-	// Check to see if we need to perform a token request.
-	auto collector_list = daemonCore->getCollectorList();
-	if (collector_list && collector_list->shouldTryTokenRequest()) {
-		dprintf(D_FULLDEBUG|D_SECURITY, "Authentication failed; startd will perform a token request\n");
-		daemonCore->Register_Timer(0, (TimerHandlercpp)&ResMgr::try_token_request,
-			"ResMgr::try_token_request", this);
-	} else if (res == 0) {
-		dprintf(D_FULLDEBUG|D_SECURITY, "Authentication failed but no token request will be tried.\n");
-	}
+	int res = daemonCore->sendUpdates(cmd, public_ad, private_ad, nonblock, &m_token_requester,
+		DCTokenRequester::default_identity, "ADVERTISE_SCHEDD");
 
 	if (first_time) {
 		first_time = false;
@@ -2646,90 +2639,13 @@ ResMgr::checkForDrainCompletion() {
 
 
 void
-ResMgr::try_token_request()
+ResMgr::token_request_callback(bool success, void *miscdata)
 {
-	dprintf(D_SECURITY, "Trying token request to remote host.\n");
-	std::string token;
-	if (m_token_client_id.empty()) {
-		m_token_daemon = nullptr;
-		m_token_request_id = "";
-		std::vector<char> hostname;
-		hostname.reserve(MAXHOSTNAMELEN);
-		if (condor_gethostname(&hostname[0], MAXHOSTNAMELEN)) {
-			dprintf(D_ALWAYS, "Unable to determine hostname; cannot start token request.\n");
-			return;
-		}
-		m_token_client_id = "startd-" + std::string(&hostname[0]) + "-" +
-			std::to_string(get_csrng_uint() % 1000);
-
-		auto collector_list = daemonCore->getCollectorList();
-		if (!collector_list || collector_list->IsEmpty()) {
-			dprintf(D_ALWAYS, "Unable to start token request because no collectors are available.\n");
-			m_token_client_id = "";
-			return;
-		}
-		Daemon *daemon = nullptr;
-		collector_list->Rewind();
-		collector_list->Current(daemon);
-
-		if (!daemon) {
-			dprintf(D_ALWAYS, "Unable to start token request because collector not found.\n");
-			m_token_client_id = "";
-			return;
-		}
-
-		std::string request_id;
-		std::vector<std::string> authz_list;
-		authz_list.push_back("ADVERTISE_STARTD");
-		int lifetime = -1;
-		CondorError err;
-		if (!daemon->startTokenRequest("", authz_list, lifetime, m_token_client_id,
-			token, request_id, &err))
-		{
-			dprintf(D_ALWAYS, "Failed to request a new token: %s\n", err.getFullText().c_str());
-			m_token_client_id = "";
-			return;
-		}
-		if (token.empty()) {
-			m_token_request_id = request_id;
-			m_token_daemon = daemon;
-			dprintf(D_ALWAYS, "Token requested; please ask collector admin to approve request ID %s.\n", request_id.c_str());
-			daemonCore->Register_Timer(5, (TimerHandlercpp)&ResMgr::try_token_request,
-				"ResMgr::try_token_request", this);
-		} else {
-			dprintf(D_ALWAYS, "Token request auto-approved.\n");
-			Condor_Auth_Passwd::retry_token_search();
-			daemonCore->getSecMan()->reconfig();
-			if( up_tid != -1 ) {
-				daemonCore->Reset_Timer( up_tid, update_offset,
-					update_interval );
-			}
-		}
-	} else {
-		CondorError err;
-		if (!m_token_daemon->finishTokenRequest(m_token_client_id, m_token_request_id, token, &err)) {
-			dprintf(D_ALWAYS, "Failed to retrieve a new token: %s\n", err.getFullText().c_str());
-			m_token_client_id = "";
-			return;
-		}
-		if (token.empty()) {
-			dprintf(D_FULLDEBUG|D_SECURITY, "Token request not approved; will retry in 5 seconds.\n");
-			dprintf(D_ALWAYS, "Token requested not yet approved; please ask collector admin to approve request ID %s.\n", m_token_request_id.c_str());
-			daemonCore->Register_Timer(5, (TimerHandlercpp)&ResMgr::try_token_request,
-				"ResMgr::try_token_request", this);
-			return;
-		} else {
-			dprintf(D_ALWAYS, "Token request approved.\n");
-			Condor_Auth_Passwd::retry_token_search();
-			daemonCore->getSecMan()->reconfig();
-			if( up_tid != -1 ) {
-				daemonCore->Reset_Timer( up_tid, update_offset,
-					update_interval );
-			}
-		}
-		m_token_client_id = "";
-	}
-	if (!token.empty()) {
-		write_out_token("startd_auto_generated_token", token);
+	auto self = reinterpret_cast<ResMgr *>(miscdata);
+		// In the successful case, instantly re-fire the timer
+		// that will send an update to the collector.
+	if (success && (self->up_tid != 1)) {
+		daemonCore->Reset_Timer( self->up_tid, update_offset,
+			update_interval );
 	}
 }

--- a/src/condor_startd.V6/ResMgr.cpp
+++ b/src/condor_startd.V6/ResMgr.cpp
@@ -1064,7 +1064,7 @@ ResMgr::send_update( int cmd, ClassAd* public_ad, ClassAd* private_ad,
 	num_updates++;
 
 	int res = daemonCore->sendUpdates(cmd, public_ad, private_ad, nonblock, &m_token_requester,
-		DCTokenRequester::default_identity, "ADVERTISE_SCHEDD");
+		DCTokenRequester::default_identity, "ADVERTISE_STARTD");
 
 	if (first_time) {
 		first_time = false;

--- a/src/condor_startd.V6/ResMgr.h
+++ b/src/condor_startd.V6/ResMgr.h
@@ -330,6 +330,7 @@ public:
 	void resetMaxJobRetirementTime() { max_job_retirement_time_override = -1; }
 
 private:
+	static void token_request_callback(bool success, void *miscdata);
 
 	Resource**	resources;		// Array of pointers to Resource objects
 	int			nresources;		// Size of the array
@@ -417,6 +418,8 @@ private:
 	int total_draining_badput;
 	int total_draining_unclaimed;
 	int max_job_retirement_time_override;
+
+	DCTokenRequester m_token_requester;
 };
 
 

--- a/src/condor_tools/token_create.cpp
+++ b/src/condor_tools/token_create.cpp
@@ -26,8 +26,7 @@
 #include "daemon.h"
 #include "dc_collector.h"
 #include "directory.h"
-
-extern int write_out_token(const std::string &token_name, const std::string &token);
+#include "token_utils.h"
 
 void print_usage(const char *argv0) {
 	fprintf(stderr, "Usage: %s -identity USER@DOMAIN [-key KEYID] [-authz AUTHZ] [-lifetime VAL] [-token NAME]\n"
@@ -119,5 +118,5 @@ int main(int argc, char *argv[]) {
 		exit(2);
 	}
 
-	return write_out_token(token_name, token);
+	return htcondor::write_out_token(token_name, token);
 }

--- a/src/condor_tools/token_fetch.cpp
+++ b/src/condor_tools/token_fetch.cpp
@@ -26,8 +26,7 @@
 #include "daemon.h"
 #include "dc_collector.h"
 #include "directory.h"
-
-extern int write_out_token(const std::string &token_name, const std::string &token);
+#include "token_utils.h"
 
 void print_usage(const char *argv0) {
 	fprintf(stderr, "Usage: %s [-type TYPE] [-name NAME] [-pool POOL] [-authz AUTHZ] [-lifetime VAL] [-token NAME]\n\n"
@@ -75,7 +74,7 @@ generate_remote_token(const std::string &pool, const std::string &name, daemon_t
 		fprintf(stderr, "Failed to request a session token: %s\n", err.getFullText().c_str());
 		exit(1);
 	}
-	return write_out_token(token_name, token);
+	return htcondor::write_out_token(token_name, token);
 }
 
 int main(int argc, char *argv[]) {

--- a/src/condor_tools/token_request.cpp
+++ b/src/condor_tools/token_request.cpp
@@ -27,8 +27,7 @@
 #include "dc_collector.h"
 #include "directory.h"
 #include "condor_netdb.h"
-
-extern int write_out_token(const std::string &token_name, const std::string &token);
+#include "token_utils.h"
 
 void print_usage(const char *argv0) {
 	fprintf(stderr, "Usage: %s [-type TYPE] [-name NAME] [-pool POOL] [-authz AUTHZ] [-lifetime VAL] [-token NAME]\n\n"
@@ -103,7 +102,7 @@ request_remote_token(const std::string &pool, const std::string &name, daemon_t 
 		}
 	}
 
-	return write_out_token(token_name, token);
+	return htcondor::write_out_token(token_name, token);
 }
 
 int main(int argc, char *argv[]) {

--- a/src/condor_utils/token_utils.cpp
+++ b/src/condor_utils/token_utils.cpp
@@ -19,13 +19,16 @@
 
 #include "condor_common.h"
 
-#include <string>
+#include "token_utils.h"
+
 #include "condor_config.h"
 #include "condor_string.h"
 #include "directory.h"
 
+#include <string>
+
 int
-write_out_token(const std::string &token_name, const std::string &token)
+htcondor::write_out_token(const std::string &token_name, const std::string &token)
 {
 	if (token_name.empty()) {
 		printf("%s\n", token.c_str());

--- a/src/condor_utils/token_utils.h
+++ b/src/condor_utils/token_utils.h
@@ -1,0 +1,35 @@
+/***************************************************************
+ *
+ * Copyright (C) 2019, HTCondor Team, Computer Sciences Department,
+ * University of Wisconsin-Madison, WI.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include <string>
+
+#ifndef __TOKEN_UTILS_H
+#define __TOKEN_UTILS_H
+
+namespace htcondor {
+
+	// Append a given token's contents to a given token file.
+	// The correct directory is automatically determined from the
+	// HTCondor configuration.
+int
+write_out_token(const std::string &token_name, const std::string &token);
+
+}
+
+#endif


### PR DESCRIPTION
This pulls common token request code from the schedd and startd into a single implementation inside DaemonCore.

It also refactors a number of calling interfaces to allow the entire token request workflow to become non-blocking.  This cleverly solves some memory management issues where the `Socket` the `DaemonList` held was no longer valid: the callbacks are instead invoked immediately after success/failure in the SecMan.