### PR TITLE
In condor_prio manpage make ordering more prominent

### DIFF
--- a/docs/man-pages/condor_prio.rst
+++ b/docs/man-pages/condor_prio.rst
@@ -26,11 +26,13 @@ all jobs belonging to that user. For **-a**, *condor_prio* attempts to
 change priority of all jobs in the queue.
 
 The user must set a new priority with the **-p** option, or specify a
-priority adjustment. The priority of a job can be any integer, with
-higher numbers corresponding to greater priority. For adjustment of the
-current priority, *+value* increases the priority by the amount
-given with *value*. *-value* decreases the priority by the amount
-given with *value*.
+priority adjustment.
+
+The priority of a job can be any integer, with higher numbers
+corresponding to greater priority. For adjustment of the current
+priority, *+value* increases the priority by the amount given with
+*value*. *-value* decreases the priority by the amount given with
+*value*.
 
 Only the owner of a job or the super user can change the priority.
 


### PR DESCRIPTION
Add text to to explain the ordering of job priority in the
condor_prio manpage.

Good to have this clear, as it is inverted compared to user priority
and UNIX nice values.