### PR TITLE
Implicitly add ALLOW permission to tokens. #7456

### DIFF
--- a/src/condor_daemon_core.V6/daemon_command.cpp
+++ b/src/condor_daemon_core.V6/daemon_command.cpp
@@ -1392,14 +1392,16 @@ DaemonCommandProtocol::CommandProtocolResult DaemonCommandProtocol::VerifyComman
 						break;
 					}
 				}
+				bool has_allow_perm = !strcmp(perm_cstr, "ALLOW");
 					// If there was no match, iterate through the alternates table.
 				if (!found_limit && m_comTable[m_cmd_index].alternate_perm) {
 					for (auto perm : *m_comTable[m_cmd_index].alternate_perm) {
 						auto perm_cstr = PermString(perm);
 						const char *authz_name;
 						authz_limits.rewind();
+						has_allow_perm |= !strcmp(perm_cstr, "ALLOW");
 						while ( (authz_name = authz_limits.next()) ) {
-							dprintf(D_ALWAYS, "Checking token limit %s\n", perm_cstr);
+							dprintf(D_SECURITY, "Checking limit in token (%s) for permission %s\n", authz_name, perm_cstr);
 							if (!strcmp(perm_cstr, authz_name)) {
 								found_limit = true;
 								break;
@@ -1408,7 +1410,7 @@ DaemonCommandProtocol::CommandProtocolResult DaemonCommandProtocol::VerifyComman
 						if (found_limit) {break;}
 					}
 				}
-				if (!found_limit && strcmp(perm_cstr, "ALLOW")) {
+				if (!found_limit && !has_allow_perm) {
 					can_attempt = false;
 				}
 			}

--- a/src/condor_io/sock.cpp
+++ b/src/condor_io/sock.cpp
@@ -315,6 +315,11 @@ Sock::getPolicyAd(classad::ClassAd &ad) const
 bool
 Sock::isAuthorizationInBoundingSet(const std::string &authz)
 {
+		// Short-circuit: ALLOW is implicitly in the bounding set.
+	if (authz == "ALLOW") {
+		return true;
+	}
+
 		// Cache the bounding set on first access.
 	if (m_authz_bound.empty())
 	{


### PR DESCRIPTION
The behavior to add ALLOW permissions (introduced in #7006) was not carried over to the alternate permissions approach added in