### PR TITLE
Kerberos authentication fails to set remote domain

### DIFF
--- a/src/condor_io/condor_auth_kerberos.cpp
+++ b/src/condor_io/condor_auth_kerberos.cpp
@@ -1298,8 +1298,8 @@ int Condor_Auth_Kerberos :: map_domain_name(const char * domain)
 	if (IsDebugVerbose(D_SECURITY)) {
 		dprintf (D_SECURITY, "KERBEROS: mapping realm %s to domain %s.\n", 
 			domain, domain);
-		setRemoteDomain(domain);
 	}
+	setRemoteDomain(domain);
 	return TRUE;
 
 }


### PR DESCRIPTION
Kerberos authentication fails to set the remote domain unless verbose debugging is on for `D_SECURITY`.

The cause is that the call to `setRemoteDomain()` in `Condor_Auth_Kerberos::map_domain_name()` is _inside_ the condition `if (IsDebugVerbose(D_SECURITY))`.