### PR TITLE
Address code review for #6971.  #7079.

### DIFF
--- a/src/condor_filetransfer_plugins/multifile_curl_plugin.h
+++ b/src/condor_filetransfer_plugins/multifile_curl_plugin.h
@@ -39,6 +39,10 @@ class MultiFileCurlPlugin {
     int DownloadFile( const std::string &url, const std::string &local_file_name, const std::string &cred, long &partial_bytes );
     int BuildTransferRequests (const std::string & input_filename, std::vector<std::pair<std::string, transfer_request>> &requested_files) const;
     FILE *OpenLocalFile (const std::string &local_file, const char *mode) const;
+
+        // Parse the job and machine ads (if present), looking for settings that control
+        // the configuration of libcurl (such as setting timeouts) for this invocation.
+        // If neither are present - or are present but corrupted - the failure is ignored.
     void ParseAds();
 
     CURL* _handle{nullptr};

--- a/src/condor_utils/file_transfer.cpp
+++ b/src/condor_utils/file_transfer.cpp
@@ -5337,11 +5337,12 @@ int FileTransfer::InvokeFileTransferPlugin(CondorError &e, const char* source, c
 
 	if (!m_job_ad.empty()) {
 		plugin_env.SetEnv("_CONDOR_JOB_AD", m_job_ad.c_str());
+		dprintf(D_FULLDEBUG, "FILETRANSFER: setting runtime job ad to %s\n", m_job_ad.c_str(), m_machine_ad.c_str());
 	}
 	if (!m_machine_ad.empty()) {
 		plugin_env.SetEnv("_CONDOR_MACHINE_AD", m_machine_ad.c_str());
+		dprintf(D_FULLDEBUG, "FILETRANSFER: setting runtime machine ad to %s\n", m_machine_ad.c_str(), m_machine_ad.c_str());
 	}
-	dprintf(D_FULLDEBUG, "FILETRANSFER: setting runtime ads to %s and %s\n", m_job_ad.c_str(), m_machine_ad.c_str());
 
 	// prepare args for the plugin
 	ArgList plugin_args;
@@ -5444,11 +5445,12 @@ int FileTransfer::InvokeMultipleFileTransferPlugin( CondorError &e,
 	}
 	if (!m_job_ad.empty()) {
 		plugin_env.SetEnv("_CONDOR_JOB_AD", m_job_ad.c_str());
+		dprintf(D_FULLDEBUG, "FILETRANSFER: setting runtime job ad to %s\n", m_job_ad.c_str(), m_machine_ad.c_str());
 	}
 	if (!m_machine_ad.empty()) {
 		plugin_env.SetEnv("_CONDOR_MACHINE_AD", m_machine_ad.c_str());
+		dprintf(D_FULLDEBUG, "FILETRANSFER: setting runtime machine ad to %s\n", m_job_ad.c_str(), m_machine_ad.c_str());
 	}
-	dprintf(D_FULLDEBUG, "FILETRANSFER: setting runtime ads to %s and %s\n", m_job_ad.c_str(), m_machine_ad.c_str());
 
 
 	// Determine if we want to run the plugin with root priv (if available).


### PR DESCRIPTION
This does a few things:
- Simplify the implementation of `ParseAds`.  Objects live on the stack;
  we use smart pointers to manage lifetimes; safe_fopen variants are used.
  More commentary is added about the function's purpose in the header.
- `ParseAds` is invoked next to other libcurl-related setup instead of in
  the constructor.  It still can't fail, but groups logically-like things
  together.
- Tidy up a few dprintf debug statements so they are only printed when the
  corresponding functionality is used.