### PR TITLE
First revision of AES-GCM support in CEDAR

### DIFF
--- a/src/condor_daemon_core.V6/daemon_command.cpp
+++ b/src/condor_daemon_core.V6/daemon_command.cpp
@@ -914,7 +914,7 @@ DaemonCommandProtocol::CommandProtocolResult DaemonCommandProtocol::ReadCommand(
 								m_key = new KeyInfo(rbuf, 24, CONDOR_3DES);
 								break;
 							case 'A': // AES-GCM
-								dprintf (D_SECURITY, "DC_AUTHENTICATE: generating AES-GCM key for session %...\n", m_sid);
+								dprintf (D_SECURITY, "DC_AUTHENTICATE: generating AES-GCM key for session %s...\n", m_sid);
 								m_key = new KeyInfo(rbuf, 32, CONDOR_AESGCM);
 							default:
 								dprintf (D_SECURITY, "DC_AUTHENTICATE: generating RANDOM key for session %s...\n", m_sid);

--- a/src/condor_daemon_core.V6/daemon_command.cpp
+++ b/src/condor_daemon_core.V6/daemon_command.cpp
@@ -903,17 +903,17 @@ DaemonCommandProtocol::CommandProtocolResult DaemonCommandProtocol::ReadCommand(
 							return CommandProtocolFinished;
 						}
 
-						switch (toupper(crypto_method[0])) {
-							case 'B': // blowfish
+						Protocol method = SecMan::getCryptProtocolNameToEnum(crypto_method);
+						switch (method) {
+							case CONDOR_BLOWFISH:
 								dprintf (D_SECURITY, "DC_AUTHENTICATE: generating BLOWFISH key for session %s...\n", m_sid);
 								m_key = new KeyInfo(rbuf, 24, CONDOR_BLOWFISH, 0, std::shared_ptr<CryptoState>());
 								break;
-							case '3': // 3des
-							case 'T': // Tripledes
+							case CONDOR_3DES:
 								dprintf (D_SECURITY, "DC_AUTHENTICATE: generating 3DES key for session %s...\n", m_sid);
 								m_key = new KeyInfo(rbuf, 24, CONDOR_3DES, 0, std::shared_ptr<CryptoState>());
 								break;
-							case 'A': // AES-GCM
+							case CONDOR_AESGCM:
 								dprintf (D_SECURITY, "DC_AUTHENTICATE: generating AES-GCM key for session %s...\n", m_sid);
 								m_key = new KeyInfo(rbuf, 32, CONDOR_AESGCM, 0, std::shared_ptr<CryptoState>(new CryptoState()));
 								break;

--- a/src/condor_daemon_core.V6/daemon_command.cpp
+++ b/src/condor_daemon_core.V6/daemon_command.cpp
@@ -906,19 +906,20 @@ DaemonCommandProtocol::CommandProtocolResult DaemonCommandProtocol::ReadCommand(
 						switch (toupper(crypto_method[0])) {
 							case 'B': // blowfish
 								dprintf (D_SECURITY, "DC_AUTHENTICATE: generating BLOWFISH key for session %s...\n", m_sid);
-								m_key = new KeyInfo(rbuf, 24, CONDOR_BLOWFISH);
+								m_key = new KeyInfo(rbuf, 24, CONDOR_BLOWFISH, 0, std::shared_ptr<CryptoState>());
 								break;
 							case '3': // 3des
 							case 'T': // Tripledes
 								dprintf (D_SECURITY, "DC_AUTHENTICATE: generating 3DES key for session %s...\n", m_sid);
-								m_key = new KeyInfo(rbuf, 24, CONDOR_3DES);
+								m_key = new KeyInfo(rbuf, 24, CONDOR_3DES, 0, std::shared_ptr<CryptoState>());
 								break;
 							case 'A': // AES-GCM
 								dprintf (D_SECURITY, "DC_AUTHENTICATE: generating AES-GCM key for session %s...\n", m_sid);
-								m_key = new KeyInfo(rbuf, 32, CONDOR_AESGCM);
+								m_key = new KeyInfo(rbuf, 32, CONDOR_AESGCM, 0, std::shared_ptr<CryptoState>(new CryptoState()));
+								break;
 							default:
 								dprintf (D_SECURITY, "DC_AUTHENTICATE: generating RANDOM key for session %s...\n", m_sid);
-								m_key = new KeyInfo(rbuf, 24);
+								m_key = new KeyInfo(rbuf, 24, CONDOR_NO_PROTOCOL, 0, std::shared_ptr<CryptoState>());
 								break;
 						}
 

--- a/src/condor_daemon_core.V6/daemon_command.cpp
+++ b/src/condor_daemon_core.V6/daemon_command.cpp
@@ -888,14 +888,14 @@ DaemonCommandProtocol::CommandProtocolResult DaemonCommandProtocol::ReadCommand(
 							return CommandProtocolFinished;
 						}
 
-						unsigned char* rkey = Condor_Crypt_Base::randomKey(24);
-						unsigned char  rbuf[24];
+						unsigned char* rkey = Condor_Crypt_Base::randomKey(32);
+						unsigned char  rbuf[32];
 						if (rkey) {
-							memcpy (rbuf, rkey, 24);
+							memcpy (rbuf, rkey, 32);
 							// this was malloced in randomKey
 							free (rkey);
 						} else {
-							memset (rbuf, 0, 24);
+							memset (rbuf, 0, 32);
 							dprintf ( D_ALWAYS, "DC_AUTHENTICATE: unable to generate key for request from %s - no crypto available!\n", m_sock->peer_description() );							
 							free( crypto_method );
 							crypto_method = NULL;
@@ -913,6 +913,9 @@ DaemonCommandProtocol::CommandProtocolResult DaemonCommandProtocol::ReadCommand(
 								dprintf (D_SECURITY, "DC_AUTHENTICATE: generating 3DES key for session %s...\n", m_sid);
 								m_key = new KeyInfo(rbuf, 24, CONDOR_3DES);
 								break;
+							case 'A': // AES-GCM
+								dprintf (D_SECURITY, "DC_AUTHENTICATE: generating AES-GCM key for session %...\n", m_sid);
+								m_key = new KeyInfo(rbuf, 32, CONDOR_AESGCM);
 							default:
 								dprintf (D_SECURITY, "DC_AUTHENTICATE: generating RANDOM key for session %s...\n", m_sid);
 								m_key = new KeyInfo(rbuf, 24);

--- a/src/condor_includes/CryptKey.h
+++ b/src/condor_includes/CryptKey.h
@@ -24,7 +24,8 @@
 enum Protocol {
     CONDOR_NO_PROTOCOL,
     CONDOR_BLOWFISH,
-    CONDOR_3DES
+    CONDOR_3DES,
+    CONDOR_AESGCM
 };
 
 class KeyInfo {

--- a/src/condor_includes/CryptKey.h
+++ b/src/condor_includes/CryptKey.h
@@ -36,8 +36,10 @@ struct CryptoState {
 		// The ctr is added to the last 4 bytes of the IV.
 	union Packed_IV {
 		unsigned char iv[12]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-		uint32_t ctr;
-		uint32_t ctr_conn;
+                struct {
+		    uint32_t pkt;
+		    uint32_t conn;
+                } ctr;
 	};
 
 	uint32_t m_ctr_enc{0}; // Number of outgoing (encrypted) packets
@@ -45,6 +47,8 @@ struct CryptoState {
 	uint32_t m_ctr_conn{0}; // Number of times this session has been used by a connection
 	union Packed_IV m_iv_enc; // IV for outgoing data
 	union Packed_IV m_iv_dec; // IV for incoming data.
+        unsigned char m_prev_mac_enc[16]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        unsigned char m_prev_mac_dec[16]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 };
 
 class KeyInfo {

--- a/src/condor_includes/buffers.h
+++ b/src/condor_includes/buffers.h
@@ -43,6 +43,7 @@ public:
 
 	inline void reset() { _dta_pt = _dta_sz = 0; }
 	inline void rewind() { _dta_pt = 0; }
+	void truncate(int new_sz) {_dta_sz = _dta_pt + new_sz;}
 
 	void alloc_buf();
 	void dealloc_buf();

--- a/src/condor_includes/condor_crypt.h
+++ b/src/condor_includes/condor_crypt.h
@@ -86,6 +86,8 @@ class Condor_Crypt_Base {
                          unsigned char *& output, 
                          int&             output_len) = 0;
 
+    virtual int ciphertext_size(int ciphertext) const {return ciphertext;}
+
  protected:
     static int encryptedSize(int inputLength, int blockSize = 8);
     //------------------------------------------

--- a/src/condor_includes/condor_crypt_aesgcm.h
+++ b/src/condor_includes/condor_crypt_aesgcm.h
@@ -32,15 +32,29 @@ class Condor_Crypt_AESGCM : public Condor_Crypt_Base {
 
     void resetState();
 
-    bool encrypt(const unsigned char * input,
-                 int          input_len, 
-                 unsigned char *&      output, 
-                 int&         output_len);
+    bool encrypt(const unsigned char *,
+                 int                  ,
+                 unsigned char *&     ,
+                 int&                 ) {return false;}
 
-    bool decrypt(const unsigned char * input,
-                 int          input_len, 
-                 unsigned char *&      output, 
-                 int&         output_len);
+    bool decrypt(const unsigned char * ,
+                       int             ,
+                       unsigned char *&,
+                       int&            ) {return false;}
+
+    bool encrypt(const unsigned char * aad_data,
+                 int                   aad_data_len,
+                 const unsigned char * input,
+                 int                   input_len, 
+                 unsigned char *       output, 
+                 int                   output_len);
+
+    bool decrypt(const unsigned char * aad_data,
+                 int                   aad_data_len,
+                 const unsigned char * input,
+                 int                   input_len, 
+                 unsigned char *       output, 
+                 int&                  output_len);
 
     virtual int ciphertext_size(int plaintext) const;
 

--- a/src/condor_includes/condor_crypt_aesgcm.h
+++ b/src/condor_includes/condor_crypt_aesgcm.h
@@ -1,0 +1,51 @@
+/***************************************************************
+ *
+ * Copyright (C) 2020, Condor Team, Computer Sciences Department,
+ * University of Wisconsin-Madison, WI.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+
+#ifndef CONDOR_CRYPTO_AESGCM_H
+#define CONDOR_CRYPTO_AESGCM_H
+
+#include "condor_crypt.h"          // base class
+
+class Condor_Crypt_AESGCM : public Condor_Crypt_Base {
+
+ public:
+    Condor_Crypt_AESGCM(const KeyInfo& key);
+
+    ~Condor_Crypt_AESGCM();
+
+    void resetState();
+
+    bool encrypt(const unsigned char * input,
+                 int          input_len, 
+                 unsigned char *&      output, 
+                 int&         output_len);
+
+    bool decrypt(const unsigned char * input,
+                 int          input_len, 
+                 unsigned char *&      output, 
+                 int&         output_len);
+
+ private:
+    Condor_Crypt_AESGCM();
+
+    uint64_t m_ctr{0};
+};
+
+#endif

--- a/src/condor_includes/condor_crypt_aesgcm.h
+++ b/src/condor_includes/condor_crypt_aesgcm.h
@@ -42,6 +42,8 @@ class Condor_Crypt_AESGCM : public Condor_Crypt_Base {
                  unsigned char *&      output, 
                  int&         output_len);
 
+    virtual int ciphertext_size(int plaintext) const;
+
  private:
     Condor_Crypt_AESGCM();
 

--- a/src/condor_includes/condor_crypt_aesgcm.h
+++ b/src/condor_includes/condor_crypt_aesgcm.h
@@ -61,7 +61,20 @@ class Condor_Crypt_AESGCM : public Condor_Crypt_Base {
  private:
     Condor_Crypt_AESGCM();
 
-    uint64_t m_ctr{0};
+    union Packed_IV {
+       unsigned char iv[12];
+       uint32_t ctr;
+    };
+
+        // The IV is split in two: a 32-bit counter and a
+        // 64-bit random number for a total of 12 bytes.
+        // The ctr is added to the last 4 bytes of the IV.
+    uint32_t m_ctr_enc{0};
+    uint32_t m_ctr_dec{0};
+    union Packed_IV m_iv;
+        // The first packet this object receives will set the
+        // IV here.
+    union Packed_IV m_iv_decrypt;
 };
 
 #endif

--- a/src/condor_includes/condor_crypt_aesgcm.h
+++ b/src/condor_includes/condor_crypt_aesgcm.h
@@ -31,6 +31,7 @@ class Condor_Crypt_AESGCM : public Condor_Crypt_Base {
     ~Condor_Crypt_AESGCM();
 
     void resetState();
+    void resetState(std::shared_ptr<CryptoState>);
 
     bool encrypt(const unsigned char *,
                  int                  ,
@@ -61,20 +62,7 @@ class Condor_Crypt_AESGCM : public Condor_Crypt_Base {
  private:
     Condor_Crypt_AESGCM();
 
-    union Packed_IV {
-       unsigned char iv[12];
-       uint32_t ctr;
-    };
-
-        // The IV is split in two: a 32-bit counter and a
-        // 64-bit random number for a total of 12 bytes.
-        // The ctr is added to the last 4 bytes of the IV.
-    uint32_t m_ctr_enc{0};
-    uint32_t m_ctr_dec{0};
-    union Packed_IV m_iv;
-        // The first packet this object receives will set the
-        // IV here.
-    union Packed_IV m_iv_decrypt;
+    std::shared_ptr<CryptoState> m_state;
 };
 
 #endif

--- a/src/condor_includes/condor_secman.h
+++ b/src/condor_includes/condor_secman.h
@@ -290,6 +290,9 @@ public:
 		// session, the lingering session will simply be replaced.
 	bool SetSessionLingerFlag(char const *session_id);
 
+		// Given a list of crypto methods, return the first valid protocol name.
+	static Protocol getCryptProtocolNameToEnum(char const *name);
+
  private:
 	void invalidateOneExpiredCache(KeyCache *session_cache);
 	static  std::string		filterAuthenticationMethods(DCpermission perm, const std::string &input_methods);

--- a/src/condor_includes/reli_sock.h
+++ b/src/condor_includes/reli_sock.h
@@ -297,6 +297,7 @@ protected:
 
         virtual bool init_MD(CONDOR_MD_MODE mode, KeyInfo * key, const char * keyId);
         virtual bool set_encryption_id(const char * keyId);
+	Condor_Crypt_Base *get_crypto() {return crypto_;}
 
 	/*
 	**	Types
@@ -326,6 +327,7 @@ protected:
 		ReliSock      * p_sock; //preserve parent pointer to use for condor_read/write
 		bool		m_partial_packet; // A partial packet is stored.
 		size_t		m_remaining_read_length; // Length remaining on a partial packet
+		size_t		m_len_t; // Network-encoded length of packet (used to reconstruct header).
 		int		m_end; // The end status of the partial packet.
 		Buf		*m_tmp;
 	public:

--- a/src/condor_includes/sock.h
+++ b/src/condor_includes/sock.h
@@ -233,6 +233,8 @@ public:
         // Encryption support below
         //------------------------------------------
         bool set_crypto_key(bool enable, KeyInfo * key, const char * keyId=0);
+
+	int ciphertext_size(int cipher_size) {return crypto_ ? crypto_->ciphertext_size(cipher_size) : cipher_size;}
         //------------------------------------------
         // PURPOSE: set sock to use a particular encryption key
         // REQUIRE: KeyInfo -- a wrapper for keyData

--- a/src/condor_includes/stream.h
+++ b/src/condor_includes/stream.h
@@ -529,6 +529,8 @@ public:
         // RETURNS: true -- on, false -- off
         //------------------------------------------
 
+	int ciphertext_size(int plaintext_size) const {return plaintext_size;};
+
 	bool set_crypto_mode(bool enable);
         //------------------------------------------
         // PURPOSE: enable or disable encryption

--- a/src/condor_io/CMakeLists.txt
+++ b/src/condor_io/CMakeLists.txt
@@ -33,6 +33,7 @@ ${CMAKE_CURRENT_SOURCE_DIR}/condor_auth_sspi.cpp
 ${CMAKE_CURRENT_SOURCE_DIR}/condor_auth_x509.cpp
 ${CMAKE_CURRENT_SOURCE_DIR}/condor_crypt_3des.cpp
 ${CMAKE_CURRENT_SOURCE_DIR}/condor_crypt_blowfish.cpp
+${CMAKE_CURRENT_SOURCE_DIR}/condor_crypt_aesgcm.cpp
 ${CMAKE_CURRENT_SOURCE_DIR}/condor_crypt.cpp
 ${CMAKE_CURRENT_SOURCE_DIR}/condor_ipverify.cpp
 ${CMAKE_CURRENT_SOURCE_DIR}/condor_rw.cpp

--- a/src/condor_io/CryptKey.cpp
+++ b/src/condor_io/CryptKey.cpp
@@ -35,7 +35,8 @@ KeyInfo :: KeyInfo(const KeyInfo& copy)
     : keyData_    ( 0 ),
       keyDataLen_ (copy.keyDataLen_),
       protocol_   (copy.protocol_),
-      duration_   (copy.duration_)
+      duration_   (copy.duration_),
+      state_      (copy.state_)
 {
     init(copy.keyData_, copy.keyDataLen_);
 }
@@ -43,12 +44,14 @@ KeyInfo :: KeyInfo(const KeyInfo& copy)
 KeyInfo :: KeyInfo(const unsigned char * keyData,
                    int             keyDataLen,
                    Protocol        protocol,
-                   int             duration )
+                   int             duration,
+                   std::shared_ptr<CryptoState> state )
     : 
       keyData_    (0),
       keyDataLen_ (keyDataLen),
 	  protocol_   (protocol),
-      duration_   (duration)
+      duration_   (duration),
+      state_      (state)
 {
     init(keyData, keyDataLen);
 }
@@ -64,6 +67,7 @@ KeyInfo& KeyInfo :: operator=(const KeyInfo& copy)
 		keyDataLen_ = copy.keyDataLen_;
 		protocol_   = copy.protocol_;
 		duration_   = copy.duration_;
+		state_      = copy.state_;
 
 		init(copy.keyData_, copy.keyDataLen_);
 	}

--- a/src/condor_io/authentication.cpp
+++ b/src/condor_io/authentication.cpp
@@ -981,7 +981,13 @@ int Authentication::exchangeKey(KeyInfo *& key)
             // Now, unwrap it.  
             if ( authenticator_ && authenticator_->unwrap(encryptedKey,  inputLen, decryptedKey, outputLen) ) {
 					// Success
-				key = new KeyInfo((unsigned char *)decryptedKey, keyLength,(Protocol) protocol,duration);
+				if (protocol == CONDOR_AESGCM) {
+					key = new KeyInfo((unsigned char *)decryptedKey, keyLength,
+						(Protocol) protocol, duration,
+						std::shared_ptr<CryptoState>(new CryptoState()));
+				} else {
+					key = new KeyInfo((unsigned char *)decryptedKey, keyLength,(Protocol) protocol,duration, std::shared_ptr<CryptoState>());
+				}
 			} else {
 					// Failure!
 				retval = 0;

--- a/src/condor_io/buffers.cpp
+++ b/src/condor_io/buffers.cpp
@@ -43,16 +43,21 @@ sanity_check()
 Buf::Buf(
 	int	sz
 	)
+	: _dta{nullptr},
+	_dta_sz{0},
+	_dta_maxsz{sz},
+	_dta_pt{0},
+	_next{nullptr},
+	p_sock{nullptr}
 {
-	_dta = NULL;
-	_dta_maxsz = sz;
-	_dta_sz = 0;
-	_dta_pt = 0;
-	_next = NULL;
 	num_created++;
-	p_sock = NULL;
 }
 
+Buf::Buf(Sock *sock, int sz) :
+    Buf(sz)
+{
+	p_sock = sock;
+}
 
 Buf::~Buf()
 {

--- a/src/condor_io/condor_auth_munge.cpp
+++ b/src/condor_io/condor_auth_munge.cpp
@@ -257,7 +257,7 @@ Condor_Auth_MUNGE::setupCrypto(const unsigned char* key, const int keylen)
 	}
 
 	// This could be 3des -- maybe we should use "best crypto" indirection.
-	KeyInfo thekey(key,keylen,CONDOR_3DES);
+	KeyInfo thekey(key, keylen, CONDOR_3DES, 0, std::shared_ptr<CryptoState>());
 	m_crypto = new Condor_Crypt_3des(thekey);
 	return m_crypto ? true : false;
 }

--- a/src/condor_io/condor_auth_passwd.cpp
+++ b/src/condor_io/condor_auth_passwd.cpp
@@ -697,7 +697,7 @@ Condor_Auth_Passwd::setupCrypto(const unsigned char* key, const int keylen)
 	}
 
 		// This could be 3des -- maybe we should use "best crypto" indirection.
-	KeyInfo thekey(key,keylen,CONDOR_3DES);
+	KeyInfo thekey(key, keylen, CONDOR_3DES, 0, std::shared_ptr<CryptoState>());
 	m_crypto = new Condor_Crypt_3des(thekey);
 	return m_crypto ? true : false;
 }
@@ -2773,7 +2773,7 @@ Condor_Auth_Passwd::set_session_key(struct msg_t_buf *t_buf, struct sk_buf *sk)
 
 	dprintf(D_SECURITY, "Key length: %d\n", key_len);
 		// Fill the key structure.
-	KeyInfo thekey(key,(int)key_len,CONDOR_3DES);
+	KeyInfo thekey(key, (int)key_len, CONDOR_3DES, 0, std::shared_ptr<CryptoState>());
 	m_crypto = new Condor_Crypt_3des(thekey);
 
 	if ( key ) free(key);	// KeyInfo makes a copy of the key

--- a/src/condor_io/condor_auth_ssl.cpp
+++ b/src/condor_io/condor_auth_ssl.cpp
@@ -1105,7 +1105,7 @@ Condor_Auth_SSL::setup_crypto(unsigned char* key, const int keylen)
 	}
 
 		// This could be 3des -- maybe we should use "best crypto" indirection.
-	KeyInfo thekey(key,keylen,CONDOR_3DES);
+	KeyInfo thekey(key, keylen, CONDOR_3DES, 0, std::shared_ptr<CryptoState>());
 	m_crypto = new Condor_Crypt_3des(thekey);
 	return m_crypto ? true : false;
 }

--- a/src/condor_io/condor_crypt_aesgcm.cpp
+++ b/src/condor_io/condor_crypt_aesgcm.cpp
@@ -239,7 +239,6 @@ bool Condor_Crypt_AESGCM::decrypt(const unsigned char *  aad,
                                   unsigned char *        output, 
                                   int&                   output_len)
 {
-    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt with payload %d.\n", input_len);
     EVP_CIPHER_CTX *ctx;
 
     dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt with input buffer %d.\n", input_len);
@@ -320,7 +319,9 @@ bool Condor_Crypt_AESGCM::decrypt(const unsigned char *  aad,
         return false;
     }
 
-    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt about to init key %0x %0x %0x %0x.\n", *(get_key().getKeyData()), *(get_key().getKeyData() + 15), *(get_key().getKeyData() + 16), *(get_key().getKeyData() + 31));
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt about to init key %0x %0x %0x %0x.\n",
+        *(get_key().getKeyData()), *(get_key().getKeyData() + 15),
+        *(get_key().getKeyData() + 16), *(get_key().getKeyData() + 31));
 
     char hex[3 * IV_SIZE + 1];
     dprintf(D_ALWAYS,"IO: Incoming IV : %s\n",

--- a/src/condor_io/condor_crypt_aesgcm.cpp
+++ b/src/condor_io/condor_crypt_aesgcm.cpp
@@ -19,6 +19,7 @@
 
 
 #include "condor_common.h"
+#include "condor_debug.h"
 #include "condor_crypt_aesgcm.h"
 
 #include <openssl/evp.h>
@@ -38,43 +39,63 @@ void Condor_Crypt_AESGCM::resetState()
 {
 }
 
+int Condor_Crypt_AESGCM::ciphertext_size(int plaintext_size) const
+{
+    int ct_sz;
+    if (plaintext_size % 16)
+        ct_sz = ((plaintext_size >> 4) + 1) << 4;
+    else
+        ct_sz = plaintext_size;
+    // Authentication tag is an additional 16 bytes; IV is 8 bytes; padding size is 1 byte
+    ct_sz += 16 + 8 + 1;
+    return ct_sz;
+}
+
 bool Condor_Crypt_AESGCM::encrypt(const unsigned char *  input,
                                   int              input_len, 
                                   unsigned char *& output, 
                                   int&             output_len)
 {
-        // Encryption size is at most 4 bytes long.
-    if (input_len > (1 << 24)) {
-        return false;
-    }
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::encrypt\n");
 
         // output length must be aligned to nearest 128-bit block for AES-GCM
     if (input_len % 16)
-        output_len = ((input_len >> 3) + 1) << 3;
+        output_len = ((input_len >> 4) + 1) << 4;
     else
         output_len = input_len;
+    if ((output_len - input_len < 0) || (output_len - input_len >= 16)) {
+        dprintf(D_NETWORK, "Failed to calculate output size.\n");
+        return false;
+    }
+    char padding_bytes = output_len - input_len;
+
         // Authentication tag is an additional 16 bytes; IV is 8 bytes; padding size is 1 byte
     output_len += 16 + 8 + 1;
 
     output = (unsigned char *) malloc(output_len);
-    if (!output)
+    if (!output) {
+        dprintf(D_NETWORK, "Failed to allocate encryption buffer.\n");
         return false;
+    }
 
-    if ((output_len - input_len < 0) || (output_len - input_len >= 16))
-        return false;
-
-    char padding_bytes = output_len - input_len;
+    dprintf(D_NETWORK, "Padding bytes: %d; input length %d\n", padding_bytes, input_len);
     output[0] = padding_bytes;
 
     EVP_CIPHER_CTX *ctx;
-    if (!(ctx = EVP_CIPHER_CTX_new()))
+    if (!(ctx = EVP_CIPHER_CTX_new())) {
+        dprintf(D_NETWORK, "Failed to allocate new EVP method.\n");
         return false;
+    }
 
-    if (1 != EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL))
+    if (1 != EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL)) {
+        dprintf(D_NETWORK, "Failed to create AES-GCM-256 mode.\n");
         return false;
+    }
 
-    if (1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, 8, NULL))
+    if (1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, 8, NULL)) {
+        dprintf(D_NETWORK, "Failed to set IV length.\n");
         return false;
+    }
 
     // TODO: Increase the IV size to also include a timestamp.  If the
     // session key is reused, currently the IV may be reused, resulting in
@@ -88,31 +109,57 @@ bool Condor_Crypt_AESGCM::encrypt(const unsigned char *  input,
     m_ctr++;
     unsigned char iv[8];
     memcpy(iv, &ctr_enc, 8);
+    dprintf(D_NETWORK, "IV value %lu\n", ctr_enc);
+    dprintf(D_NETWORK, "IV value not encoded %lu\n", m_ctr);
 
     memcpy(output + 1, iv, 8);
 
-    if (get_key().getProtocol() != CONDOR_AESGCM)
+    if (get_key().getProtocol() != CONDOR_AESGCM) {
+        dprintf(D_NETWORK, "Failed to have correct AES-GCM key type.\n");
         return false;
+    }
+    dprintf(D_NETWORK, "Key length %d\n", get_key().getKeyLength());
 
-    if (1 != EVP_EncryptInit_ex(ctx, NULL, NULL, get_key().getKeyData(), iv))
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::encrypt about to init key %0x %0x %0x %0x.\n", *(get_key().getKeyData()), *(get_key().getKeyData() + 15), *(get_key().getKeyData() + 16), *(get_key().getKeyData() + 31));
+    if (1 != EVP_EncryptInit_ex(ctx, NULL, NULL, get_key().getKeyData(), iv)) {
+        dprintf(D_NETWORK, "Failed to initialize key and IV.\n");
         return false;
+    }
 
     // Ensure that the length of the decrypted buffer is authenticated.
     int len;
-    if (1 != EVP_EncryptUpdate(ctx, NULL, &len, output, 1))
+    dprintf(D_NETWORK, "Padding value is %c\n", *output);
+    if (1 != EVP_EncryptUpdate(ctx, NULL, &len, output, 1)) {
+        dprintf(D_NETWORK, "Failed to authenticate length of padding.\n");
         return false;
+    }
 
-    if (1 != EVP_EncryptUpdate(ctx, output+9, &len, input, input_len))
+    dprintf(D_NETWORK, "First byte of plaintext is %0x\n", *input);
+    if (1 != EVP_EncryptUpdate(ctx, output+9, &len, input, input_len)) {
+        dprintf(D_NETWORK, "Failed to encrypt plaintext buffer.\n");
         return false;
+    }
+    dprintf(D_NETWORK, "First %d bytes written to ciphertext.\n", len);
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::encrypt Cipher text: %0x %0x %0x %0x\n", *(output + 1 + 8), *(output + 1 + 8 + 1), *(output + 1 + 8 + 2), *(output + 1 + 8 + 3));
 
     int len2;
-    if (1 != EVP_EncryptFinal_ex(ctx, output + 9 + len, &len2))
+    if (1 != EVP_EncryptFinal_ex(ctx, output + 9 + len, &len2)) {
+        dprintf(D_NETWORK, "Failed to finalize cipher text.\n");
         return false;
+    }
+    dprintf(D_NETWORK, "Finalized an additional %d bytes written to ciphertext.\n", len2);
     len += len2;
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::encrypt Cipher text: %0x %0x %0x %0x\n", *(output + 1 + 8), *(output + 1 + 8 + 1), *(output + 1 + 8 + 2), *(output + 1 + 8 + 3));
 
-    if (1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, 16, output + 9 + len))
+    if (1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, 16, output + output_len - 16)) {
+        dprintf(D_NETWORK, "Failed to get tag.\n");
         return false;
+    }
+    dprintf(D_NETWORK, "First two tag values are %0x, %0x starting at %d\n", *(output + output_len - 16), *(output + output_len - 15), output_len - 9);
+    memcpy(&ctr_enc, output + 1, 8);
+    dprintf(D_NETWORK, "IV value %lu\n", ctr_enc);
 
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::encrypt.  Successful encryption with cipher text %d bytes.\n", output_len);
     return true;
 }
 
@@ -121,51 +168,85 @@ bool Condor_Crypt_AESGCM::decrypt(const unsigned char *  input,
                                   unsigned char *&       output, 
                                   int&                   output_len)
 {
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt with payload %d.\n", input_len);
+    output_len = 0;
     EVP_CIPHER_CTX *ctx;
 
-    if (!(ctx = EVP_CIPHER_CTX_new()))
-        return false;
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt with input buffer %d.\n", input_len);
 
-    if (!EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL))
+    if (!(ctx = EVP_CIPHER_CTX_new())) {
+        dprintf(D_NETWORK, "Failed to initialize EVP object.\n");
         return false;
+    }
 
-    if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, 8, NULL))
+    if (!EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL)) {
+        dprintf(D_NETWORK, "Failed to initialize AES-GCM-256 mode.\n");
         return false;
+    }
 
-    if (get_key().getProtocol() != CONDOR_AESGCM)
+    if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, 8, NULL)) {
+        dprintf(D_NETWORK, "Failed to initialize IV length to 8.\n");
         return false;
+    }
+
+    if (get_key().getProtocol() != CONDOR_AESGCM) {
+        dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt failed due to the wrong protocol.\n");
+        return false;
+    }
+    dprintf(D_NETWORK, "Key length %d\n", get_key().getKeyLength());
 
         // TODO: for a ReliSock, we should enforce an ordering
     uint64_t ctr_enc;
     memcpy(&ctr_enc, input + 1, 8);
+    dprintf(D_NETWORK, "IV value %lu\n", ctr_enc);
 #if __BYTE_ORDER == __BIG_ENDIAN
     m_ctr = ctr_enc;
 #else
-    m_ctr = (((uint64_t)ntohl(static_cast<uint32_t>(ctr_enc)) << 32) + htonl(ctr_enc >> 32);
+    m_ctr = ((uint64_t)ntohl(static_cast<uint32_t>(ctr_enc)) << 32) + htonl(ctr_enc >> 32);
 #endif
+    dprintf(D_NETWORK, "IV value unencoded %lu\n", m_ctr);
 
-    if (!EVP_DecryptInit_ex(ctx, NULL, NULL, get_key().getKeyData(), input + 1))
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt about to init key %0x %0x %0x %0x.\n", *(get_key().getKeyData()), *(get_key().getKeyData() + 15), *(get_key().getKeyData() + 16), *(get_key().getKeyData() + 31));
+    if (!EVP_DecryptInit_ex(ctx, NULL, NULL, get_key().getKeyData(), input + 1)) {
+        dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt failed due to failed init.\n");
         return false;
+    }
 
     int len;
-    if (!EVP_DecryptUpdate(ctx, NULL, &len, input, 1))
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt about to decrypt AAD %c.\n", *input);
+    if (!EVP_DecryptUpdate(ctx, NULL, &len, input, 1)) {
+        dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt failed due to failed AAD update.\n");
         return false;
+    }
 
         // output is at most input_len.
     output = static_cast<unsigned char *>(malloc(input_len));
 
         // Padding bytes + IV + tag = 1 + 8 + 16
-    if (!EVP_DecryptUpdate(ctx, output, &len, input + 1 + 8, input_len - 1 - 8 - 16))
-        return false;
-
-    if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, 16, const_cast<unsigned char *>(input + input_len - 16)))
-        return false;
-
-    if (!EVP_DecryptFinal_ex(ctx, output + len, &len))
-       return false;
-
     char padding = input[0];
-    output_len = input_len - padding;
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt about to decrypt cipher text.  Input length is %d\n", input_len - 1 - 8 - 16 - padding);
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt Cipher text: %0x %0x %0x %0x\n", *(input + 1 + 8), *(input + 1 + 8 + 1), *(input + 1 + 8 + 2), *(input + 1 + 8 + 3));
+    if (!EVP_DecryptUpdate(ctx, output, &len, input + 1 + 8, input_len - 1 - 8 - 16 - padding)) {
+        dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt failed due to failed cipher text update.\n");
+        return false;
+    }
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt produced output of size %d with value %0x\n", len, *output);
 
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt about to set tag %0x,%0x.\n", *(input + input_len - 16), *(input + input_len - 15));
+    if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, 16, const_cast<unsigned char *>(input + input_len - 16))) {
+        dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt failed due to failed set of tag.\n");
+        return false;
+    }
+
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt about to finalize output.\n");
+    if (!EVP_DecryptFinal_ex(ctx, output + len, &len)) {
+        dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt failed due to finalize decryption and check of tag.\n");
+       return false;
+    }
+
+    dprintf(D_NETWORK, "decrypt; input_len is %d and output_len is %d\n", input_len, input_len - padding - 1 - 8 - 16);
+    output_len = input_len - padding - 1 - 8 - 16;
+
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt.  Successful decryption with plain text %d bytes.\n", output_len);
     return true;
 }

--- a/src/condor_io/condor_crypt_aesgcm.cpp
+++ b/src/condor_io/condor_crypt_aesgcm.cpp
@@ -2,13 +2,13 @@
  *
  * Copyright (C) 1990-2007, Condor Team, Computer Sciences Department,
  * University of Wisconsin-Madison, WI.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,24 +23,34 @@
 #include "condor_crypt_aesgcm.h"
 
 #include <openssl/evp.h>
+#include <openssl/rand.h>
 
-#define IV_SIZE 8
+#define IV_SIZE 12
 #define PADDING_SIZE 1
 #define MAC_SIZE 16
+
+unsigned char g_unset_iv[IV_SIZE] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
 Condor_Crypt_AESGCM::Condor_Crypt_AESGCM(const KeyInfo& key)
     : Condor_Crypt_Base(CONDOR_AESGCM, key)
 {
+	resetState();
 }
 
 Condor_Crypt_AESGCM::~Condor_Crypt_AESGCM()
 {
 }
 
-	// IMPORTANT: we never actually reset the state as AES-GCM
-	// IVs may not be reused.
 void Condor_Crypt_AESGCM::resetState()
 {
+	dprintf(D_NETWORK, "Condor_Crypt_AESGCM::resetState\n");
+	m_ctr_dec = 0;
+	m_ctr_enc = 0;
+	memset(m_iv.iv, '\0', IV_SIZE);
+	while (!memcmp(m_iv.iv, g_unset_iv, IV_SIZE)) {
+		RAND_pseudo_bytes(m_iv.iv, IV_SIZE);
+	}
+	memset(m_iv_decrypt.iv, '\0', IV_SIZE);
 }
 
 int Condor_Crypt_AESGCM::ciphertext_size(int plaintext_size) const
@@ -50,7 +60,7 @@ int Condor_Crypt_AESGCM::ciphertext_size(int plaintext_size) const
         ct_sz = ((plaintext_size >> 4) + 1) << 4;
     else
         ct_sz = plaintext_size;
-    // Authentication tag is an additional 16 bytes; IV is 8 bytes; padding size is 1 byte
+    // Authentication tag is an additional 16 bytes; IV is 12 bytes; padding size is 1 byte
     ct_sz += MAC_SIZE + IV_SIZE + PADDING_SIZE;
     return ct_sz;
 }
@@ -84,7 +94,7 @@ bool Condor_Crypt_AESGCM::encrypt(const unsigned char *aad,
         return false;
     }
 
-        // Authentication tag is an additional 16 bytes; IV is 8 bytes; padding size is 1 byte
+        // Authentication tag is an additional 16 bytes; IV is 12 bytes; padding size is 1 byte
     output_len += MAC_SIZE + IV_SIZE + PADDING_SIZE;
 
     dprintf(D_NETWORK, "Padding bytes: %d; input length %d\n", padding_bytes, input_len);
@@ -109,19 +119,26 @@ bool Condor_Crypt_AESGCM::encrypt(const unsigned char *aad,
     // TODO: Increase the IV size to also include a timestamp.  If the
     // session key is reused, currently the IV may be reused, resulting in
     // a complete defeat of the encryption.
-    uint64_t ctr_enc;
-#if __BYTE_ORDER == __BIG_ENDIAN
-    ctr_enc = m_ctr; 
-#else
-    ctr_enc = (((uint64_t)htonl(m_ctr)) << 32) + htonl(m_ctr >> 32);
-#endif
-    m_ctr++;
+    int32_t base = ntohl(m_iv.ctr);
+    int32_t result = base + *reinterpret_cast<int32_t*>(&m_ctr_enc);
+    int32_t ctr_enc = htonl(result);
+    if (m_ctr_enc == 0xffffffff) {
+        dprintf(D_NETWORK, "Hit max number of packets per connection.\n");
+        return false;
+    }
+    m_ctr_enc++;
     unsigned char iv[IV_SIZE];
-    memcpy(iv, &ctr_enc, IV_SIZE);
-    dprintf(D_NETWORK, "IV value %lu\n", ctr_enc);
-    dprintf(D_NETWORK, "IV value not encoded %lu\n", m_ctr-1);
+    memcpy(iv, &ctr_enc, sizeof(ctr_enc));
+    memcpy(iv + sizeof(ctr_enc), m_iv.iv + sizeof(ctr_enc), IV_SIZE - sizeof(ctr_enc));
+    dprintf(D_NETWORK, "IV ctr value %d\n", ctr_enc);
+    dprintf(D_NETWORK, "Counter plus base value %d\n", result);
+    dprintf(D_NETWORK, "Counter value %u\n", m_ctr_enc-1);
 
     memcpy(output + PADDING_SIZE, iv, IV_SIZE);
+
+    char hex[3 * IV_SIZE + 1];
+    dprintf(D_ALWAYS,"IO: Outgoing IV : %s\n",
+        debug_hex_dump(hex, reinterpret_cast<char*>(output + PADDING_SIZE), IV_SIZE));
 
     if (get_key().getProtocol() != CONDOR_AESGCM) {
         dprintf(D_NETWORK, "Failed to have correct AES-GCM key type.\n");
@@ -150,7 +167,9 @@ bool Condor_Crypt_AESGCM::encrypt(const unsigned char *aad,
     }
 
     dprintf(D_NETWORK, "First byte of plaintext is %0x\n", *input);
-    if (1 != EVP_EncryptUpdate(ctx, output+9, &len, input, input_len)) {
+    if (1 != EVP_EncryptUpdate(ctx, output + PADDING_SIZE + IV_SIZE,
+        &len, input, input_len))
+    {
         dprintf(D_NETWORK, "Failed to encrypt plaintext buffer.\n");
         return false;
     }
@@ -163,15 +182,20 @@ bool Condor_Crypt_AESGCM::encrypt(const unsigned char *aad,
     }
     dprintf(D_NETWORK, "Finalized an additional %d bytes written to ciphertext.\n", len2);
     len += len2;
-    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::encrypt Cipher text: %0x %0x %0x %0x\n", *(output + 1 + 8), *(output + 1 + 8 + 1), *(output + 1 + 8 + 2), *(output + 1 + 8 + 3));
+    dprintf(D_NETWORK,
+        "Condor_Crypt_AESGCM::encrypt Cipher text: %0x %0x %0x %0x\n",
+        *(output + PADDING_SIZE + IV_SIZE),
+        *(output + PADDING_SIZE + IV_SIZE + 1),
+        *(output + PADDING_SIZE + IV_SIZE + 2),
+        *(output + PADDING_SIZE + IV_SIZE + 3));
 
     if (1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, MAC_SIZE, output + output_len - MAC_SIZE)) {
         dprintf(D_NETWORK, "Failed to get tag.\n");
         return false;
     }
     dprintf(D_NETWORK, "First two tag values are %0x, %0x starting at %d\n", *(output + output_len - 16), *(output + output_len - 15), output_len - 9);
-    memcpy(&ctr_enc, output + PADDING_SIZE, IV_SIZE);
-    dprintf(D_NETWORK, "IV value %lu\n", ctr_enc);
+    memcpy(&ctr_enc, output + PADDING_SIZE, sizeof(ctr_enc));
+    dprintf(D_NETWORK, "IV value %d\n", ctr_enc);
 
     dprintf(D_NETWORK, "Condor_Crypt_AESGCM::encrypt.  Successful encryption with cipher text %d bytes.\n", output_len);
     return true;
@@ -209,7 +233,7 @@ bool Condor_Crypt_AESGCM::decrypt(const unsigned char *  aad,
     }
 
     if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, IV_SIZE, NULL)) {
-        dprintf(D_NETWORK, "Failed to initialize IV length to 8.\n");
+        dprintf(D_NETWORK, "Failed to initialize IV length to %d.\n", IV_SIZE);
         return false;
     }
 
@@ -219,18 +243,42 @@ bool Condor_Crypt_AESGCM::decrypt(const unsigned char *  aad,
     }
     dprintf(D_NETWORK, "Key length %d\n", get_key().getKeyLength());
 
-        // TODO: for a ReliSock, we should enforce an ordering
-    uint64_t ctr_enc;
-    memcpy(&ctr_enc, input + PADDING_SIZE, IV_SIZE);
-    dprintf(D_NETWORK, "IV value %lu\n", ctr_enc);
-#if __BYTE_ORDER == __BIG_ENDIAN
-    m_ctr = ctr_enc;
-#else
-    m_ctr = ((uint64_t)ntohl(static_cast<uint32_t>(ctr_enc)) << 32) + htonl(ctr_enc >> 32);
-#endif
-    dprintf(D_NETWORK, "IV value unencoded %lu\n", m_ctr);
+        // TODO: For a SafeSock, we can't enforce an ordering...
+    if (m_ctr_dec == 0xffffffff) {
+        dprintf(D_NETWORK, "Hit max number of packets per connection.\n");
+        return false;
+    }
+    if (!memcmp(m_iv_decrypt.iv, g_unset_iv, IV_SIZE)) {
+        dprintf(D_NETWORK, "First decrypt - initializing IV\n");
+        memcpy(m_iv_decrypt.iv, input + PADDING_SIZE, IV_SIZE);
+    }
+    int32_t base = ntohl(m_iv_decrypt.ctr);
+    int32_t ctr_enc;
+    memcpy(&ctr_enc, input + PADDING_SIZE, sizeof(ctr_enc));
+    int32_t cur_packet = ntohl(ctr_enc) - base;
+    dprintf(D_NETWORK, "IV ctr value (encoded) %d\n", ctr_enc);
+    dprintf(D_NETWORK, "Counter value %u\n", m_ctr_dec);
+    dprintf(D_NETWORK, "Counter value as int32_t %d\n", *reinterpret_cast<int32_t*>(&m_ctr_dec));
+    dprintf(D_NETWORK, "Counter value from IV %d\n", cur_packet);
+    if (cur_packet != *reinterpret_cast<int32_t*>(&m_ctr_dec)) {
+        dprintf(D_NETWORK, "Counter does not match expected value.\n");
+        return false;
+    }
+    m_ctr_dec ++;
+    if (!memcmp(input + PADDING_SIZE + sizeof(ctr_enc),
+        m_iv_decrypt.iv, IV_SIZE - sizeof(ctr_enc)))
+    {
+        dprintf(D_NETWORK, "Unexpected IV from remote side.\n");
+        return false;
+    }
 
     dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt about to init key %0x %0x %0x %0x.\n", *(get_key().getKeyData()), *(get_key().getKeyData() + 15), *(get_key().getKeyData() + 16), *(get_key().getKeyData() + 31));
+
+    char hex[3 * IV_SIZE + 1];
+    dprintf(D_ALWAYS,"IO: Incoming IV : %s\n",
+        debug_hex_dump(hex,
+        reinterpret_cast<const char *>(input + PADDING_SIZE), IV_SIZE));
+
     if (!EVP_DecryptInit_ex(ctx, NULL, NULL, get_key().getKeyData(), input + PADDING_SIZE)) {
         dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt failed due to failed init.\n");
         return false;
@@ -248,10 +296,18 @@ bool Condor_Crypt_AESGCM::decrypt(const unsigned char *  aad,
         return false;
     }
 
-        // Padding bytes + IV + tag = 1 + 8 + 16
+        // Padding bytes + IV + tag = 1 + 12 + 16
     char padding = input[0];
-    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt about to decrypt cipher text.  Input length is %d\n", input_len - 1 - 8 - 16 - padding);
-    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt Cipher text: %0x %0x %0x %0x\n", *(input + 1 + 8), *(input + 1 + 8 + 1), *(input + 1 + 8 + 2), *(input + 1 + 8 + 3));
+    dprintf(D_NETWORK,
+        "Condor_Crypt_AESGCM::decrypt about to decrypt cipher text."
+        "Input length is %d\n",
+        input_len - PADDING_SIZE - IV_SIZE - MAC_SIZE - padding);
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt Cipher text: "
+        "%0x %0x %0x %0x\n",
+        *(input + PADDING_SIZE + IV_SIZE),
+        *(input + PADDING_SIZE + IV_SIZE + 1),
+        *(input + PADDING_SIZE + IV_SIZE + 2),
+        *(input + PADDING_SIZE + IV_SIZE + 3));
     if (!EVP_DecryptUpdate(ctx, output, &len, input + PADDING_SIZE + IV_SIZE, input_len - PADDING_SIZE - IV_SIZE - MAC_SIZE - padding)) {
         dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt failed due to failed cipher text update.\n");
         return false;
@@ -270,7 +326,7 @@ bool Condor_Crypt_AESGCM::decrypt(const unsigned char *  aad,
        return false;
     }
 
-    dprintf(D_NETWORK, "decrypt; input_len is %d and output_len is %d\n", input_len, input_len - padding - 1 - 8 - 16);
+    dprintf(D_NETWORK, "decrypt; input_len is %d and output_len is %d\n", input_len, input_len - padding - PADDING_SIZE - IV_SIZE - MAC_SIZE);
     output_len = input_len - padding - PADDING_SIZE - IV_SIZE - MAC_SIZE;
 
     dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt.  Successful decryption with plain text %d bytes.\n", output_len);

--- a/src/condor_io/condor_crypt_aesgcm.cpp
+++ b/src/condor_io/condor_crypt_aesgcm.cpp
@@ -24,6 +24,10 @@
 
 #include <openssl/evp.h>
 
+#define IV_SIZE 8
+#define PADDING_SIZE 1
+#define MAC_SIZE 16
+
 Condor_Crypt_AESGCM::Condor_Crypt_AESGCM(const KeyInfo& key)
     : Condor_Crypt_Base(CONDOR_AESGCM, key)
 {
@@ -47,18 +51,21 @@ int Condor_Crypt_AESGCM::ciphertext_size(int plaintext_size) const
     else
         ct_sz = plaintext_size;
     // Authentication tag is an additional 16 bytes; IV is 8 bytes; padding size is 1 byte
-    ct_sz += 16 + 8 + 1;
+    ct_sz += MAC_SIZE + IV_SIZE + PADDING_SIZE;
     return ct_sz;
 }
 
-bool Condor_Crypt_AESGCM::encrypt(const unsigned char *  input,
-                                  int              input_len, 
-                                  unsigned char *& output, 
-                                  int&             output_len)
+bool Condor_Crypt_AESGCM::encrypt(const unsigned char *aad,
+                                  int                  aad_len,
+                                  const unsigned char *input,
+                                  int                  input_len, 
+                                  unsigned char *      output, 
+                                  int                  output_buf_len)
 {
     dprintf(D_NETWORK, "Condor_Crypt_AESGCM::encrypt\n");
 
         // output length must be aligned to nearest 128-bit block for AES-GCM
+    int output_len;
     if (input_len % 16)
         output_len = ((input_len >> 4) + 1) << 4;
     else
@@ -68,15 +75,17 @@ bool Condor_Crypt_AESGCM::encrypt(const unsigned char *  input,
         return false;
     }
     char padding_bytes = output_len - input_len;
-
-        // Authentication tag is an additional 16 bytes; IV is 8 bytes; padding size is 1 byte
-    output_len += 16 + 8 + 1;
-
-    output = (unsigned char *) malloc(output_len);
-    if (!output) {
-        dprintf(D_NETWORK, "Failed to allocate encryption buffer.\n");
+    if (output_buf_len < output_len) {
+        dprintf(D_NETWORK, "Output buffer must be at least %d bytes.\n", output_buf_len);
         return false;
     }
+    if (!output) {
+        dprintf(D_NETWORK, "Condor_Crypt_AESGCM::encrypt - cannot pass a null output buffer.\n");
+        return false;
+    }
+
+        // Authentication tag is an additional 16 bytes; IV is 8 bytes; padding size is 1 byte
+    output_len += MAC_SIZE + IV_SIZE + PADDING_SIZE;
 
     dprintf(D_NETWORK, "Padding bytes: %d; input length %d\n", padding_bytes, input_len);
     output[0] = padding_bytes;
@@ -92,7 +101,7 @@ bool Condor_Crypt_AESGCM::encrypt(const unsigned char *  input,
         return false;
     }
 
-    if (1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, 8, NULL)) {
+    if (1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, IV_SIZE, NULL)) {
         dprintf(D_NETWORK, "Failed to set IV length.\n");
         return false;
     }
@@ -107,12 +116,12 @@ bool Condor_Crypt_AESGCM::encrypt(const unsigned char *  input,
     ctr_enc = (((uint64_t)htonl(m_ctr)) << 32) + htonl(m_ctr >> 32);
 #endif
     m_ctr++;
-    unsigned char iv[8];
-    memcpy(iv, &ctr_enc, 8);
+    unsigned char iv[IV_SIZE];
+    memcpy(iv, &ctr_enc, IV_SIZE);
     dprintf(D_NETWORK, "IV value %lu\n", ctr_enc);
-    dprintf(D_NETWORK, "IV value not encoded %lu\n", m_ctr);
+    dprintf(D_NETWORK, "IV value not encoded %lu\n", m_ctr-1);
 
-    memcpy(output + 1, iv, 8);
+    memcpy(output + PADDING_SIZE, iv, IV_SIZE);
 
     if (get_key().getProtocol() != CONDOR_AESGCM) {
         dprintf(D_NETWORK, "Failed to have correct AES-GCM key type.\n");
@@ -126,10 +135,16 @@ bool Condor_Crypt_AESGCM::encrypt(const unsigned char *  input,
         return false;
     }
 
-    // Ensure that the length of the decrypted buffer is authenticated.
+    // Authenticate additional data from the caller.
     int len;
-    dprintf(D_NETWORK, "Padding value is %c\n", *output);
-    if (1 != EVP_EncryptUpdate(ctx, NULL, &len, output, 1)) {
+    if (aad && (1 != EVP_EncryptUpdate(ctx, NULL, &len, aad, aad_len))) {
+        dprintf(D_NETWORK, "Failed to authenticate caller input data.\n");
+        return false;
+    }
+
+    // Ensure that the length of the decrypted buffer is authenticated.
+    dprintf(D_NETWORK, "Padding value is %0x\n", *output);
+    if (1 != EVP_EncryptUpdate(ctx, NULL, &len, output, PADDING_SIZE)) {
         dprintf(D_NETWORK, "Failed to authenticate length of padding.\n");
         return false;
     }
@@ -140,10 +155,9 @@ bool Condor_Crypt_AESGCM::encrypt(const unsigned char *  input,
         return false;
     }
     dprintf(D_NETWORK, "First %d bytes written to ciphertext.\n", len);
-    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::encrypt Cipher text: %0x %0x %0x %0x\n", *(output + 1 + 8), *(output + 1 + 8 + 1), *(output + 1 + 8 + 2), *(output + 1 + 8 + 3));
 
     int len2;
-    if (1 != EVP_EncryptFinal_ex(ctx, output + 9 + len, &len2)) {
+    if (1 != EVP_EncryptFinal_ex(ctx, output + PADDING_SIZE + IV_SIZE + len, &len2)) {
         dprintf(D_NETWORK, "Failed to finalize cipher text.\n");
         return false;
     }
@@ -151,28 +165,38 @@ bool Condor_Crypt_AESGCM::encrypt(const unsigned char *  input,
     len += len2;
     dprintf(D_NETWORK, "Condor_Crypt_AESGCM::encrypt Cipher text: %0x %0x %0x %0x\n", *(output + 1 + 8), *(output + 1 + 8 + 1), *(output + 1 + 8 + 2), *(output + 1 + 8 + 3));
 
-    if (1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, 16, output + output_len - 16)) {
+    if (1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, MAC_SIZE, output + output_len - MAC_SIZE)) {
         dprintf(D_NETWORK, "Failed to get tag.\n");
         return false;
     }
     dprintf(D_NETWORK, "First two tag values are %0x, %0x starting at %d\n", *(output + output_len - 16), *(output + output_len - 15), output_len - 9);
-    memcpy(&ctr_enc, output + 1, 8);
+    memcpy(&ctr_enc, output + PADDING_SIZE, IV_SIZE);
     dprintf(D_NETWORK, "IV value %lu\n", ctr_enc);
 
     dprintf(D_NETWORK, "Condor_Crypt_AESGCM::encrypt.  Successful encryption with cipher text %d bytes.\n", output_len);
     return true;
 }
 
-bool Condor_Crypt_AESGCM::decrypt(const unsigned char *  input,
+bool Condor_Crypt_AESGCM::decrypt(const unsigned char *  aad,
+                                  int                    aad_len,
+                                  const unsigned char *  input,
                                   int                    input_len, 
-                                  unsigned char *&       output, 
+                                  unsigned char *        output, 
                                   int&                   output_len)
 {
     dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt with payload %d.\n", input_len);
-    output_len = 0;
     EVP_CIPHER_CTX *ctx;
 
     dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt with input buffer %d.\n", input_len);
+
+    if (output_len < input_len) {
+        dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt - output length %d must be at least the size of input %d.\n", output_len, input_len);
+        return false;
+    }
+    if (!output) {
+        dprintf(D_NETWORK, "Condor_Crypt_AESGCM::encrypt - cannot pass a null output buffer.\n");
+        return false;
+    }
 
     if (!(ctx = EVP_CIPHER_CTX_new())) {
         dprintf(D_NETWORK, "Failed to initialize EVP object.\n");
@@ -184,7 +208,7 @@ bool Condor_Crypt_AESGCM::decrypt(const unsigned char *  input,
         return false;
     }
 
-    if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, 8, NULL)) {
+    if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, IV_SIZE, NULL)) {
         dprintf(D_NETWORK, "Failed to initialize IV length to 8.\n");
         return false;
     }
@@ -197,7 +221,7 @@ bool Condor_Crypt_AESGCM::decrypt(const unsigned char *  input,
 
         // TODO: for a ReliSock, we should enforce an ordering
     uint64_t ctr_enc;
-    memcpy(&ctr_enc, input + 1, 8);
+    memcpy(&ctr_enc, input + PADDING_SIZE, IV_SIZE);
     dprintf(D_NETWORK, "IV value %lu\n", ctr_enc);
 #if __BYTE_ORDER == __BIG_ENDIAN
     m_ctr = ctr_enc;
@@ -207,33 +231,35 @@ bool Condor_Crypt_AESGCM::decrypt(const unsigned char *  input,
     dprintf(D_NETWORK, "IV value unencoded %lu\n", m_ctr);
 
     dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt about to init key %0x %0x %0x %0x.\n", *(get_key().getKeyData()), *(get_key().getKeyData() + 15), *(get_key().getKeyData() + 16), *(get_key().getKeyData() + 31));
-    if (!EVP_DecryptInit_ex(ctx, NULL, NULL, get_key().getKeyData(), input + 1)) {
+    if (!EVP_DecryptInit_ex(ctx, NULL, NULL, get_key().getKeyData(), input + PADDING_SIZE)) {
         dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt failed due to failed init.\n");
         return false;
     }
 
     int len;
-    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt about to decrypt AAD %c.\n", *input);
-    if (!EVP_DecryptUpdate(ctx, NULL, &len, input, 1)) {
-        dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt failed due to failed AAD update.\n");
+    if (aad && !EVP_DecryptUpdate(ctx, NULL, &len, aad, aad_len)) {
+        dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt failed when authenticating user AAD.\n");
         return false;
     }
 
-        // output is at most input_len.
-    output = static_cast<unsigned char *>(malloc(input_len));
+    dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt about to decrypt AAD %0x.\n", *input);
+    if (!EVP_DecryptUpdate(ctx, NULL, &len, input, PADDING_SIZE)) {
+        dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt failed due to failed AAD update.\n");
+        return false;
+    }
 
         // Padding bytes + IV + tag = 1 + 8 + 16
     char padding = input[0];
     dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt about to decrypt cipher text.  Input length is %d\n", input_len - 1 - 8 - 16 - padding);
     dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt Cipher text: %0x %0x %0x %0x\n", *(input + 1 + 8), *(input + 1 + 8 + 1), *(input + 1 + 8 + 2), *(input + 1 + 8 + 3));
-    if (!EVP_DecryptUpdate(ctx, output, &len, input + 1 + 8, input_len - 1 - 8 - 16 - padding)) {
+    if (!EVP_DecryptUpdate(ctx, output, &len, input + PADDING_SIZE + IV_SIZE, input_len - PADDING_SIZE - IV_SIZE - MAC_SIZE - padding)) {
         dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt failed due to failed cipher text update.\n");
         return false;
     }
     dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt produced output of size %d with value %0x\n", len, *output);
 
     dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt about to set tag %0x,%0x.\n", *(input + input_len - 16), *(input + input_len - 15));
-    if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, 16, const_cast<unsigned char *>(input + input_len - 16))) {
+    if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, MAC_SIZE, const_cast<unsigned char *>(input + input_len - MAC_SIZE))) {
         dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt failed due to failed set of tag.\n");
         return false;
     }
@@ -245,7 +271,7 @@ bool Condor_Crypt_AESGCM::decrypt(const unsigned char *  input,
     }
 
     dprintf(D_NETWORK, "decrypt; input_len is %d and output_len is %d\n", input_len, input_len - padding - 1 - 8 - 16);
-    output_len = input_len - padding - 1 - 8 - 16;
+    output_len = input_len - padding - PADDING_SIZE - IV_SIZE - MAC_SIZE;
 
     dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt.  Successful decryption with plain text %d bytes.\n", output_len);
     return true;

--- a/src/condor_io/condor_crypt_aesgcm.cpp
+++ b/src/condor_io/condor_crypt_aesgcm.cpp
@@ -1,0 +1,171 @@
+/***************************************************************
+ *
+ * Copyright (C) 1990-2007, Condor Team, Computer Sciences Department,
+ * University of Wisconsin-Madison, WI.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+
+#include "condor_common.h"
+#include "condor_crypt_aesgcm.h"
+
+#include <openssl/evp.h>
+
+Condor_Crypt_AESGCM::Condor_Crypt_AESGCM(const KeyInfo& key)
+    : Condor_Crypt_Base(CONDOR_AESGCM, key)
+{
+}
+
+Condor_Crypt_AESGCM::~Condor_Crypt_AESGCM()
+{
+}
+
+	// IMPORTANT: we never actually reset the state as AES-GCM
+	// IVs may not be reused.
+void Condor_Crypt_AESGCM::resetState()
+{
+}
+
+bool Condor_Crypt_AESGCM::encrypt(const unsigned char *  input,
+                                  int              input_len, 
+                                  unsigned char *& output, 
+                                  int&             output_len)
+{
+        // Encryption size is at most 4 bytes long.
+    if (input_len > (1 << 24)) {
+        return false;
+    }
+
+        // output length must be aligned to nearest 128-bit block for AES-GCM
+    if (input_len % 16)
+        output_len = ((input_len >> 3) + 1) << 3;
+    else
+        output_len = input_len;
+        // Authentication tag is an additional 16 bytes; IV is 8 bytes; padding size is 1 byte
+    output_len += 16 + 8 + 1;
+
+    output = (unsigned char *) malloc(output_len);
+    if (!output)
+        return false;
+
+    if ((output_len - input_len < 0) || (output_len - input_len >= 16))
+        return false;
+
+    char padding_bytes = output_len - input_len;
+    output[0] = padding_bytes;
+
+    EVP_CIPHER_CTX *ctx;
+    if (!(ctx = EVP_CIPHER_CTX_new()))
+        return false;
+
+    if (1 != EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL))
+        return false;
+
+    if (1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, 8, NULL))
+        return false;
+
+    // TODO: Increase the IV size to also include a timestamp.  If the
+    // session key is reused, currently the IV may be reused, resulting in
+    // a complete defeat of the encryption.
+    uint64_t ctr_enc;
+#if __BYTE_ORDER == __BIG_ENDIAN
+    ctr_enc = m_ctr; 
+#else
+    ctr_enc = (((uint64_t)htonl(m_ctr)) << 32) + htonl(m_ctr >> 32);
+#endif
+    m_ctr++;
+    unsigned char iv[8];
+    memcpy(iv, &ctr_enc, 8);
+
+    memcpy(output + 1, iv, 8);
+
+    if (get_key().getProtocol() != CONDOR_AESGCM)
+        return false;
+
+    if (1 != EVP_EncryptInit_ex(ctx, NULL, NULL, get_key().getKeyData(), iv))
+        return false;
+
+    // Ensure that the length of the decrypted buffer is authenticated.
+    int len;
+    if (1 != EVP_EncryptUpdate(ctx, NULL, &len, output, 1))
+        return false;
+
+    if (1 != EVP_EncryptUpdate(ctx, output+9, &len, input, input_len))
+        return false;
+
+    int len2;
+    if (1 != EVP_EncryptFinal_ex(ctx, output + 9 + len, &len2))
+        return false;
+    len += len2;
+
+    if (1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, 16, output + 9 + len))
+        return false;
+
+    return true;
+}
+
+bool Condor_Crypt_AESGCM::decrypt(const unsigned char *  input,
+                                  int                    input_len, 
+                                  unsigned char *&       output, 
+                                  int&                   output_len)
+{
+    EVP_CIPHER_CTX *ctx;
+
+    if (!(ctx = EVP_CIPHER_CTX_new()))
+        return false;
+
+    if (!EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL))
+        return false;
+
+    if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, 8, NULL))
+        return false;
+
+    if (get_key().getProtocol() != CONDOR_AESGCM)
+        return false;
+
+        // TODO: for a ReliSock, we should enforce an ordering
+    uint64_t ctr_enc;
+    memcpy(&ctr_enc, input + 1, 8);
+#if __BYTE_ORDER == __BIG_ENDIAN
+    m_ctr = ctr_enc;
+#else
+    m_ctr = (((uint64_t)ntohl(static_cast<uint32_t>(ctr_enc)) << 32) + htonl(ctr_enc >> 32);
+#endif
+
+    if (!EVP_DecryptInit_ex(ctx, NULL, NULL, get_key().getKeyData(), input + 1))
+        return false;
+
+    int len;
+    if (!EVP_DecryptUpdate(ctx, NULL, &len, input, 1))
+        return false;
+
+        // output is at most input_len.
+    output = static_cast<unsigned char *>(malloc(input_len));
+
+        // Padding bytes + IV + tag = 1 + 8 + 16
+    if (!EVP_DecryptUpdate(ctx, output, &len, input + 1 + 8, input_len - 1 - 8 - 16))
+        return false;
+
+    if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, 16, const_cast<unsigned char *>(input + input_len - 16)))
+        return false;
+
+    if (!EVP_DecryptFinal_ex(ctx, output + len, &len))
+       return false;
+
+    char padding = input[0];
+    output_len = input_len - padding;
+
+    return true;
+}

--- a/src/condor_io/condor_crypt_aesgcm.cpp
+++ b/src/condor_io/condor_crypt_aesgcm.cpp
@@ -34,7 +34,7 @@ unsigned char g_unset_iv[IV_SIZE] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 Condor_Crypt_AESGCM::Condor_Crypt_AESGCM(const KeyInfo& key)
     : Condor_Crypt_Base(CONDOR_AESGCM, key)
 {
-	resetState();
+	resetState(key.getCryptoState());
 }
 
 Condor_Crypt_AESGCM::~Condor_Crypt_AESGCM()
@@ -44,13 +44,31 @@ Condor_Crypt_AESGCM::~Condor_Crypt_AESGCM()
 void Condor_Crypt_AESGCM::resetState()
 {
 	dprintf(D_NETWORK, "Condor_Crypt_AESGCM::resetState\n");
-	m_ctr_dec = 0;
-	m_ctr_enc = 0;
-	memset(m_iv.iv, '\0', IV_SIZE);
-	while (!memcmp(m_iv.iv, g_unset_iv, IV_SIZE)) {
-		RAND_pseudo_bytes(m_iv.iv, IV_SIZE);
+	m_state.reset(new CryptoState());
+	while (!memcmp(m_state->m_iv_enc.iv, g_unset_iv, IV_SIZE)) {
+		RAND_pseudo_bytes(m_state->m_iv_enc.iv, IV_SIZE);
 	}
-	memset(m_iv_decrypt.iv, '\0', IV_SIZE);
+	memset(m_state->m_iv_dec.iv, '\0', IV_SIZE);
+}
+
+void Condor_Crypt_AESGCM::resetState(std::shared_ptr<CryptoState> state)
+{
+	dprintf(D_NETWORK, "Condor_Crypt_AESGCM::resetState with key\n");
+	if (state.get()) {
+		m_state = state;
+		while (!memcmp(m_state->m_iv_enc.iv, g_unset_iv, IV_SIZE)) {
+			RAND_pseudo_bytes(m_state->m_iv_enc.iv, IV_SIZE);
+		}
+		if (m_state->m_ctr_conn != 0xffffffff)
+			m_state->m_ctr_conn ++;
+		else
+			dprintf(D_NETWORK, "Condor_Crypt_AESGCM::resetState - Max session reuse hit!\n");
+		m_state->m_ctr_enc = 0;
+		m_state->m_ctr_dec = 0;
+		dprintf(D_NETWORK, "Condor_Crypt_AESGCM::resetState: Connection count %u.\n", m_state->m_ctr_conn);
+	} else {
+		resetState();
+	}	
 }
 
 int Condor_Crypt_AESGCM::ciphertext_size(int plaintext_size) const
@@ -99,6 +117,7 @@ bool Condor_Crypt_AESGCM::encrypt(const unsigned char *aad,
 
     dprintf(D_NETWORK, "Padding bytes: %d; input length %d\n", padding_bytes, input_len);
     output[0] = padding_bytes;
+    memset(output + output_len - MAC_SIZE - padding_bytes, '\0', padding_bytes);
 
     EVP_CIPHER_CTX *ctx;
     if (!(ctx = EVP_CIPHER_CTX_new())) {
@@ -116,23 +135,35 @@ bool Condor_Crypt_AESGCM::encrypt(const unsigned char *aad,
         return false;
     }
 
-    // TODO: Increase the IV size to also include a timestamp.  If the
-    // session key is reused, currently the IV may be reused, resulting in
-    // a complete defeat of the encryption.
-    int32_t base = ntohl(m_iv.ctr);
-    int32_t result = base + *reinterpret_cast<int32_t*>(&m_ctr_enc);
+    int32_t base = ntohl(m_state->m_iv_enc.ctr);
+    int32_t result = base + *reinterpret_cast<int32_t*>(&m_state->m_ctr_enc);
     int32_t ctr_enc = htonl(result);
-    if (m_ctr_enc == 0xffffffff) {
+    if (m_state->m_ctr_enc == 0xffffffff) {
         dprintf(D_NETWORK, "Hit max number of packets per connection.\n");
         return false;
     }
-    m_ctr_enc++;
+    m_state->m_ctr_enc++;
+
+    int32_t base_conn = ntohl(m_state->m_iv_enc.ctr_conn);
+    int32_t result_conn = base_conn + *reinterpret_cast<int32_t*>(&m_state->m_ctr_conn);
+    int32_t ctr_enc_conn = htonl(result_conn);
+    if (m_state->m_ctr_conn == 0xffffffff) {
+        dprintf(D_NETWORK, "Hit max number of connections in a session.\n");
+        return false;
+    }
+
     unsigned char iv[IV_SIZE];
     memcpy(iv, &ctr_enc, sizeof(ctr_enc));
-    memcpy(iv + sizeof(ctr_enc), m_iv.iv + sizeof(ctr_enc), IV_SIZE - sizeof(ctr_enc));
+    memcpy(iv + sizeof(ctr_enc), &ctr_enc_conn, sizeof(ctr_enc_conn));
+    memcpy(iv + 2*sizeof(ctr_enc), m_state->m_iv_enc.iv + 2*sizeof(ctr_enc), IV_SIZE - 2*sizeof(ctr_enc));
+
     dprintf(D_NETWORK, "IV ctr value %d\n", ctr_enc);
     dprintf(D_NETWORK, "Counter plus base value %d\n", result);
-    dprintf(D_NETWORK, "Counter value %u\n", m_ctr_enc-1);
+    dprintf(D_NETWORK, "Counter value %u\n", m_state->m_ctr_enc-1);
+
+    dprintf(D_NETWORK, "IV conn ctr value %d\n", ctr_enc);
+    dprintf(D_NETWORK, "Connection Counter plus base value %d\n", result);
+    dprintf(D_NETWORK, "Connection Counter value %u\n", m_state->m_ctr_conn);
 
     memcpy(output + PADDING_SIZE, iv, IV_SIZE);
 
@@ -193,7 +224,7 @@ bool Condor_Crypt_AESGCM::encrypt(const unsigned char *aad,
         dprintf(D_NETWORK, "Failed to get tag.\n");
         return false;
     }
-    dprintf(D_NETWORK, "First two tag values are %0x, %0x starting at %d\n", *(output + output_len - 16), *(output + output_len - 15), output_len - 9);
+    dprintf(D_NETWORK, "First two tag values are %0x, %0x starting at %d\n", *(output + output_len - MAC_SIZE), *(output + output_len - MAC_SIZE), output_len - MAC_SIZE);
     memcpy(&ctr_enc, output + PADDING_SIZE, sizeof(ctr_enc));
     dprintf(D_NETWORK, "IV value %d\n", ctr_enc);
 
@@ -244,29 +275,46 @@ bool Condor_Crypt_AESGCM::decrypt(const unsigned char *  aad,
     dprintf(D_NETWORK, "Key length %d\n", get_key().getKeyLength());
 
         // TODO: For a SafeSock, we can't enforce an ordering...
-    if (m_ctr_dec == 0xffffffff) {
+    if (m_state->m_ctr_dec == 0xffffffff) {
         dprintf(D_NETWORK, "Hit max number of packets per connection.\n");
         return false;
     }
-    if (!memcmp(m_iv_decrypt.iv, g_unset_iv, IV_SIZE)) {
-        dprintf(D_NETWORK, "First decrypt - initializing IV\n");
-        memcpy(m_iv_decrypt.iv, input + PADDING_SIZE, IV_SIZE);
+    if (m_state->m_ctr_conn == 0xffffffff) {
+        dprintf(D_NETWORK, "Hit max number of connections per session.\n");
+        return false;
     }
-    int32_t base = ntohl(m_iv_decrypt.ctr);
+    if (!memcmp(m_state->m_iv_dec.iv, g_unset_iv, IV_SIZE)) {
+        dprintf(D_NETWORK, "First decrypt - initializing IV\n");
+        memcpy(m_state->m_iv_dec.iv, input + PADDING_SIZE, IV_SIZE);
+    }
+
+    int32_t base = ntohl(m_state->m_iv_dec.ctr);
     int32_t ctr_enc;
     memcpy(&ctr_enc, input + PADDING_SIZE, sizeof(ctr_enc));
     int32_t cur_packet = ntohl(ctr_enc) - base;
     dprintf(D_NETWORK, "IV ctr value (encoded) %d\n", ctr_enc);
-    dprintf(D_NETWORK, "Counter value %u\n", m_ctr_dec);
-    dprintf(D_NETWORK, "Counter value as int32_t %d\n", *reinterpret_cast<int32_t*>(&m_ctr_dec));
+    dprintf(D_NETWORK, "Counter value %u\n", m_state->m_ctr_dec);
     dprintf(D_NETWORK, "Counter value from IV %d\n", cur_packet);
-    if (cur_packet != *reinterpret_cast<int32_t*>(&m_ctr_dec)) {
+    if (cur_packet != *reinterpret_cast<int32_t*>(&m_state->m_ctr_dec)) {
         dprintf(D_NETWORK, "Counter does not match expected value.\n");
         return false;
     }
-    m_ctr_dec ++;
+
+    int32_t base_conn = ntohl(m_state->m_iv_dec.ctr_conn);
+    int32_t ctr_enc_conn;
+    memcpy(&ctr_enc_conn, input + PADDING_SIZE + sizeof(ctr_enc), sizeof(ctr_enc_conn));
+    int32_t cur_packet_conn = ntohl(ctr_enc_conn) - base_conn;
+    dprintf(D_NETWORK, "IV conn ctr value (encoded) %d\n", ctr_enc_conn);
+    dprintf(D_NETWORK, "Connection Counter value %u\n", m_state->m_ctr_conn);
+    dprintf(D_NETWORK, "Connection Counter value from IV %d\n", cur_packet_conn);
+    if (cur_packet_conn != *reinterpret_cast<int32_t*>(&m_state->m_ctr_conn)) {
+        dprintf(D_NETWORK, "Condor_Crypt_AESGCM::decrypt: Connection counter does not match expected value.\n");
+        return false;
+    }
+
+    m_state->m_ctr_dec ++;
     if (!memcmp(input + PADDING_SIZE + sizeof(ctr_enc),
-        m_iv_decrypt.iv, IV_SIZE - sizeof(ctr_enc)))
+        m_state->m_iv_dec.iv, IV_SIZE - sizeof(ctr_enc)))
     {
         dprintf(D_NETWORK, "Unexpected IV from remote side.\n");
         return false;

--- a/src/condor_io/condor_secman.cpp
+++ b/src/condor_io/condor_secman.cpp
@@ -3156,11 +3156,7 @@ getDefaultAuthenticationMethods(DCpermission perm) {
 
 
 MyString SecMan::getDefaultCryptoMethods() {
-#ifdef HAVE_EXT_OPENSSL
-	return "BLOWFISH,3DES";
-#else
-	return "";
-#endif
+	return "AESGCM,BLOWFISH,3DES";
 }
 
 char* SecMan::my_unique_id() {
@@ -3257,6 +3253,8 @@ Protocol CryptProtocolNameToEnum(char const *name) {
 	case '3': // 3des
 	case 'T': // Tripledes
 		return CONDOR_3DES;
+	case 'A': // AES-GCM-256
+		return CONDOR_AESGCM;
 	default:
 		return CONDOR_NO_PROTOCOL;
 	}

--- a/src/condor_io/condor_secman.cpp
+++ b/src/condor_io/condor_secman.cpp
@@ -3351,9 +3351,9 @@ SecMan::CreateNonNegotiatedSecuritySession(DCpermission auth_level, char const *
 		unsigned char keybuf2[32];
 		memcpy(keybuf2, keybuf, 16);
 		memcpy(keybuf2 + 16, keybuf, 16);
-		keyinfo = new KeyInfo(keybuf2,32,crypt_protocol);
+		keyinfo = new KeyInfo(keybuf2, 32, crypt_protocol, 0, std::shared_ptr<CryptoState>());
 	} else {
-		keyinfo = new KeyInfo(keybuf,MAC_SIZE,crypt_protocol);
+		keyinfo = new KeyInfo(keybuf,MAC_SIZE,crypt_protocol, 0, std::shared_ptr<CryptoState>());
 	}
 	free( keybuf );
 	keybuf = NULL;

--- a/src/condor_io/shared_port_client.cpp
+++ b/src/condor_io/shared_port_client.cpp
@@ -159,6 +159,8 @@ SharedPortClient::sendSharedPortID(char const *shared_port_id,Sock *sock)
 		return false;
 	}
 
+	static_cast<ReliSock*>(sock)->resetHeaderMD();
+
 	dprintf(D_FULLDEBUG,
 			"SharedPortClient: sent connection request to %s for shared port id %s\n",
 			sock->peer_description(), shared_port_id);

--- a/src/condor_io/sock.cpp
+++ b/src/condor_io/sock.cpp
@@ -2886,9 +2886,9 @@ Sock::initialize_crypto(KeyInfo * key)
             break;
         case CONDOR_AESGCM:
 			setCryptoMethodUsed("AESGCM");
+            set_MD_mode(MD_OFF);
             crypto_ = new Condor_Crypt_AESGCM(*key);
                 // AES-GCM is incompatible with MD mode.
-            set_MD_mode(MD_OFF);
             break;
         default:
             break;

--- a/src/condor_io/sock.cpp
+++ b/src/condor_io/sock.cpp
@@ -2224,7 +2224,7 @@ const char * Sock::serializeCryptoInfo(const char * buf)
         }        
 
         // Initialize crypto info
-        KeyInfo k((unsigned char *)kserial, len, (Protocol)protocol);
+        KeyInfo k((unsigned char *)kserial, len, (Protocol)protocol, 0, std::shared_ptr<CryptoState>());
         set_crypto_key(encryption_mode==1, &k, 0);
         free(kserial);
 		ASSERT( *ptmp == '*' );
@@ -2273,7 +2273,7 @@ const char * Sock::serializeMdInfo(const char * buf)
         }        
 
         // Initialize crypto info
-        KeyInfo k((unsigned char *)kmd, len);
+        KeyInfo k((unsigned char *)kmd, len, CONDOR_NO_PROTOCOL, 0, std::shared_ptr<CryptoState>());
         set_MD_mode(MD_ALWAYS_ON, &k, 0);
         free(kmd);
 		ASSERT( *ptmp == '*' );

--- a/src/condor_io/sock.cpp
+++ b/src/condor_io/sock.cpp
@@ -48,11 +48,10 @@
 #include <netinet/in.h>
 #endif
 
-#ifdef HAVE_EXT_OPENSSL
 #include "condor_crypt_blowfish.h"
 #include "condor_crypt_3des.h"
+#include "condor_crypt_aesgcm.h"
 #include "condor_md.h"                // Message authentication stuff
-#endif
 
 #if !defined(WIN32)
 #define closesocket close
@@ -2877,7 +2876,6 @@ Sock::initialize_crypto(KeyInfo * key)
     if (key) {
         switch (key->getProtocol()) 
         {
-#ifdef HAVE_EXT_OPENSSL
         case CONDOR_BLOWFISH :
 			setCryptoMethodUsed("BLOWFISH");
             crypto_ = new Condor_Crypt_Blowfish(*key);
@@ -2886,7 +2884,9 @@ Sock::initialize_crypto(KeyInfo * key)
 			setCryptoMethodUsed("3DES");
             crypto_ = new Condor_Crypt_3des(*key);
             break;
-#endif
+        case CONDOR_AESGCM:
+            crypto_ = new Condor_Crypt_AESGCM(*key);
+            break;
         default:
             break;
         }

--- a/src/condor_io/sock.cpp
+++ b/src/condor_io/sock.cpp
@@ -2887,6 +2887,8 @@ Sock::initialize_crypto(KeyInfo * key)
         case CONDOR_AESGCM:
 			setCryptoMethodUsed("AESGCM");
             crypto_ = new Condor_Crypt_AESGCM(*key);
+                // AES-GCM is incompatible with MD mode.
+            set_MD_mode(MD_OFF);
             break;
         default:
             break;
@@ -2898,6 +2900,10 @@ Sock::initialize_crypto(KeyInfo * key)
 
 bool Sock::set_MD_mode(CONDOR_MD_MODE mode, KeyInfo * key, const char * keyId)
 {
+    if (mode != MD_OFF && crypto_ && crypto_->protocol() == CONDOR_AESGCM) {
+        set_MD_mode(MD_OFF);
+    }
+
     mdMode_ = mode;
     delete mdKey_;
     mdKey_ = 0;

--- a/src/condor_io/sock.cpp
+++ b/src/condor_io/sock.cpp
@@ -2885,6 +2885,7 @@ Sock::initialize_crypto(KeyInfo * key)
             crypto_ = new Condor_Crypt_3des(*key);
             break;
         case CONDOR_AESGCM:
+			setCryptoMethodUsed("AESGCM");
             crypto_ = new Condor_Crypt_AESGCM(*key);
             break;
         default:

--- a/src/condor_io/stream.cpp
+++ b/src/condor_io/stream.cpp
@@ -548,7 +548,7 @@ Stream::code(condor_mode_t &m)
 int 
 Stream::put( char	c)
 {
-	if (put_bytes(&c, 1) != 1) return FALSE;
+	if (put_bytes(&c, 1) == -1) return FALSE;
 	return TRUE;
 }
 
@@ -557,7 +557,7 @@ Stream::put( char	c)
 int 
 Stream::put( unsigned char	c)
 {
-	if (put_bytes(&c, 1) != 1) return FALSE;
+	if (put_bytes(&c, 1) == -1) return FALSE;
 	return TRUE;
 }
 
@@ -571,10 +571,10 @@ Stream::put( int		i)
 
 	tmp = htonl(i);
 	pad = (i >= 0) ? 0 : 0xff; // sign extend value
-	for (int s=0; s < INT_SIZE-(int)sizeof(int); s++) {
-		if (put_bytes(&pad, 1) != 1) return FALSE;
-	}
-	if (put_bytes(&tmp, sizeof(int)) != sizeof(int)) return FALSE;
+	char pad_array[INT_SIZE - (int)sizeof(int)];
+	memset(pad_array, pad, sizeof(pad_array));
+	if (put_bytes(&pad_array, sizeof(pad_array)) == -1) return FALSE;
+	if (put_bytes(&tmp, sizeof(int)) == -1) return FALSE;
 	return TRUE;
 }
 
@@ -589,9 +589,9 @@ Stream::put( unsigned int		i)
 	tmp = htonl(i);
 	pad = 0;
 	for (int s=0; s < INT_SIZE-(int)sizeof(int); s++) {
-		if (put_bytes(&pad, 1) != 1) return FALSE;
+		if (put_bytes(&pad, 1) == -1) return FALSE;
 	}
-	if (put_bytes(&tmp, sizeof(int)) != sizeof(int)) return FALSE;
+	if (put_bytes(&tmp, sizeof(int)) == -1) return FALSE;
 	return TRUE;
 }
 
@@ -641,10 +641,10 @@ Stream::put( long	l)
 		if (sizeof(long) < INT_SIZE) {
 			pad = (l >= 0) ? 0 : 0xff; // sign extend value
 			for (int s=0; s < INT_SIZE-(int)sizeof(long); s++) {
-				if (put_bytes(&pad, 1) != 1) return FALSE;
+				if (put_bytes(&pad, 1) == -1) return FALSE;
 			}
 		}
-		if (put_bytes(&l, sizeof(long)) != sizeof(long)) return FALSE;
+		if (put_bytes(&l, sizeof(long)) == -1) return FALSE;
 	}
 	return TRUE;
 }
@@ -664,10 +664,10 @@ Stream::put( unsigned long	l)
 		if (sizeof(long) < INT_SIZE) {
 			pad = 0;
 			for (int s=0; s < INT_SIZE-(int)sizeof(long); s++) {
-				if (put_bytes(&pad, 1) != 1) return FALSE;
+				if (put_bytes(&pad, 1) == -1) return FALSE;
 			}
 		}
-		if (put_bytes(&l, sizeof(long)) != sizeof(long)) return FALSE;
+		if (put_bytes(&l, sizeof(long)) == -1) return FALSE;
 	}
 	return TRUE;
 }
@@ -717,10 +717,10 @@ Stream::put( int64_t	l)
 		if (sizeof(int64_t) < INT_SIZE) {
 			pad = (l >= 0) ? 0 : 0xff; // sign extend value
 			for (int s=0; s < INT_SIZE-(int)sizeof(int64_t); s++) {
-				if (put_bytes(&pad, 1) != 1) return FALSE;
+				if (put_bytes(&pad, 1) == -1) return FALSE;
 			}
 		}
-		if (put_bytes(&l, sizeof(int64_t)) != sizeof(int64_t)) return FALSE;
+		if (put_bytes(&l, sizeof(int64_t)) == -1) return FALSE;
 	}
 	return TRUE;
 }
@@ -740,10 +740,10 @@ Stream::put( uint64_t	l)
 		if (sizeof(uint64_t) < INT_SIZE) {
 			pad = 0;
 			for (int s=0; s < INT_SIZE-(int)sizeof(uint64_t); s++) {
-				if (put_bytes(&pad, 1) != 1) return FALSE;
+				if (put_bytes(&pad, 1) == -1) return FALSE;
 			}
 		}
-		if (put_bytes(&l, sizeof(uint64_t)) != sizeof(uint64_t)) return FALSE;
+		if (put_bytes(&l, sizeof(uint64_t)) == -1) return FALSE;
 	}
 	return TRUE;
 }
@@ -797,7 +797,7 @@ Stream::put( char const *s)
 			return FALSE;
 		}
 	}
-	if (put_bytes(s, len) != len) return FALSE;
+	if (put_bytes(s, len) == -1) return FALSE;
 	return TRUE;
 }
 
@@ -820,7 +820,7 @@ Stream::put_nullstr( char const *s)
 				return FALSE;
 			}
 		}
-		if (put_bytes(BIN_NULL_CHAR, 1) != 1) return FALSE;
+		if (put_bytes(BIN_NULL_CHAR, 1) == -1) return FALSE;
 	}
 	else{
 		len = (int)strlen(s)+1;
@@ -829,7 +829,7 @@ Stream::put_nullstr( char const *s)
 				return FALSE;
 			}
 		}
-		if (put_bytes(s, len) != len) return FALSE;
+		if (put_bytes(s, len) == -1) return FALSE;
 	}
 	return TRUE;
 }
@@ -883,7 +883,7 @@ Stream::put( char const *s, int		l)
 			return FALSE;
 		}
 	}
-	if (put_bytes(s, l) != l) return FALSE;
+	if (put_bytes(s, l) == -1) return FALSE;
 	return TRUE;
 }
 
@@ -919,17 +919,20 @@ Stream::get( int		&i)
 	int		tmp;
 	char	pad[INT_SIZE-sizeof(int)], sign;
 
+	dprintf(D_NETWORK,"Streaming an integer\n");
 	if (INT_SIZE > sizeof(int)) { // get overflow bytes
 		if (get_bytes(pad, INT_SIZE-sizeof(int))
-			!= INT_SIZE-sizeof(int)) {
+			== -1) {
 			dprintf(D_NETWORK, "Stream::get(int) failed to read padding\n");
 			return FALSE;
 		}
+		dprintf(D_NETWORK,"Got %u bytes of padding.\n", INT_SIZE-sizeof(int));
 	}
-	if (get_bytes(&tmp, sizeof(int)) != sizeof(int)) {
+	if (get_bytes(&tmp, sizeof(int)) == -1) {
 		dprintf(D_NETWORK, "Stream::get(int) failed to read int\n");
 		return FALSE;
 	}
+	dprintf(D_NETWORK,"Got %u bytes of integer\n", sizeof(int));
 	i = ntohl(tmp);
 	sign = (i >= 0) ? 0 : 0xff;
 	for (int s=0; s < INT_SIZE-(int)sizeof(int); s++) { // chk 4 overflow
@@ -951,12 +954,12 @@ Stream::get( unsigned int	&i)
 
 	if (INT_SIZE > sizeof(int)) { // get overflow bytes
 		if (get_bytes(pad, INT_SIZE-sizeof(int))
-			!= INT_SIZE-sizeof(int)) {
+			== -1) {
 			dprintf(D_NETWORK, "Stream::get(uint) failed to read padding\n");
 			return FALSE;
 		}
 	}
-	if (get_bytes(&tmp, sizeof(int)) != sizeof(int)) {
+	if (get_bytes(&tmp, sizeof(int)) == -1) {
 		dprintf(D_NETWORK, "Stream::get(uint) failed to read int\n");
 		return FALSE;
 	}


### PR DESCRIPTION
This is the first draft of AES-GCM support in CEDAR.  AES-GCM, being an AEAD approach, integrates both encryption and authentication into a single operation and utilizes modern algorithms compared to the existing options (e.g., BLOWFISH + MD5).  By leveraging OpenSSL for these operations, we get access to hardware-based acceleration.

A few notes:
- Because the AEAD encryption operations generate a message digest for each encryption call, we can't do an encryption call for each `get_bytes` (also, calls to `get_bytes` would no longer be associative).  For AES-GCM, we have to switch to encrypting at the message level instead.
- I realized the above fact after a first draft of the code, resulting in a bit of a messy commit history.  I would suggest squashing the PR.
- Most of the difficulty is in selection of the IV.  Reuse of IVs is particularly problematic in AES-GCM and we have 12 bytes to work with.  Here's the scheme:
   - The IV starts off as a 12 byte random number.  We need some randomness as non-negotiated sessions (such as the family session) are reused.
   - The first 4 bytes are reused as a message counter.
   - For negotiated sessions, the second 4 bytes are reused as a "connection counter".  The connection counter is incremented for each new TCP connection.  For non-negotiated sessions, we thus have at least 8 bytes (2^64)of randomness -- significantly more if the connections are short (e.g., if all connections are elss less than 65,536 messages then we have 2^80).  From the birthday paradox, this implies we can safely reuse this billions of times with a fairly low probability of collision (10^-9).
      - We can't have the "connection counter" for non-negotiated sessions because those sessions are reused across multiple daemons - there's no way to have a linear counter.
      - This also assumes a negotiated session is not shared with multiple entities.  This assumption probably needs to be more battle tested.
- The decryption and encryption side must agree on the connection counter and the message counter values for decryption to succeed.  This prevents all replay attacks for negotiated sessions and replay attacks in the middle of a connection for non-negotiated sessions.
- This is the first encryption algorithm with the longer keylength (256 bits).  This is fine _except_ for negotiated sessions as those are currently fixed-size at 128 bits.  Right now, we just repeat the key twice (meaning non-negotiate sessions are really 128-bit security).

Known TODOs:
- [x] The relisock should calculate a message digest for the header handshake and include the digest in the AAD of the first encrypted packet.  This ensures the relisock doesn't proceed if the header was tampered with.
- [ ] The `SafeSock` path is entirely untested and likely doesn't work.
- [x] We generate the symmetric key based on the first letter in the encryption algorithm list.  We should parse the list and generate a key only if the encryption algorithm is needed (otherwise we'll have to ensure all future algorithm names have unique first letters - e.g., adding `AES-GCM-128` wouldn't work).
- [x] I suspect the padding and padding byte is actually not necessary.  It looks like AEAD is doing some internal management of the blocks.
- [x] When generating a non-negotiated session we should either always generate a 256-bit key or generate a longer key if AES-GCM is being considered.