### PR TITLE
some condor.spec updates to harmonize with osg (SOFTWARE-3929)

### DIFF
--- a/build/packaging/srpm/condor.spec
+++ b/build/packaging/srpm/condor.spec
@@ -64,6 +64,10 @@
 %endif
 %endif
 
+%if 0%{?osg} && 0%{?rhel} == 7
+%define cream 0
+%endif
+
 # cream support is going away, skip for EL8
 %if 0%{?rhel} >= 8
 %define cream 0
@@ -278,6 +282,7 @@ BuildRequires: globus-common-devel
 BuildRequires: globus-ftp-client-devel
 BuildRequires: globus-ftp-control-devel
 BuildRequires: munge-devel
+BuildRequires: scitokens-cpp-devel
 BuildRequires: voms-devel
 %endif
 BuildRequires: libtool-ltdl-devel
@@ -410,6 +415,10 @@ Requires(post): selinux-policy-targeted
 #Provides: group(condor) = 43
 
 Obsoletes: condor-static < 7.2.0
+
+%if ! %cream
+Obsoletes: condor-cream-gahp <= %{version}
+%endif
 
 %description
 HTCondor is a specialized workload management system for


### PR DESCRIPTION
- OSG explicitly does not want cream for RHEL7
- `scitokens-cpp-devel` is needed when not building the external (that is, when not doing a uw_build)
- if cream is not included, the Obsoletes is needed in order for yum to know it can remove an old installed `condor-cream-gahp` package, which otherwise breaks a yum upgrade