### PR TITLE
Auto-request tokens for condor_master. #7447

### DIFF
--- a/src/condor_daemon_core.V6/daemon_core_main.cpp
+++ b/src/condor_daemon_core.V6/daemon_core_main.cpp
@@ -242,7 +242,7 @@ public:
 		}
 			// Only auto-approve requests that ask for schedds or startds.
 		for (const auto &authz : token_request.getBoundingSet()) {
-			if ((authz != "ADVERTISE_SCHEDD") && (authz != "ADVERTISE_STARTD")) {
+			if ((authz != "ADVERTISE_SCHEDD") && (authz != "ADVERTISE_STARTD") && (authz != "ADVERTISE_MASTER")) {
 				return false;
 			}
 		}

--- a/src/condor_master.V6/master.h
+++ b/src/condor_master.V6/master.h
@@ -250,6 +250,7 @@ private:
 	int m_retry_start_all_daemons_tid;
 	int m_deferred_query_ready_tid;
 	std::list<DeferredQuery*> deferred_queries;
+	DCTokenRequester m_token_requester;
 
 	void ScheduleRetryStartAllDaemons();
 	void CancelRetryStartAllDaemons();
@@ -264,6 +265,8 @@ private:
 	bool StopDaemonsBeforeMasterStops();
 
 	static void ProcdStopped(void*, int pid, int status);
+
+	static void token_request_callback(bool success, void *miscdata);
 };
 
 #endif /* _CONDOR_MASTER_H */

--- a/src/condor_master.V6/masterDaemon.cpp
+++ b/src/condor_master.V6/masterDaemon.cpp
@@ -1855,6 +1855,7 @@ daemon::DeregisterControllee( class daemon *controllee )
 ///////////////////////////////////////////////////////////////////////////
 
 Daemons::Daemons()
+	: m_token_requester(&Daemons::token_request_callback, this)
 {
 	check_new_exec_tid = -1;
 	update_tid = -1;
@@ -3276,7 +3277,8 @@ Daemons::UpdateCollector()
     daemonCore->publish(ad);
     daemonCore->dc_stats.Publish(*ad);
     daemonCore->monitor_data.ExportData(ad);
-	daemonCore->sendUpdates(UPDATE_MASTER_AD, ad, NULL, true);
+	daemonCore->sendUpdates(UPDATE_MASTER_AD, ad, NULL, true, &m_token_requester,
+		DCTokenRequester::default_identity, "ADVERTISE_MASTER");
 
 #if defined(WANT_CONTRIB) && defined(WITH_MANAGEMENT)
 #if defined(HAVE_DLOPEN) || defined(WIN32)
@@ -3338,4 +3340,16 @@ Daemons::CancelRestartTimers( void )
 	for( iter = daemon_ptr.begin(); iter != daemon_ptr.end(); iter++ ) {
 		iter->second->CancelRestartTimers();
 	}
+}
+
+void
+Daemons::token_request_callback(bool success, void *miscdata)
+{
+	auto self = reinterpret_cast<Daemons *>(miscdata);
+		// In the successful case, instantly re-fire the timer
+		// that will send an update to the collector.
+	if (success && (self->update_tid != -1)) {
+		daemonCore->Reset_Timer( self->update_tid, 0,
+		update_interval );
+}
 }


### PR DESCRIPTION
Similar to the startd and schedd logic, this causes the master to automatically request tokens if it cannot authenticate with the collector.  Also allows tokens for `ADVERTISE_MASTER` to be allowed for auto-approval.