### PR TITLE
Fix condor_fetchlog with fine-grained auth tokens. #7446

### DIFF
--- a/src/condor_daemon_client/daemon.cpp
+++ b/src/condor_daemon_client/daemon.cpp
@@ -1984,6 +1984,11 @@ Daemon::getInfoFromAd( const ClassAd* ad )
 
 	initStringFromAd( ad, ATTR_PLATFORM, &_platform );
 
+	std::string capability;
+	if (ad->EvaluateAttrString(ATTR_CAPABILITY, capability)) {
+		m_capability = capability;
+	}
+
 	if( initStringFromAd( ad, ATTR_MACHINE, &_full_hostname ) ) {
 		initHostnameFromFull();
 		_tried_init_hostname = false;

--- a/src/condor_daemon_client/daemon.h
+++ b/src/condor_daemon_client/daemon.h
@@ -657,6 +657,12 @@ public:
 	void setAuthenticationMethods(const std::vector<std::string> &methods) {m_methods = methods;}
 	const std::vector<std::string> &getAuthenticationMethods() const {return m_methods;}
 
+		// Returns true if there's a capability found for the remote daemon.
+	bool getCapability(std::string &capability) { if (!m_capability.empty()) {capability = m_capability;} return !m_capability.empty(); }
+
+		// Returns the SecMan object in use by this daemon.
+	SecMan & getSecMan() {return _sec_man;}
+
 protected:
 	// Data members
 	char* _name;
@@ -936,6 +942,9 @@ private:
 	// unless they use DaemonAllowLocateFull::locate().
 
 	ClassAd *m_daemon_ad_ptr;
+
+		// If the locate method found a capability, it is stored here.
+	std::string m_capability;
 
 	std::string m_trust_domain;
 

--- a/src/condor_daemon_core.V6/condor_daemon_core.h
+++ b/src/condor_daemon_core.V6/condor_daemon_core.h
@@ -359,6 +359,20 @@ class DaemonCore : public Service
         @return Not_Yet_Documented
     */
     int Verify (char const *command_descrip, DCpermission perm, const condor_sockaddr& addr, const char * fqu, int log_level=D_ALWAYS);
+
+	/** Given a socket, check to see whether it has a given permission.
+	    This checks:
+	    - the authentication was done with an appropriate settings and methods.
+	    - any permission limits on the authentication (such as used with fine-grained tokens)
+	      are applied correctly.
+	    - the user / IP address has authorization (e.g., applies ALLOW_* / DENY_* from the IpVerify
+	      class).
+
+	    The `command_descrip` is used to generate a useful logging message on an authorization allowed
+	    or denied; log_level controls how "loud" the log message is.
+	 */
+    int Verify (char const *command_descrip, DCpermission perm, const Sock &sock, int log_level=D_ALWAYS);
+
     int AddAllowHost( const char* host, DCpermission perm );
 
     /** clear all sessions associated with the child 

--- a/src/condor_includes/condor_secman.h
+++ b/src/condor_includes/condor_secman.h
@@ -257,6 +257,11 @@ public:
 	static IpVerify *getIpVerify();
 	static int Verify(DCpermission perm, const condor_sockaddr& addr, const char * fqu, MyString *allow_reason=NULL, MyString *deny_reason=NULL );
 
+		// Check to see if the authentication that was performed on the socket
+		// (if any at all!) is sufficient to have the socket authorized at a given
+		// permission level.
+	bool IsAuthenticationSufficient(DCpermission perm, const Sock &sock, CondorError &err);
+
 	static classad::References* getResumeProj() { return &m_resume_proj; };
 
 		// Create a security session from scratch (without doing any

--- a/src/condor_includes/sock.h
+++ b/src/condor_includes/sock.h
@@ -374,7 +374,7 @@ public:
 	void setAuthenticatedName(char const *auth_name);
 	const char *getAuthenticatedName() const;
 
-	bool isAuthorizationInBoundingSet(const std::string &);
+	bool isAuthorizationInBoundingSet(const std::string &) const;
 
 	void setCryptoMethodUsed(char const *crypto_method);
 	const char* getCryptoMethodUsed() const;

--- a/src/condor_io/sock.cpp
+++ b/src/condor_io/sock.cpp
@@ -313,7 +313,7 @@ Sock::getPolicyAd(classad::ClassAd &ad) const
 
 
 bool
-Sock::isAuthorizationInBoundingSet(const std::string &authz)
+Sock::isAuthorizationInBoundingSet(const std::string &authz) const
 {
 		// Cache the bounding set on first access.
 	if (m_authz_bound.empty())
@@ -327,7 +327,7 @@ Sock::isAuthorizationInBoundingSet(const std::string &authz)
 				const char *authz_name;
 				while ( (authz_name = authz_policy_list.next()) ) {
 					if (authz_name[0]) {
-						m_authz_bound.insert(authz_name);
+						const_cast<Sock*>(this)->m_authz_bound.insert(authz_name);
 					}
 				}
 			}
@@ -335,7 +335,7 @@ Sock::isAuthorizationInBoundingSet(const std::string &authz)
 		if (m_authz_bound.empty()) {
 				// Put in a nonsense authz level to prevent re-parsing;
 				// an empty bounding set is interpretted as no bounding set at all.
-			m_authz_bound.insert("ALL_PERMISSIONS");
+			const_cast<Sock*>(this)->m_authz_bound.insert("ALL_PERMISSIONS");
 		}
 	}
 	return (m_authz_bound.find(authz) != m_authz_bound.end()) ||

--- a/src/condor_master.V6/master.cpp
+++ b/src/condor_master.V6/master.cpp
@@ -745,6 +745,12 @@ main_init( int argc, char* argv[] )
 	}
 #endif
 
+		// Determine if we should allow remote administration by the collector
+	bool remote_admin = param_boolean("SEC_ENABLE_REMOTE_ADMINISTRATION", false);
+	daemons.SetRemoteAdmin(remote_admin);
+	if (remote_admin)
+		dprintf(D_ALWAYS, "Remote administration by pool collector is enabled.\n");
+
 	if( StartDaemons ) {
 		daemons.StartAllDaemons();
 	}
@@ -1467,6 +1473,13 @@ main_config()
 	} else {
 		daemons.DaemonsOff();
 	}
+
+		// Determine if we should allow remote administration by the collector
+	bool remote_admin = param_boolean("SEC_ENABLE_REMOTE_ADMINISTRATION", false);
+	daemons.SetRemoteAdmin(remote_admin);
+	if (remote_admin)
+		dprintf(D_ALWAYS, "Remote administration by pool collector is enabled.\n");
+
     // Invalide session if necessary
     daemonCore->invalidateSessionCache();
 		// Re-register our timers, since their intervals might have

--- a/src/condor_master.V6/master.h
+++ b/src/condor_master.V6/master.h
@@ -212,6 +212,7 @@ public:
 	int		DefaultReaper(int, int);
 	void	SetAllReaper(bool fStartdsFirst=false);
 	void	SetDefaultReaper();
+	void    SetRemoteAdmin(bool remote_admin);
 
 	void	AllDaemonsGone();
 	void	SetAllGoneAction( AllGoneT a ) {all_daemons_gone_action=a;};
@@ -250,6 +251,9 @@ private:
 	int m_retry_start_all_daemons_tid;
 	int m_deferred_query_ready_tid;
 	std::list<DeferredQuery*> deferred_queries;
+	bool m_remoteAdmin{false};
+	static unsigned m_master_admin_seq;
+	static time_t m_master_startup;
 
 	void ScheduleRetryStartAllDaemons();
 	void CancelRetryStartAllDaemons();
@@ -259,6 +263,10 @@ private:
 	//bool GetDaemonReadyStates(std::string & ready);
 	int  SendSetPeacefulShutdown(class daemon*, int timeout);
 	void DoPeacefulShutdown(int timeout, void (Daemons::*pfn)(void), const char * lbl);
+
+		// Create a new pre-negotiated security session so the collector admin
+		// can be the administrator of this host.
+	bool SetupAdministratorSession(unsigned duration, std::string &capability);
 
 		// returns true if there are no remaining daemons
 	bool StopDaemonsBeforeMasterStops();

--- a/src/condor_utils/condor_query.cpp
+++ b/src/condor_utils/condor_query.cpp
@@ -382,6 +382,7 @@ CondorQuery::setLocationLookup(const std::string &location, bool want_one_result
 	attrs.push_back(ATTR_ADDRESS_V1);
 	attrs.push_back(ATTR_NAME);
 	attrs.push_back(ATTR_MACHINE);
+	attrs.push_back(ATTR_CAPABILITY);
 	if (queryType == SCHEDD_AD)
 	{
 		attrs.push_back(ATTR_SCHEDD_IP_ADDR);

--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -947,6 +947,12 @@ default=true
 type=bool
 tags=shadow,remoteresource
 
+[SEC_ENABLE_REMOTE_ADMINISTRATION]
+default=false
+type=bool
+tags=master
+usage=Set to true to allow the collector administrator to manage the condor_master
+
 [SEC_ENABLE_IMPERSONATION_TOKENS]
 default=false
 type=bool


### PR DESCRIPTION
Similar to how the schedd sets up an automatic security session with the negotiator, this sets up an automatic security session for remote administration of the `condor_master` (allowing things like `condor_fetchlog` to function).

This way, anyone who has `ADMINISTRATOR` permission for the `condor_collector` can be an `ADMINISTRATOR` of the `condor_master` daemons in the collector, even if there's no way for the administrator to negotiate a new security session with the daemon (for example, if a worker node daemon only has a fine-grained auth token and not the pool password).

I'm a bit nervous about the level of power `ADMINISTRATOR` implies; hence, unlike the corresponding schedd code, this has a separate config knob and is disabled by default.