### PR TITLE
Fix missing bosco/glite/libexec dir on the remote host

### DIFF
--- a/src/condor_contrib/bosco/bosco_cluster
+++ b/src/condor_contrib/bosco/bosco_cluster
@@ -965,6 +965,9 @@ else
 fi
 rsync -aq  $archive_dir/$libdir/libclassad.so* $remote_glite_dir/lib/ 2>/dev/null
 rsync -aq  $archive_dir/$libdir/libcondor_utils* $remote_glite_dir/lib/ 2>/dev/null
+if [ -d $archive_dir/libexec/glite/libexec ] ; then
+    rsync -aq $archive_dir/libexec/glite/libexec $remote_glite_dir/
+fi
 show_progress "Sending libraries to $remote_host" rsync -aq  $archive_dir/$libdir/condor $remote_glite_dir/lib/ 2>/dev/null
 rsync -aq  $archive_dir/sbin/condor_ft-gahp $remote_glite_dir/bin 2>/dev/null
 


### PR DESCRIPTION
We're carrying this patch in the OSG for 8.8 (https://github.com/opensciencegrid/Software-Redhat/blob/trunk/condor/osg/bosco_https.patch). I imagine that this should be applied to 8.8 as well.