### PR TITLE
Update introduction-to-configuration.rst

### DIFF
--- a/docs/admin-manual/introduction-to-configuration.rst
+++ b/docs/admin-manual/introduction-to-configuration.rst
@@ -955,8 +955,6 @@ restart of HTCondor in order to use the changed value.
     IP address for this macro; this macro's value may not even be one of
     the IP addresses HTCondor is configured to advertise.
 
-    labelparam:IPv4Address
-
 ``$(IPV4_ADDRESS)`` :index:`IPV4_ADDRESS`
     The ASCII string version of the local machine's "most public" IPv4
     address; unset if the local machine has no IPv4 address.


### PR DESCRIPTION
Extraneous text in pre-defined-macros of IP_ADDRESS