### PR TITLE
Clear errstack after successful auth'n. #7774

### DIFF
--- a/src/condor_io/condor_secman.cpp
+++ b/src/condor_io/condor_secman.cpp
@@ -2128,6 +2128,10 @@ SecManStartCommand::authenticate_inner_finish()
 		SecMan::sec_feat_act will_enable_enc   = m_sec_man.sec_lookup_feat_act( m_auth_info, ATTR_SEC_ENCRYPTION );
 		SecMan::sec_feat_act will_enable_mac   = m_sec_man.sec_lookup_feat_act( m_auth_info, ATTR_SEC_INTEGRITY );
 
+			// We've successfully authenticated; clear out any prior authentication errors
+			// so they don't affect future messages in the stack.
+		m_errstack->clear();
+
 		if (will_enable_mac == SecMan::SEC_FEAT_ACT_YES) {
 
 			if (!m_private_key) {


### PR DESCRIPTION
After we have successfully authenticated, we should clear out the error state object.  Otherwise, any prior authentication failure is included in the error stack resulting in a confusing error message for authorization failures.

Before, on a failed `condor_submit`:
```
ERROR: Failed to connect to local queue manager
SECMAN:2010:Received "DENIED" from server for user build@07a87ab21a6b using method FS.
AUTHENTICATE:1004:Failed to authenticate using KERBEROS
```

(Here, I had included `KERBEROS` as the first authentication protocol even though it is guaranteed to fail in my setup.)

After:
```
ERROR: Failed to connect to local queue manager
SECMAN:2010:Received "DENIED" from server for user build@07a87ab21a6b using method FS.
```