### PR TITLE
Ensure condor_gpu_discovery reports CoresPerCU for Volta and later GPUs

### DIFF
--- a/src/condor_tools/condor_gpu_discovery.cpp
+++ b/src/condor_tools/condor_gpu_discovery.cpp
@@ -1314,11 +1314,7 @@ main( int argc, const char** argv)
 				if (opt_extra) {
 					props["ClockMhz"] = Format("%.2f", bp.clockRate * 1e-3f);
 					props["ComputeUnits"] = Format("%u", bp.multiProcessorCount);
-					if (bp.ccMajor <= 6) {
-						props["CoresPerCU"] = Format("%u", ConvertSMVer2Cores(bp.ccMajor, bp.ccMinor));
-					} else {
-						// CoresPerCU not meaningful for Architecture 7 and later
-					}
+					props["CoresPerCU"] = Format("%u", ConvertSMVer2Cores(bp.ccMajor, bp.ccMinor));
 				}
 			}
 		} else if (opt_basic && ocl_handle) {


### PR DESCRIPTION
The conditional was originally added before `ConvertSMVer2Cores` contained mappings for Volta and later GPUs (which have since been added). However, even if they hadn't been added, the conditional is probably unnecessary since `ConvertSMVer2Cores` will default to returning the values for the last known generation (which is probably better than omitting the property entirely from `condor_gpu_discovery` output).

Might be worth a separate discussion about how best to alert the user if they are using a newer GPU than that accounted for in `ConvertSMVer2Cores`?