### PR TITLE
Fix documentation of KERBEROS_SERVER_SERVICE

### DIFF
--- a/docs/admin-manual/configuration-macros.rst
+++ b/docs/admin-manual/configuration-macros.rst
@@ -9160,7 +9160,8 @@ macros are described in the :doc:`/admin-manual/security` section.
 
 :macro-def:`KERBEROS_SERVER_PRINCIPAL`
     An exact Kerberos principal to use. The default value is
-    host/<hostname>@<realm>, as set by the installed Kerberos. Where
+    ``$(KERBEROS_SERVER_SERVICE)/<hostname>@<realm>``, where
+    ``KERBEROS_SERVER_SERVICE`` defaults to ``host``. When
     both ``KERBEROS_SERVER_PRINCIPAL`` and ``KERBEROS_SERVER_SERVICE``
     are defined, this value takes precedence.
 
@@ -9170,12 +9171,10 @@ macros are described in the :doc:`/admin-manual/security` section.
 
 :macro-def:`KERBEROS_SERVER_SERVICE`
     A string representing the Kerberos service name. This string is
-    prepended with a slash character (/) and the host name in order to
-    form the Kerberos server principal. This value defaults to host,
-    resulting in the same default value as specified by using
-    ``KERBEROS_SERVER_PRINCIPAL``. Where both
-    ``KERBEROS_SERVER_PRINCIPAL`` and ``KERBEROS_SERVER_SERVICE`` are
-    defined, the value of ``KERBEROS_SERVER_PRINCIPAL`` takes
+    suffixed with a slash character (/) and the host name in order to
+    form the Kerberos server principal. This value defaults to ``host``.
+    When both ``KERBEROS_SERVER_PRINCIPAL`` and ``KERBEROS_SERVER_SERVICE``
+    are defined, the value of ``KERBEROS_SERVER_PRINCIPAL`` takes
     precedence.
 
 :macro-def:`KERBEROS_CLIENT_KEYTAB`

--- a/docs/admin-manual/security.rst
+++ b/docs/admin-manual/security.rst
@@ -1058,17 +1058,21 @@ the HTCondor UID domain.
 
 The configuration variable ``KERBEROS_SERVER_PRINCIPAL``
 :index:`KERBEROS_SERVER_PRINCIPAL` defines the name of a Kerberos
-principal. If ``KERBEROS_SERVER_PRINCIPAL`` is not defined, then the
-default value used is host. A principal specifies a unique name to which
-a set of credentials may be assigned.
+principal, to override the default ``host/<hostname>@<realm>.
+A principal specifies a unique name to which a set of
+credentials may be assigned.
 
-HTCondor takes the specified (or default) principal and appends a slash
-character, the host name, an '@' (at sign character), and the Kerberos
-realm. As an example, the configuration
+The configuration variable ``KERBEROS_SERVER_SERVICE``
+:index:`KERBEROS_SERVER_SERVICE` defines a Kerberos service to override
+the default ``host``. HTCondor prefixes this to ``/<hostname>@<realm>``
+to obtain the default Kerberos principal.  Configuration variable
+``KERBEROS_SERVER_PRINCIPAL`` overrides ``KERBEROS_SERVER_SERVICE``.
+
+As an example, the configuration
 
 ::
 
-    KERBEROS_SERVER_PRINCIPAL = condor-daemon
+    KERBEROS_SERVER_SERVICE = condor-daemon
 
 results in HTCondor's use of
 


### PR DESCRIPTION
This fixes a mix-up of `KERBEROS_SERVER_PRINCIPAL` and `KERBEROS_SERVER_SERVICE` in the docs.