### PR TITLE
Add token blacklisting mechanism. #7449

### DIFF
--- a/src/condor_includes/condor_auth_passwd.h
+++ b/src/condor_includes/condor_auth_passwd.h
@@ -44,7 +44,11 @@
 
 class CondorError;
 namespace classad {
+	class ExprTree;
 	class ClassAd;
+}
+namespace jwt {
+	class decoded_jwt;
 }
 
 /** A class to implement the AKEP2 protocol for password-based authentication.
@@ -328,6 +332,10 @@ class Condor_Auth_Passwd : public Condor_Auth_Base {
 	CondorAuthPasswordRetval doServerRec1(CondorError* errstack, bool non_blocking);
 	CondorAuthPasswordRetval doServerRec2(CondorError* errstack, bool non_blocking);
 
+		/** Check to see if a given token is on the blacklist; returns
+		    true if the token is blacklisted. */
+	bool isTokenBlacklisted(const jwt::decoded_jwt &jwt);
+
 	int m_client_status;
 	int m_server_status;
 	int m_ret_value;
@@ -354,6 +362,7 @@ class Condor_Auth_Passwd : public Condor_Auth_Base {
 	std::string m_keyfile_token;
 	std::string m_server_issuer;
 	std::set<std::string> m_server_keys;
+	std::unique_ptr<classad::ExprTree> m_token_blacklist_expr;
 
 	CondorAuthPasswordState m_state;
 

--- a/src/condor_io/condor_auth_passwd.cpp
+++ b/src/condor_io/condor_auth_passwd.cpp
@@ -45,6 +45,8 @@
 #include "subsystem_info.h"
 #include "secure_file.h"
 #include "condor_secman.h"
+#include "compat_classad_util.h"
+#include "classad/exprTree.h"
 
 #include "condor_auth_passwd.h"
 
@@ -395,6 +397,15 @@ Condor_Auth_Passwd :: Condor_Auth_Passwd(ReliSock * sock, int version)
     m_k_prime_len(0),
 	m_state(ServerRec1)
 {
+	if (m_version == 2) {
+		std::string blacklist_param;
+		classad::ExprTree *expr = nullptr;
+		if (param(blacklist_param, "SEC_TOKEN_BLACKLIST_EXPR") &&
+			!ParseClassAdRvalExpr(blacklist_param.c_str(), expr))
+		{
+			m_token_blacklist_expr.reset(expr);
+		}
+	}
 }
 
 Condor_Auth_Passwd :: ~Condor_Auth_Passwd()
@@ -888,6 +899,14 @@ Condor_Auth_Passwd::setup_shared_keys(struct sk_buf *sk, const std::string &init
 					return false;
 				}
 			}
+			if (isTokenBlacklisted(jwt)) {
+				dprintf(D_SECURITY, "User token with payload %s has been blacklisted.\n", jwt.get_payload().c_str());
+				free(ka);
+				free(kb);
+				free(seed_ka);
+				free(seed_kb);
+				return false;
+			}
 
 			const std::string& algo = jwt.get_algorithm();
 			if (algo == "HS256") {
@@ -933,6 +952,56 @@ Condor_Auth_Passwd::setup_shared_keys(struct sk_buf *sk, const std::string &init
 
     return true;
 }
+
+
+bool
+Condor_Auth_Passwd::isTokenBlacklisted(const jwt::decoded_jwt &jwt)
+{
+	if (!m_token_blacklist_expr) {
+		return false;
+	}
+	classad::ClassAd ad;
+	auto claims = jwt.get_payload_claims();
+	for (const auto &pair : claims) {
+		const auto &claim = pair.second;
+		switch (claim.get_type()) {
+		case jwt::claim::type::null:
+			ad.InsertLiteral(pair.first, classad::Literal::MakeUndefined());
+			break;
+		case jwt::claim::type::boolean:
+			ad.InsertAttr(pair.first, pair.second.as_bool());
+			break;
+		case jwt::claim::type::int64:
+			ad.InsertAttr(pair.first, pair.second.as_int());
+			break;
+		case jwt::claim::type::number:
+			ad.InsertAttr(pair.first, pair.second.as_number());
+			break;
+		case jwt::claim::type::string:
+			ad.InsertAttr(pair.first, pair.second.as_string());
+			break;
+		// TODO: these are not currently supported
+		case jwt::claim::type::array: // fallthrough
+		case jwt::claim::type::object: // fallthrough
+		default:
+			break;
+		};
+	}
+
+	classad::EvalState state;
+	state.SetScopes(&ad);
+	classad::Value val;
+	bool blacklisted = true;
+		// Out of an abundance of caution, if we fail to evaluate the
+		// expression or it doesn't evaluate to something boolean-like,
+		// we consider the token potentially suspect.
+	if (!m_token_blacklist_expr->Evaluate(state, val) ||
+		!val.IsBooleanValueEquiv(blacklisted)) {
+		return true;
+	}
+	return blacklisted;
+}
+
 
 void
 Condor_Auth_Passwd::setup_seed(unsigned char *ka, unsigned char *kb) 

--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -2522,6 +2522,12 @@ description=Maximum age of accepted tokens.
 type=int
 tags=condor_auth_passwd
 
+[SEC_TOKEN_BLACKLIST_EXPR]
+default=
+description=Expression describing token blacklist.
+type=string
+tags=condor_auth_passwd
+
 [SEC_ISSUED_TOKEN_EXPIRATION]
 default=
 description=Default max expiration time of issued session tokens.


### PR DESCRIPTION
This allows the admin to set an expression, `SEC_TOKEN_BLACKLIST_EXPR`, which will reject any matching tokens (tokens are converted into ClassAds for the purpose of the blacklist evaluation).