### PR TITLE
condor_starter: Support of CPU affinity with docker

### DIFF
--- a/src/condor_utils/docker-api.h
+++ b/src/condor_utils/docker-api.h
@@ -50,7 +50,8 @@ class DockerAPI {
 						int & pid,
 						int * childFDs,
 						bool & shouldAskForPorts,
-						CondorError & error );
+						CondorError & error,
+						int * affinity_mask = NULL);
 
 		static int startContainer(const std::string &name,
 						int &pid,


### PR DESCRIPTION
If condor admin configured CPU affinity (ASSIGN_CPU_AFFINITY for example), use this CPU affinity
for docker universe jobs running on those slots by using the --cpuset-cpus
option in Docker create cmd API.
Also, made this support mutuale exclusive with the CPU share configuration
(taking into account machineAD number of CPUs), as they should have the same effect.

@shohamd4