### PR TITLE
Update the RHEL8 Bosco version

### DIFF
--- a/src/condor_contrib/bosco/bosco_findplatform
+++ b/src/condor_contrib/bosco/bosco_findplatform
@@ -30,7 +30,7 @@ URL_DICT={
   DEB10: "https://research.cs.wisc.edu/htcondor/bosco/1.2/bosco-1.2-x86_64_Debian10.tar.gz",
   OSX: "https://research.cs.wisc.edu/htcondor/bosco/1.2/bosco-1.2-x86_64_MacOSX.tar.gz",
   RH7: "https://research.cs.wisc.edu/htcondor/bosco/1.3/bosco-1.3-x86_64_RedHat7.tar.gz",
-  RH8: "https://research.cs.wisc.edu/htcondor/bosco/1.2/bosco-1.2-x86_64_RedHat8.tar.gz",
+  RH8: "https://research.cs.wisc.edu/htcondor/bosco/1.3/bosco-1.3-x86_64_RedHat8.tar.gz",
   UBUNTU16: "https://research.cs.wisc.edu/htcondor/bosco/1.2/bosco-1.2-x86_64_Ubuntu16.tar.gz",
   UBUNTU18: "https://research.cs.wisc.edu/htcondor/bosco/1.2/bosco-1.2-x86_64_Ubuntu18.tar.gz",
 }


### PR DESCRIPTION
Should we do the same for the other operating systems?