### PR TITLE
Filter authentication methods when possible

### DIFF
--- a/src/condor_includes/condor_secman.h
+++ b/src/condor_includes/condor_secman.h
@@ -213,9 +213,8 @@ public:
 	static  void			key_printf(int debug_levels, KeyInfo *k);
 
 	static	int 			getAuthBitmask ( const char * methods );
-	static void             getAuthenticationMethods( DCpermission perm, MyString *result );
+	static  std::string		getAuthenticationMethods( DCpermission perm );
 
-	static	MyString 		getDefaultAuthenticationMethods( DCpermission perm );
 	static	MyString 		getDefaultCryptoMethods();
 	static	SecMan::sec_req 		sec_alpha_to_sec_req(char *b);
 	static	SecMan::sec_feat_act 	sec_alpha_to_sec_feat_act(char *b);
@@ -293,6 +292,7 @@ public:
 
  private:
 	void invalidateOneExpiredCache(KeyCache *session_cache);
+	static  std::string		filterAuthenticationMethods(DCpermission perm, const std::string &input_methods);
 
     void                    remove_commands(KeyCacheEntry * keyEntry);
 

--- a/src/condor_io/condor_auth_ssl.cpp
+++ b/src/condor_io/condor_auth_ssl.cpp
@@ -1710,9 +1710,13 @@ Condor_Auth_SSL::should_try_auth()
 
 	std::string certfile, keyfile;
 	if (!param(certfile, AUTH_SSL_SERVER_CERTFILE_STR)) {
+		dprintf(D_SECURITY, "Not trying SSL auth because server certificate"
+			" parameter (%s) is not set.\n", AUTH_SSL_SERVER_CERTFILE_STR);
 		return false;
 	}
 	if (!param(keyfile, AUTH_SSL_SERVER_KEYFILE_STR)) {
+		dprintf(D_SECURITY, "Not trying SSL auth because server key"
+			" parameter (%s) is not set.\n", AUTH_SSL_SERVER_KEYFILE_STR);
 		return false;
 	}
 
@@ -1720,11 +1724,15 @@ Condor_Auth_SSL::should_try_auth()
 		TemporaryPrivSentry sentry(PRIV_ROOT);
 		int fd = open(certfile.c_str(), O_RDONLY);
 		if (fd < 0) {
+			dprintf(D_SECURITY, "Not trying SSL auth because server certificate"
+				" (%s) is not readable by HTCondor: %s.\n", certfile.c_str(), strerror(errno));
 			return false;
 		}
 		close(fd);
 		fd = open(keyfile.c_str(), O_RDONLY);
 		if (fd < 0) {
+			dprintf(D_SECURITY, "Not trying SSL auth because server key"
+				" (%s) is not readable by HTCondor: %s.\n", certfile.c_str(), strerror(errno));
 			return false;
 		}
 		close(fd);

--- a/src/condor_schedd.V6/qmgmt_receivers.cpp
+++ b/src/condor_schedd.V6/qmgmt_receivers.cpp
@@ -71,9 +71,8 @@ do_Q_request(QmgmtPeer &Q_PEER, bool &may_fork)
 		// Authenticate socket, if not already done by daemonCore
 		if( !syscall_sock->triedAuthentication() ) {
 			if( IsDebugLevel(D_SECURITY) ) {
-				MyString methods;
-				SecMan::getAuthenticationMethods( WRITE, &methods );
-				dprintf(D_SECURITY,"Calling authenticate(%s) in qmgmt_receivers\n", methods.Value());
+				auto methods = SecMan::getAuthenticationMethods(WRITE);
+				dprintf(D_SECURITY,"Calling authenticate(%s) in qmgmt_receivers\n", methods.c_str());
 			}
 			CondorError errstack;
 			if( ! SecMan::authenticate_sock(syscall_sock, WRITE, &errstack) ) {


### PR DESCRIPTION
Currently, clients and servers will advertise / request authentication methods that don't exist.

This PR centralizes the code for determining the list of valid authentication methods and ensures that we only send out methods that exist and are compiled in to our version of HTCondor.