### PR TITLE
Access token as PRIV_CONDOR when a daemon

### DIFF
--- a/src/condor_io/condor_auth_passwd.cpp
+++ b/src/condor_io/condor_auth_passwd.cpp
@@ -190,6 +190,11 @@ findTokens(const std::string &issuer,
 		return true;
 	}
 
+	auto subsys = get_mySubSystem();
+
+		// If we are supposed to retrieve a token on behalf of a user, then
+		// owner will be set and we will use PRIV_USER.  In all other cases,
+		// if we are a daemon we should read the token as PRIV_CONDOR.
 	TemporaryPrivSentry tps( !owner.empty() );
 	if (!owner.empty()) {
 		if (!init_user_ids(owner.c_str(), NULL)) {
@@ -197,6 +202,8 @@ findTokens(const std::string &issuer,
 			return false;
 		}
 		set_user_priv();
+	} else if (subsys->isDaemon()) {
+		set_priv(PRIV_CONDOR);
 	}
 
 	// Note we reuse the exclude regexp from the configuration subsys.
@@ -248,7 +255,7 @@ findTokens(const std::string &issuer,
 	const char *file;
 	std::vector<std::string> tokens;
 	std::string subsys_token_file;
-	std::string subsys_agt_name = get_mySubSystemName();
+	std::string subsys_agt_name = subsys->getName();
 	subsys_agt_name += "_auto_generated_token";
 
 	while ( (file = dir.Next()) ) {

--- a/src/condor_io/condor_auth_passwd.cpp
+++ b/src/condor_io/condor_auth_passwd.cpp
@@ -116,11 +116,13 @@ bool checkToken(const std::string &line,
 		}
 		const std::string &tmp_key_id = decoded_jwt.get_key_id();
 		if (!server_key_ids.empty() && (server_key_ids.find(tmp_key_id) == server_key_ids.end())) {
+			dprintf(D_SECURITY|D_FULLDEBUG, "Ignoring token as it was signed with key %s (not known to the server).\n", tmp_key_id.c_str());
 			return false;
 		}
 		dprintf(D_SECURITY|D_FULLDEBUG, "JWT object was signed with server key %s (out of %lu possible keys)\n", tmp_key_id.c_str(), server_key_ids.size());
 		const std::string &tmp_issuer = decoded_jwt.get_issuer();
 		if (!issuer.empty() && issuer != tmp_issuer) {
+			dprintf(D_SECURITY|D_FULLDEBUG, "Ignoring token as it is from trust domain %s (server trust domain is %s).\n", tmp_issuer.c_str(), issuer.c_str());
 			return false;
 		}
 		if (!decoded_jwt.has_subject()) {
@@ -147,7 +149,7 @@ bool findToken(const std::string &tokenfilename,
 	std::string &token,
 	std::string &signature)
 {
-	dprintf(D_SECURITY, "TOKEN: Will use tokens found in %s.\n", tokenfilename.c_str());
+	dprintf(D_SECURITY, "IDTOKENS: Examining %s for valid tokens from issuer %s.\n", tokenfilename.c_str(), issuer.c_str());
 
 	std::unique_ptr<FILE,decltype(&fclose)> 
 		f(safe_fopen_no_create( tokenfilename.c_str(), "r" ), fclose);


### PR DESCRIPTION
This causes HTCondor to access the token as PRIV_CONDOR when running as a daemon _unless_ we are purposely impersonating a user.  To my knowledge, the latter only happens in various user-level flocking scenarios.

This was tested by forcing a shadow to use a CCB which requires `IDTOKENS` auth; because the shadow spends most of its life as `PRIV_USER`, before this patch it would try to read the daemon's token as the unprivileged user.  Fixes #7767, reported by an OSG user.