### PR TITLE
Do not check for root Owner on client side

### DIFF
--- a/src/condor_includes/condor_qmgr.h
+++ b/src/condor_includes/condor_qmgr.h
@@ -185,7 +185,7 @@ int SetAttributeExprByConstraint(const char *constraint, const char *attr,
 	quotes)
 	@return -1 on failure; 0 on success
 */
-int SetAttribute(int cluster, int proc, const char *attr, const char *value, SetAttributeFlags_t flags=0 );
+int SetAttribute(int cluster, int proc, const char *attr, const char *value, SetAttributeFlags_t flags=0, CondorError *err=nullptr );
 
 /** Set attr = value for job with specified cluster and proc.  The value
 	will be a ClassAd integer literal.

--- a/src/condor_schedd.V6/qmgmt.cpp
+++ b/src/condor_schedd.V6/qmgmt.cpp
@@ -3743,7 +3743,7 @@ SetSecureAttribute(int cluster_id, int proc_id, const char *attr_name, const cha
 
 int
 SetAttribute(int cluster_id, int proc_id, const char *attr_name,
-			 const char *attr_value, SetAttributeFlags_t flags)
+			 const char *attr_value, SetAttributeFlags_t flags, CondorError *err)
 {
 	JOB_ID_KEY_BUF key;
 	JobQueueJob    *job = NULL;
@@ -3752,6 +3752,7 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 
 	// Only an authenticated user or the schedd itself can set an attribute.
 	if ( Q_SOCK && !(Q_SOCK->isAuthenticated()) ) {
+		if (err) err->push("QMGMT", EACCES, "Authentication is required to set attributes");
 		errno = EACCES;
 		return -1;
 	}
@@ -3760,6 +3761,8 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 	// attribute name, bail out early
 	if (!IsValidAttrName(attr_name)) {
 		dprintf(D_ALWAYS, "SetAttribute got invalid attribute named %s for job %d.%d\n", 
+			attr_name ? attr_name : "(null)", cluster_id, proc_id);
+		if (err) err->pushf("QMGMT", EINVAL, "Got invalid attribute named %s for job %d.%d",
 			attr_name ? attr_name : "(null)", cluster_id, proc_id);
 		errno = EINVAL;
 		return -1;
@@ -3771,6 +3774,9 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 		dprintf(D_ALWAYS,
 				"SetAttribute received invalid attribute value '%s' for "
 				"job %d.%d, ignoring\n",
+				attr_value ? attr_value : "(null)", cluster_id, proc_id);
+		if (err) err->pushf("QMGMT", EINVAL, "Received invalid attribute value '%s' for "
+				"job %d.%d; ignoring",
 				attr_value ? attr_value : "(null)", cluster_id, proc_id);
 		errno = EINVAL;
 		return -1;
@@ -3790,6 +3796,8 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 			dprintf(D_ALWAYS,
 				"SetAttribute attempt to edit secure attribute %s in job %d.%d. Failing!\n",
 				attr_name, cluster_id, proc_id);
+			if (err) err->pushf("QMGMT", EACCES, "Attempt to edit secure attribute %s"
+				" in job %d.%d. Failing!", attr_name, cluster_id, proc_id);
 			errno = EACCES;
 			return -1;
 		} else {
@@ -3819,6 +3827,8 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 			dprintf(D_ALWAYS,
 					"OwnerCheck(%s) failed in SetAttribute for job %d.%d\n",
 					owner, cluster_id, proc_id);
+			if (err) err->pushf("QMGMT", EACCES, "User %s may not change attributes for "
+				"jobs they do not own (job %d.%d)", owner, cluster_id, proc_id);
 			errno = EACCES;
 			return -1;
 		}
@@ -3837,6 +3847,8 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 			dprintf(D_ALWAYS,
 					"SetAttribute attempt to edit immutable attribute %s in job %d.%d\n",
 					attr_name, cluster_id, proc_id);
+			if (err) err->pushf("QMGMT", EACCES, "Attempt to edit immutable attribute"
+				" %s in job %d.%d", attr_name, cluster_id, proc_id);
 			errno = EACCES;
 			return -1;
 		}
@@ -3859,6 +3871,14 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 					Q_SOCK->getOwner() ? Q_SOCK->getOwner() : "(null)",
 					Q_SOCK->getAllowProtectedAttrChanges() ? "true" : "false",
 					attr_name, cluster_id, proc_id);
+			if (err) err->pushf("QMGMT", EACCES,
+				"Unauthorized setting of protected attribute %s denied "
+				"for real owner %s (effective owner %s; allowed protected attribute "
+				"change = %s) in job %d.%d", attr_name,
+				Q_SOCK->getRealOwner() ? Q_SOCK->getRealOwner() : "(null)",
+				Q_SOCK->getOwner() ? Q_SOCK->getOwner() : "(null)",
+				Q_SOCK->getAllowProtectedAttrChanges() ? "true" : "false",
+				cluster_id, proc_id);
 			errno = EACCES;
 			return -1;
 		}
@@ -3883,6 +3903,9 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 		if ((cluster_id != active_cluster_num) || (proc_id >= next_proc_num)) {
 			dprintf(D_ALWAYS,"Inserting new attribute %s into non-active cluster cid=%d acid=%d\n", 
 					attr_name, cluster_id,active_cluster_num);
+			if (err) err->pushf("QMGMT", ENOENT, "Inserting new attribute %s into "
+				"a non-active cluster %d (current active cluster is %d)",
+				attr_name, cluster_id, active_cluster_num);
 			errno = ENOENT;
 			return -1;
 		}
@@ -3922,6 +3945,8 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 				// socket not authenticated and Owner is UNDEFINED.
 				dprintf(D_ALWAYS, "ERROR SetAttribute violation: "
 					"Owner is UNDEFINED, but client not authenticated\n");
+				if (err) err->pushf("QMGMT", EACCES, "Client is not authenticated "
+					"and owner is unfedfined");
 				errno = EACCES;
 				return -1;
 
@@ -3950,6 +3975,8 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 			dprintf(D_ALWAYS, "SetAttribute security violation: "
 					"setting owner to %s which is not a valid string\n",
 					attr_value);
+			if (err) err->pushf("QMGMT", EACCES, "Unable to set owner to %s as it is"
+				" not a valid owner string", attr_value);
 			errno = EACCES;
 			return -1;
 		}
@@ -3958,6 +3985,8 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 			// Never allow the owner to be "root" (Linux) or "LOCAL_SYSTEM" (Windows).
 			// Because we run cross-platform, we never allow either name on all platforms
 			dprintf(D_ALWAYS, "SetAttribute security violation: setting owner to %s is not permitted\n", attr_value);
+			if (err) err->pushf("QMGMT", EACCES, "Setting job owner to %s is not "
+				"permitted", attr_value);
 			errno = EACCES;
 			return -1;
 		}
@@ -3973,6 +4002,8 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 			dprintf(D_ALWAYS, "SetAttribute security violation: "
 					"setting owner to %s when previously set to \"%s\"\n",
 					attr_value, orig_owner.Value());
+			if (err) err->pushf("QMGMT", EACCES, "Setting owner to %s when previously "
+				"set to %s is not permitted.", attr_value, orig_owner.Value());
 			errno = EACCES;
 			return -1;
 		}
@@ -3987,6 +4018,9 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 				dprintf(D_ALWAYS, "SetAttribute security violation: "
 					"setting owner to %s when active owner is \"%s\"\n",
 					attr_value, sock_owner);
+				if (err) err->pushf("QMGMT", EACCES, "Setting owner to %s when "
+					"active owner is %s is not permitted",
+					attr_value, sock_owner);
 				errno = EACCES;
 				return -1;
 		}
@@ -3997,6 +4031,8 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 			dprintf( D_ALWAYS, "SetAttribute security violation: "
 					 "setting owner to %s, which is not a valid user account\n",
 					 attr_value );
+			if (err) err->pushf("QMGMT", EACCES, "Setting owner to %s, which is not a "
+				"valid user account", attr_value);
 			errno = EACCES;
 			return -1;
 		}
@@ -4017,7 +4053,7 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 						 &nice_user );
 		user.formatstr( "\"%s%s@%s\"", (nice_user) ? "nice-user." : "",
 				 owner, scheduler.uidDomain() );
-		SetAttribute( cluster_id, proc_id, ATTR_USER, user.Value(), flags );
+		SetAttribute( cluster_id, proc_id, ATTR_USER, user.Value(), flags, nullptr );
 
 			// Also update the owner history hash table
 		AddOwnerHistory(owner);
@@ -4043,7 +4079,7 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 			>= 0 ) {
 			user.formatstr( "\"%s%s@%s\"", (nice_user) ? "nice-user." :
 					 "", owner.Value(), scheduler.uidDomain() );
-			SetAttribute( cluster_id, proc_id, ATTR_USER, user.Value(), flags );
+			SetAttribute( cluster_id, proc_id, ATTR_USER, user.Value(), flags, nullptr );
 		}
 	}
 	else if (attr_id == idATTR_JOB_NOOP) {
@@ -4057,12 +4093,16 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 		if (attr_id == idATTR_CLUSTER_ID && (*endptr != '\0' || id != cluster_id)) {
 			dprintf(D_ALWAYS, "SetAttribute security violation: setting ClusterId to incorrect value (%s!=%d)\n",
 				attr_value, cluster_id);
+			if (err) err->pushf("QMGMT", EACCES, "Setting cluster ID %d to new value "
+				"(%s) is not permitted", cluster_id, attr_value);
 			errno = EACCES;
 			return -1;
 		}
 		if (attr_id == idATTR_PROC_ID && (*endptr != '\0' || id != proc_id)) {
 			dprintf(D_ALWAYS, "SetAttribute security violation: setting ProcId to incorrect value (%s!=%d)\n",
 				attr_value, proc_id);
+			if (err) err->pushf("QMGMT", EACCES, "Setting proc ID %d to new value (%s) "
+				"is not permitted", proc_id, attr_value);
 			errno = EACCES;
 			return -1;
 		}
@@ -4114,6 +4154,8 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 			dprintf( D_ALWAYS, "SetAttribute violation: Attempt to change %s of removed job %d.%d to %d\n",
 					 ATTR_JOB_STATUS, cluster_id, proc_id, new_status );
 			errno = EINVAL;
+			if (err) err->pushf("QMGMT", EINVAL, "Changing %s of removed job %d.%d to "
+				"%d is invalid", ATTR_JOB_STATUS, cluster_id, proc_id, new_status);
 			return -1;
 		}
 		if (query_can_change_only) {
@@ -5010,7 +5052,7 @@ void AddClusterEditedAttributes(std::set<std::string> & ad_keys)
 
 	// add the new values for ATTR_EDITED_CLUSTER_ATTRS to the current transaction.
 	for (auto it = to_add.begin(); it != to_add.end(); ++it) {
-		SetAttribute(it->first.cluster, it->first.proc, ATTR_EDITED_CLUSTER_ATTRS, it->second.c_str(), 0);
+		SetAttribute(it->first.cluster, it->first.proc, ATTR_EDITED_CLUSTER_ATTRS, it->second.c_str(), 0, nullptr);
 	}
 }
 

--- a/src/condor_schedd.V6/qmgmt_receivers.cpp
+++ b/src/condor_schedd.V6/qmgmt_receivers.cpp
@@ -48,6 +48,12 @@ static bool QmgmtMayAccessAttribute( char const *attr_name ) {
 	return !ClassAdAttributeIsPrivate( attr_name );
 }
 
+	// When in NoAck mode for SetAttribute, we don't have any
+	// opportunity to send an error message back to the client;
+	// instead, we'll buffer errors here and send them back to
+	// the client at attempted commit.
+static std::unique_ptr<CondorError> g_transaction_error;
+
 int
 do_Q_request(QmgmtPeer &Q_PEER, bool &may_fork)
 {
@@ -167,6 +173,7 @@ do_Q_request(QmgmtPeer &Q_PEER, bool &may_fork)
 	  {
 		int terrno;
 
+		if (!g_transaction_error) g_transaction_error.reset(new CondorError());
 		assert( syscall_sock->end_of_message() );;
 
 		errno = 0;
@@ -195,6 +202,7 @@ do_Q_request(QmgmtPeer &Q_PEER, bool &may_fork)
 	  {
 		int cluster_id = -1;
 		int terrno;
+		if (!g_transaction_error) g_transaction_error.reset(new CondorError());
 
 		assert( syscall_sock->code(cluster_id) );
 		dprintf( D_SYSCALLS, "	cluster_id = %d\n", cluster_id );
@@ -388,7 +396,15 @@ do_Q_request(QmgmtPeer &Q_PEER, bool &may_fork)
 			return -1;
 		}
 
-
+			// We are unable to send responses in NoAck mode and will always fail
+			// the transaction upon an attempted commit.  Hence, we ignore SetAttribute
+			// calls of this type after the first error.
+		if (g_transaction_error && !g_transaction_error->empty() &&
+			(flags & SetAttribute_NoAck))
+		{
+			dprintf( D_SYSCALLS, "\tIgnored due to previous error\n");
+			return 0;
+		}
 
 		// ckireyev:
 		// We do NOT want to include MyProxy password in the ClassAd (since it's a secret)
@@ -404,7 +420,7 @@ do_Q_request(QmgmtPeer &Q_PEER, bool &may_fork)
 		else {
 			errno = 0;
 
-			rval = SetAttribute( cluster_id, proc_id, attr_name.c_str(), attr_value, flags );
+			rval = SetAttribute( cluster_id, proc_id, attr_name.c_str(), attr_value, flags, g_transaction_error.get() );
 			terrno = errno;
 			dprintf( D_SYSCALLS, "\trval = %d, errno = %d\n", rval, terrno );
 				// If we're modifying a previously-submitted job AND either
@@ -428,7 +444,11 @@ do_Q_request(QmgmtPeer &Q_PEER, bool &may_fork)
 
 		if( flags & SetAttribute_NoAck ) {
 			if( rval < 0 ) {
-				return -1;
+				// Failures are deferred until we try to commit
+				// Unlike SetAttribute with explicit Ack, this is error is going to be
+				// fatal to the transaction.  Hence we'll short circuit any subsequent
+				// SetAttribute_NoAck in this transaction.
+				return 0;
 			}
 		}
 		else {
@@ -584,6 +604,7 @@ do_Q_request(QmgmtPeer &Q_PEER, bool &may_fork)
 	case CONDOR_BeginTransaction:
 	  {
 		int terrno;
+		g_transaction_error.reset(new CondorError());
 
 		assert( syscall_sock->end_of_message() );;
 
@@ -605,6 +626,7 @@ do_Q_request(QmgmtPeer &Q_PEER, bool &may_fork)
 	case CONDOR_AbortTransaction:
 	{
 		int terrno;
+		g_transaction_error.reset();
 
 		assert( syscall_sock->end_of_message() );;
 
@@ -640,10 +662,19 @@ do_Q_request(QmgmtPeer &Q_PEER, bool &may_fork)
 		}
 		assert( syscall_sock->end_of_message() );
 
-		CondorError errstack;
-		errno = 0;
-		rval = CommitTransactionAndLive( flags, & errstack );
-		terrno = errno;
+		std::unique_ptr<CondorError> errstack;
+		if (g_transaction_error && !g_transaction_error->empty()) {
+			errstack = std::move(g_transaction_error);
+			AbortTransaction();
+			terrno = errstack->code();
+			if (terrno == 0) terrno = -1;
+			else if (terrno > 0) terrno = -terrno;
+		} else {
+			errstack.reset(new CondorError());
+			errno = 0;
+			rval = CommitTransactionAndLive( flags, errstack.get() );
+			terrno = errno;
+		}
 		dprintf( D_SYSCALLS, "\tflags = %d, rval = %d, errno = %d\n", flags, rval, terrno );
 
 		syscall_sock->encode();
@@ -658,9 +689,9 @@ do_Q_request(QmgmtPeer &Q_PEER, bool &may_fork)
 			// Send a classad, for less backwards-incompatibility.
 			int code = 1;
 			const char * reason = "QMGMT rejected job submission.";
-			if(! errstack.empty()) {
+			if(! errstack->empty()) {
 				code = 2;
-				reason = errstack.message();
+				reason = errstack->message();
 			}
 
 			ClassAd reply;
@@ -671,8 +702,8 @@ do_Q_request(QmgmtPeer &Q_PEER, bool &may_fork)
 			ClassAd reply;
 
 			std::string reason;
-			if(! errstack.empty()) {
-				reason = errstack.getFullText();
+			if(! errstack->empty()) {
+				reason = errstack->getFullText();
 				reply.Assign( "WarningReason", reason );
 			}
 

--- a/src/condor_schedd.V6/qmgmt_send_stubs.cpp
+++ b/src/condor_schedd.V6/qmgmt_send_stubs.cpp
@@ -405,7 +405,7 @@ SetAttributeByConstraint( char const *constraint, char const *attr_name, char co
 
 
 int
-SetAttribute( int cluster_id, int proc_id, char const *attr_name, char const *attr_value, SetAttributeFlags_t flags_in )
+SetAttribute( int cluster_id, int proc_id, char const *attr_name, char const *attr_value, SetAttributeFlags_t flags_in, CondorError *)
 {
 	int	rval;
 

--- a/src/condor_submit.V6/submit.cpp
+++ b/src/condor_submit.V6/submit.cpp
@@ -546,15 +546,6 @@ main( int argc, const char *argv[] )
 
 	set_mySubSystem( "SUBMIT", SUBSYSTEM_TYPE_SUBMIT );
 
-#if !defined(WIN32)
-		// Make sure root isn't trying to submit.
-	if( getuid() == 0 || getgid() == 0 ) {
-		fprintf( stderr, "\nERROR: Submitting jobs as user/group 0 (root) is not "
-				 "allowed for security reasons.\n" );
-		exit( 1 );
-	}
-#endif /* not WIN32 */
-
 	MyName = condor_basename(argv[0]);
 	myDistro->Init( argc, argv );
 	set_priv_initialize(); // allow uid switching if root


### PR DESCRIPTION
For about 20 years, `condor_submit` has checked to see if it's being invoked as UID 0 or GID 0; if so, it refuses to even try to submit.

This seems to date back to a day where there was a strong correlation between the submitting UID and the `Owner` in HTCondor (arguably the GID check was always wrong...).  That's still a frequent case - but not always a safe assumption for remote submit.

This PR removes this check and relies on the schedd side; there's fundamentally no problem with running the client binary as `root` (but, of course, a problem with the schedd accepting jobs with the `Owner` attribute set to `root`).

In order to reasonably remove the safety check, the schedd must be able to give a reasonable message on failure.  The bulk of the PR is plumbing this through - and converting errors from logfile statements into error messages sent back to the client.  To do this without breaking the protocol (currently, the TCP socket closes abruptly on error), we buffer the error and write the message out as the resulting error message when a commit is attempted.