### PR TITLE
Ensure lifetime of iterators and returned values. #6721

### DIFF
--- a/src/python-bindings/classad.cpp
+++ b/src/python-bindings/classad.cpp
@@ -19,7 +19,7 @@
 #include "classad_wrapper.h"
 #include "exprtree_wrapper.h"
 #include "old_boost.h"
-
+#include "classad_expr_return_policy.h"
 
 void
 ExprTreeHolder::init()
@@ -1028,6 +1028,11 @@ AttrItemIter ClassAdWrapper::endItems()
     return AttrItemIter(end());
 }
 
+
+boost::python::object ClassAdWrapper::items(boost::shared_ptr<ClassAdWrapper> ad)
+{
+    return boost::python::range<condor::tuple_classad_value_return_policy<boost::python::objects::default_iterator_call_policies>>(&ClassAdWrapper::beginItems, &ClassAdWrapper::endItems)(ad);
+}
 
 ClassAdWrapper::ClassAdWrapper() : classad::ClassAd() {}
 

--- a/src/python-bindings/classad_expr_return_policy.h
+++ b/src/python-bindings/classad_expr_return_policy.h
@@ -59,6 +59,77 @@ struct classad_expr_return_policy : BasePolicy_
     }
 };
 
+//
+// For a given result object, if it is a tuple `t` and `t[1]` potentially
+// contains a reference to a parent ClassAd, then have t[1] hold a reference
+// to the first argument.
+//
+// The use case is the iterator returned by the `ClassAdWrapper::items` method;
+// the iterator, which holds a reference to the ClassAd, must be kept alive for
+// as long as t[1] is alive.  Otherwise, t[1] may be able to reach ClassAd memory
+// that has been garbage collected.
+//
+
+template <class BasePolicy_ = boost::python::default_call_policies>
+struct tuple_classad_value_return_policy : BasePolicy_
+{
+
+    template <class ArgumentPackage>
+    static PyObject* postcall(ArgumentPackage const& args_, PyObject* result)
+    {
+
+            // Grab a pointer to the 'patient', the first argument to this function call (aka, `self`).
+        PyObject* patient = PyTuple_GET_ITEM(args_, 0);
+
+        if (result == 0) return 0;
+
+        result = BasePolicy_::postcall(args_, result);
+        if (result == 0)
+            return 0;
+
+            // Grab a pointer to the 'nurse' that keeps the patient alive; it's assumed that this is
+            // result[1] and that result is a tuple.
+        if (!PyTuple_Check(result))
+            return result;
+
+        PyObject* nurse = PyTuple_GetItem(result, 1);
+        if (!nurse)
+            return 0;
+
+            // Grab the registered PyTypeObject of an ExprTreeHolder.
+        boost::python::type_info info = boost::python::type_id<ExprTreeHolder>();
+        const boost::python::converter::registration* reg = boost::python::converter::registry::query(info);
+        if (!reg) {Py_XDECREF(result); return 0;}
+
+        PyTypeObject* type_obj = reg->get_class_object();
+        if (!type_obj) {Py_XDECREF(result); return 0;}
+
+            // If the nurse is an ExprTreeHolder, tie the lifetime to the patient and return.
+        if (PyObject_TypeCheck(nurse, type_obj) && (boost::python::objects::make_nurse_and_patient(nurse, patient) == 0))
+        {
+            Py_XDECREF(result);
+            return 0;
+        }
+
+            // Repeat the same procedure with the ClassAdWrapper type.
+        info = boost::python::type_id<ClassAdWrapper>();
+        reg = boost::python::converter::registry::query(info);
+        if (!reg) {Py_XDECREF(result); return 0;}
+
+        type_obj = reg->get_class_object();
+        if (!type_obj) {Py_XDECREF(result); return 0;}
+
+        if (PyObject_TypeCheck(nurse, type_obj) && (boost::python::objects::make_nurse_and_patient(nurse, patient) == 0))
+        {
+            Py_XDECREF(result);
+            return 0;
+        }
+
+            // All is good, return the original result.
+        return result;
+    }
+};
+
 
 }
 

--- a/src/python-bindings/classad_module_impl.cpp
+++ b/src/python-bindings/classad_module_impl.cpp
@@ -525,7 +525,7 @@ export_classad()
             R"C0ND0R(
             As :meth:`dict.values`.
             )C0ND0R")
-        .def("items", boost::python::range(&ClassAdWrapper::beginItems, &ClassAdWrapper::endItems),
+        .def("items", &ClassAdWrapper::items, with_custodian_and_ward_postcall<0, 1>(),
             R"C0ND0R(
             As :meth:`dict.items`.
             )C0ND0R")

--- a/src/python-bindings/classad_wrapper.h
+++ b/src/python-bindings/classad_wrapper.h
@@ -86,6 +86,14 @@ struct ClassAdWrapper : classad::ClassAd, boost::python::wrapper<classad::ClassA
 
     AttrItemIter endItems();
 
+        // Returns an iterator that behaves like dict.items in python.  The
+        // iterator will create an additional copy of the shared pointer.  For each
+        // tuple (key, value) produced by invoking __next__() on the iterator,
+        // the value may contain a reference back to the ClassAdWrapper.  This means
+        // that the ClassAdWrapper object will have live references until both the
+        // iterator and all the tuple values are gone.
+    static boost::python::object items(boost::shared_ptr<ClassAdWrapper>);
+
     boost::python::object get(const std::string attr, boost::python::object result=boost::python::object()) const;
 
     boost::python::object setdefault(const std::string attr, boost::python::object result=boost::python::object());


### PR DESCRIPTION
This uses the boost call policies mechanism to ensure that the parent ClassAd both outlives the iterator and any values that the tuples may contain.