### PR TITLE
Fix command block formatting

### DIFF
--- a/docs/admin-manual/security.rst
+++ b/docs/admin-manual/security.rst
@@ -1316,6 +1316,7 @@ without a client certificate; configure the collector using a host certificate.
 Using the SSL authentication, the client can request a new authentication token:
 
 ::
+
     # condor_token_request
     Token request enqueued.  Ask an administrator to please approve request 9235785.
 


### PR DESCRIPTION
You can see the bad formatting in the live manual here: https://htcondor.readthedocs.io/en/latest/admin-manual/security.html#token-authentication