### PR TITLE
Bugfix: invoke stageout plugin at job end.  #7078

### DIFF
--- a/src/condor_utils/file_transfer.cpp
+++ b/src/condor_utils/file_transfer.cpp
@@ -3568,20 +3568,25 @@ FileTransfer::DoUpload(filesize_t *total_bytes, ReliSock *s)
 	MyString first_failed_error_desc;
 	int first_failed_line_number = 0;
 
-	bool should_invoke_output_plugins, tmp;
-	if (!jobAd.EvaluateAttrBool("OutputPluginsOnlyOnExit", tmp)) {
-		should_invoke_output_plugins = m_final_transfer_flag;
-	} else {
-		if (!InitDownloadFilenameRemaps(&jobAd)) {
+	bool should_invoke_output_plugins = m_final_transfer_flag;
+	bool tmp;
+	if (jobAd.EvaluateAttrBool("OutputPluginsOnlyOnExit", tmp) && !tmp) {
+			// InitDownloadFilenameRemaps is always called by the server
+			// (the function name is a misnomer) for final transfers.  However,
+			// in this case, we also want output files to be remapped to URLs
+			// when spooling.  Hence, we call it here.
+		if (!m_final_transfer_flag && !InitDownloadFilenameRemaps(&jobAd)) {
 			return -1;
 		}
-		should_invoke_output_plugins = !tmp;
+		should_invoke_output_plugins = true;
 	}
 
 	uploadStartTime = condor_gettimestamp_double();
 
 	*total_bytes = 0;
 	dprintf(D_FULLDEBUG,"entering FileTransfer::DoUpload\n");
+	dprintf(D_FULLDEBUG,"DoUpload: Output URL plugins %s be run\n",
+		should_invoke_output_plugins ? "will" : "will not");
 
 	priv_state saved_priv = PRIV_UNKNOWN;
 	if( want_priv_change ) {


### PR DESCRIPTION
When `OutputPluginsOnlyOnExit` is set to `true` (the default value; there would have been no reason why someone would set the undocumented knob to this value either), output plugins were not being invoked on exit. This corrects the logic to ensure plugins are invoked on exit for all cases.

This additionally refactors the stageout logic as suggested in #7042 to make it simpler to read.