### PR TITLE
Fix `-debug` flag and other odds'n'ends for the `condor_token_*` clients. #7448

### DIFF
--- a/src/condor_tools/scitoken_exchange.cpp
+++ b/src/condor_tools/scitoken_exchange.cpp
@@ -31,13 +31,12 @@
 #include "token_utils.h"
 
 void print_usage(const char *argv0) {
-	fprintf(stderr, "Usage: %s [-type TYPE] [-name NAME] [-remote] [-pool POOL] -scitoken FILENAME [-token NAME]\n\n"
+	fprintf(stderr, "Usage: %s [-type TYPE] [-name NAME] [-pool POOL] -scitoken FILENAME [-token NAME]\n\n"
 		"Exchanges a SciToken from a remote daemon and prints its contents to stdout.\n"
 		"\nToken options:\n"
 		"    -scitoken <val>                 File containing SciToken to exchange\n"
 		"Specifying target options:\n"
 		"    -pool    <host>                 Query this collector\n"
-		"    -remote                         Have collector fetch token remotely\n"
 		"    -name    <name>                 Find a daemon with this name\n"
 		"    -type    <subsystem>            Type of daemon to contact (default: SCHEDD)\n"
 		"\nOther options:\n"

--- a/src/condor_tools/token_create.cpp
+++ b/src/condor_tools/token_create.cpp
@@ -19,6 +19,7 @@
 
 #include "condor_common.h"
 #include "condor_config.h"
+#include "condor_distribution.h"
 
 #include "condor_auth_passwd.h"
 #include "match_prefix.h"
@@ -46,6 +47,10 @@ int main(int argc, char *argv[]) {
 	if (argc < 3) {
 		print_usage(argv[0]);
 	}
+
+	myDistro->Init( argc, argv );
+	set_priv_initialize();
+	config();
 
 	std::string pool;
 	std::string name;
@@ -107,8 +112,6 @@ int main(int argc, char *argv[]) {
 			exit(1);
 		}
 	}
-
-	config();
 
 	CondorError err;
 	std::string token;

--- a/src/condor_tools/token_fetch.cpp
+++ b/src/condor_tools/token_fetch.cpp
@@ -19,6 +19,7 @@
 
 #include "condor_common.h"
 #include "condor_config.h"
+#include "condor_distribution.h"
 
 #include "condor_auth_passwd.h"
 #include "match_prefix.h"
@@ -114,6 +115,10 @@ generate_remote_schedd_token(const std::string &pool, const std::string &name,
 
 int main(int argc, char *argv[]) {
 
+	myDistro->Init( argc, argv );
+	set_priv_initialize();
+	config();
+
 	daemon_t dtype = DT_SCHEDD;
 	std::string pool;
 	std::string name;
@@ -189,8 +194,6 @@ int main(int argc, char *argv[]) {
 			exit(1);
 		}
 	}
-
-	config();
 
 	if (remote_fetch && dtype != DT_SCHEDD)
 	{

--- a/src/condor_tools/token_list.cpp
+++ b/src/condor_tools/token_list.cpp
@@ -19,6 +19,7 @@
 
 #include "condor_common.h"
 #include "condor_config.h"
+#include "condor_distribution.h"
 
 #include "match_prefix.h"
 #include "CondorError.h"
@@ -192,6 +193,11 @@ int main(int argc, char *argv[]) {
 	fprintf(stderr, "Cannot list tokens on HTCondor build without OpenSSL\n");
 	return 1;
 #else
+
+	myDistro->Init( argc, argv );
+	set_priv_initialize();
+	config();
+
         for (int i = 1; i < argc; i++) {
 		if(!strcmp(argv[i],"-debug")) {
 			// dprintf to console
@@ -205,8 +211,6 @@ int main(int argc, char *argv[]) {
 			exit(1);
 		}
 	}
-
-	config();
 
 	printAllTokens();
 	return 0;

--- a/src/condor_tools/token_request.cpp
+++ b/src/condor_tools/token_request.cpp
@@ -19,6 +19,7 @@
 
 #include "condor_common.h"
 #include "condor_config.h"
+#include "condor_distribution.h"
 
 #include "condor_auth_passwd.h"
 #include "match_prefix.h"
@@ -107,6 +108,10 @@ request_remote_token(const std::string &pool, const std::string &name, daemon_t 
 
 int main(int argc, char *argv[]) {
 
+	myDistro->Init( argc, argv );
+	set_priv_initialize();
+	config();
+
 	daemon_t dtype = DT_COLLECTOR;
 	std::string pool;
 	std::string name;
@@ -186,8 +191,6 @@ int main(int argc, char *argv[]) {
 			exit(1);
 		}
 	}
-
-	config();
 
 	return request_remote_token(pool, name, dtype, authz_list, lifetime, identity, token_name);
 }

--- a/src/condor_tools/token_request_approve.cpp
+++ b/src/condor_tools/token_request_approve.cpp
@@ -19,6 +19,7 @@
 
 #include "condor_common.h"
 #include "condor_config.h"
+#include "condor_distribution.h"
 
 #include "condor_auth_passwd.h"
 #include "match_prefix.h"
@@ -131,6 +132,10 @@ approve_token(const std::string &pool, const std::string &name, daemon_t dtype,
 
 int main(int argc, char *argv[]) {
 
+	myDistro->Init( argc, argv );
+	set_priv_initialize();
+	config();
+
 	daemon_t dtype = DT_COLLECTOR;
 	std::string pool;
 	std::string name;
@@ -181,8 +186,6 @@ int main(int argc, char *argv[]) {
 			exit(1);
 		}
 	}
-
-	config();
 
 	return approve_token(pool, name, dtype, reqid);
 }

--- a/src/condor_tools/token_request_auto_approve.cpp
+++ b/src/condor_tools/token_request_auto_approve.cpp
@@ -19,6 +19,7 @@
 
 #include "condor_common.h"
 #include "condor_config.h"
+#include "condor_distribution.h"
 
 #include "condor_auth_passwd.h"
 #include "match_prefix.h"
@@ -117,6 +118,10 @@ void printRemainingRequests(std::unique_ptr<Daemon> daemon) {
 
 int main(int argc, char *argv[]) {
 
+	myDistro->Init( argc, argv );
+	set_priv_initialize();
+	config();
+
 	daemon_t dtype = DT_COLLECTOR;
 	std::string pool;
 	std::string name;
@@ -180,8 +185,6 @@ int main(int argc, char *argv[]) {
 			exit(1);
 		}
 	}
-
-	config();
 
 	if (netblock.empty()) {
 		fprintf(stderr, "%s: -netblock argument is required.\n"

--- a/src/condor_tools/token_request_list.cpp
+++ b/src/condor_tools/token_request_list.cpp
@@ -19,6 +19,7 @@
 
 #include "condor_common.h"
 #include "condor_config.h"
+#include "condor_distribution.h"
 
 #include "condor_auth_passwd.h"
 #include "match_prefix.h"
@@ -100,6 +101,10 @@ list_tokens(const std::string &pool, const std::string &name, daemon_t dtype, st
 
 int main(int argc, char *argv[]) {
 
+	myDistro->Init( argc, argv );
+	set_priv_initialize();
+	config();
+
 	daemon_t dtype = DT_COLLECTOR;
 	std::string pool;
 	std::string name;
@@ -143,8 +148,6 @@ int main(int argc, char *argv[]) {
 			exit(1);
 		}
 	}
-
-	config();
 
 	return list_tokens(pool, name, dtype, reqid);
 }

--- a/src/condor_tools/token_request_list.cpp
+++ b/src/condor_tools/token_request_list.cpp
@@ -136,6 +136,13 @@ int main(int argc, char *argv[]) {
 				print_usage(argv[0]);
 				exit(1);
 			}
+		} else if (is_dash_arg_prefix(argv[i], "reqid", 1)) {
+			i++;
+			if (!argv[i]) {
+				fprintf(stderr, "%s: -reqid requires a request ID argument.\n", argv[0]);
+				exit(1);
+			}
+			reqid = argv[i];
 		} else if(!strcmp(argv[i],"-debug")) {
 			// dprintf to console
 			dprintf_set_tool_debug("TOOL", 0);


### PR DESCRIPTION
This fixes the `-debug` flag for `condor_token_*` clients and one incorrect `-help` message.