### PR TITLE
Fixup F27 warning. #7318

### DIFF
--- a/src/condor_utils/data_reuse.cpp
+++ b/src/condor_utils/data_reuse.cpp
@@ -91,10 +91,10 @@ DataReuseDirectory::CreatePaths()
 		return;
 	}
 	name = dircat(m_dirpath.c_str(), "sha256", subdir);
-	char subdir_name[3];
-	subdir_name[2] = '\0';
+	char subdir_name[4];
 	for (int idx = 0; idx < 256; idx++) {
 		sprintf(subdir_name, "%02x", idx);
+		subdir_name[2] = '\0';
 		auto name2 = dircat(name, subdir_name, subdir2);
 		if (!mkdir_and_parents_if_needed(name2, 0700, 0700, PRIV_CONDOR)) {
 			m_valid = false;
@@ -131,7 +131,7 @@ DataReuseDirectory::LogSentry::~LogSentry()
 }
 
 
-DataReuseDirectory::LogSentry &&
+DataReuseDirectory::LogSentry
 DataReuseDirectory::LockLog(CondorError &err)
 {
 	LogSentry sentry(*this, err);

--- a/src/condor_utils/data_reuse.h
+++ b/src/condor_utils/data_reuse.h
@@ -137,7 +137,7 @@ private:
 	bool UpdateState(LogSentry &sentry, CondorError &err);
 	bool HandleEvent(ULogEvent &event, CondorError &err);
 
-	LogSentry &&LockLog(CondorError &err);
+	LogSentry LockLog(CondorError &err);
 	bool UnlockLog(LogSentry sentry, CondorError &err);
 
 	void CreatePaths();


### PR DESCRIPTION
It's not entirely clear whether the std::move would return a local reference; this replaces the usage of rvalue refs with RVO.

Also fix buffer sizing issues; it's not clear if these were actually able to trigger given the loop constraints.  Will trust the compiler's advice on that one, however.