### PR TITLE
Add mapping capabilities for non-local accounting groups

### DIFF
--- a/src/condor_negotiator.V6/matchmaker.cpp
+++ b/src/condor_negotiator.V6/matchmaker.cpp
@@ -3712,9 +3712,8 @@ Matchmaker::TransformSubmitterAd(classad::ClassAd &ad)
 	auto accounting_domain = submitter_name.substr(last_at + 1);
 
 	std::vector<classad::ExprTree*> args;
-	args.reserve(2);
-	args.push_back(classad::Literal::MakeString("GROUP_PREFIX"));
-	args.push_back(classad::Literal::MakeString(accounting_domain));
+	args.emplace_back(classad::Literal::MakeString("GROUP_PREFIX"));
+	args.emplace_back(classad::Literal::MakeString(accounting_domain));
 	std::unique_ptr<ExprTree> fnCall(classad::FunctionCall::MakeFunctionCall("userMap", args));
 
 	classad::Value val;

--- a/src/condor_negotiator.V6/matchmaker.cpp
+++ b/src/condor_negotiator.V6/matchmaker.cpp
@@ -1578,7 +1578,7 @@ negotiationTime ()
 							NegotiatorInterval);
 		dprintf(D_FULLDEBUG,
 			"New cycle requested but just finished one -- delaying %lu secs\n",
-			cycle_delay - elapsed);
+			static_cast<long unsigned>(cycle_delay - elapsed));
 		return;
 	}
 

--- a/src/condor_negotiator.V6/matchmaker.cpp
+++ b/src/condor_negotiator.V6/matchmaker.cpp
@@ -3701,14 +3701,20 @@ Matchmaker::TransformSubmitterAd(classad::ClassAd &ad)
 		return true;
 	}
 
-	std::string authenticated_identity;
-	if (!ad.EvaluateAttrString(ATTR_AUTHENTICATED_IDENTITY, authenticated_identity)) {
+	std::string submitter_name;
+	if (!ad.EvaluateAttrString(ATTR_NAME, submitter_name)) {
 		return true;
 	}
+	auto last_at = submitter_name.find_last_of('@');
+	if (last_at == std::string::npos) {
+		return true;
+	}
+	auto accounting_domain = submitter_name.substr(last_at + 1);
+
 	std::vector<classad::ExprTree*> args;
 	args.reserve(2);
 	args.push_back(classad::Literal::MakeString("GROUP_PREFIX"));
-	args.push_back(ad.LookupExpr(ATTR_AUTHENTICATED_IDENTITY)->Copy());
+	args.push_back(classad::Literal::MakeString(accounting_domain));
 	std::unique_ptr<ExprTree> fnCall(classad::FunctionCall::MakeFunctionCall("userMap", args));
 
 	classad::Value val;

--- a/src/condor_negotiator.V6/matchmaker.h
+++ b/src/condor_negotiator.V6/matchmaker.h
@@ -242,6 +242,11 @@ class Matchmaker : public Service
 		void calculateNormalizationFactor (ClassAdListDoesNotDeleteAds &submitterAds, double &max, double &normalFactor,
 										   double &maxAbs, double &normalAbsFactor);
 
+			// Take a submitter ad from the collector and apply any changes necessary.
+			// For example, we can change the submitter name based on the authenticated
+			// identity in the collector.
+		bool TransformSubmitterAd(classad::ClassAd &ad);
+
 		// Check to see if any concurrency limit is violated with the given set of limits.
 		// *Note* limits will be changed to lower-case.
 		bool rejectForConcurrencyLimits(std::string &limits);

--- a/src/condor_schedd.V6/qmgmt.cpp
+++ b/src/condor_schedd.V6/qmgmt.cpp
@@ -7641,12 +7641,24 @@ int get_job_prio(JobQueueJob *job, const JOB_ID_KEY & jid, void *)
 		// don't want for this purpose...
 	job->LookupString(ATTR_ACCOUNTING_GROUP, powner, cremain);  // TODDCORE
 	if (*powner == '\0') {
-		job->LookupString(attr_JobUser, powner, cremain);
+		std::string job_user;
+		job->LookupString(attr_JobUser, job_user);
+		auto last_at = job_user.find_last_of('@');
+		auto accounting_domain = scheduler.accountingDomain();
+		if (last_at != std::string::npos && !accounting_domain.empty()) {
+			strncat(powner, job_user.substr(0, last_at).c_str(), cremain);
+			cremain -= last_at;
+			strncat(powner, "@", cremain); cremain--;
+			strncat(powner, accounting_domain.c_str(), cremain);
+		} else {
+			strncat(powner, job_user.c_str(), cremain);
+		}
 	} else if (user_is_the_new_owner) {
 		// AccountingGroup does not include a domain, but it needs to for this code
-		if (scheduler.uidDomain()) {
-			strcat(powner, "@");
-			strcat(powner, scheduler.uidDomain());
+		auto accounting_domain = scheduler.accountingDomain();
+		if (!accounting_domain.empty()) {
+			strncat(powner, "@", cremain); cremain--;
+			strncat(powner, accounting_domain.c_str(), cremain);
 		}
 	}
 

--- a/src/condor_schedd.V6/scheduler.h
+++ b/src/condor_schedd.V6/scheduler.h
@@ -691,6 +691,7 @@ class Scheduler : public Service
 	char*			shadowSockSinful( void ) { return MyShadowSockName; };
 	int				aliveInterval( void ) const { return alive_interval; };
 	char*			uidDomain( void ) { return UidDomain; };
+	std::string 		accountingDomain() const { return AccountingDomain; };
 	int				getMaxMaterializedJobsPerCluster() const { return MaxMaterializedJobsPerCluster; }
 	bool			getAllowLateMaterialize() const { return AllowLateMaterialize; }
 	bool			getNonDurableLateMaterialize() const { return NonDurableLateMaterialize; }
@@ -961,6 +962,7 @@ private:
 	char*			Mail;
 	char*			AccountantName;
     char*			UidDomain;
+	std::string		AccountingDomain;
 
 	// connection variables
 	struct sockaddr_in	From;

--- a/src/condor_tools/user_prio.cpp
+++ b/src/condor_tools/user_prio.cpp
@@ -659,6 +659,30 @@ main(int argc, const char* argv[])
       exit(1);
     }
 
+    auto version = sock->get_peer_version();
+    if (version && version->built_since_version(8, 9, 9)) {
+        sock->decode();
+        classad::ClassAd ad;
+        if (!getClassAd(sock, ad) || !sock->end_of_message()) {
+            fprintf(stderr, "failed to get priority factor response from negotiator\n");
+            exit(1);
+        }
+        int intVal;
+        if (!ad.EvaluateAttrInt(ATTR_ERROR_CODE, intVal)) {
+            fprintf(stderr, "failed to get error code from negotiator\n");
+            exit(1);
+        }
+        if (intVal) {
+            std::string errorMsg;
+            if (ad.EvaluateAttrString(ATTR_ERROR_STRING, errorMsg)) {
+                fprintf(stderr, "set priority factor failed: %s\n", errorMsg.c_str());
+            } else {
+                fprintf(stderr, "set priority factor failed with error code %d\n", intVal);
+            }
+            exit(1);
+        }
+    }
+
     sock->close();
     delete sock;
 

--- a/src/condor_tools/user_prio.cpp
+++ b/src/condor_tools/user_prio.cpp
@@ -1512,7 +1512,7 @@ static const struct {
    { DetailPriority,  12, "Effective\0Priority" },
    { DetailRealPrio,   8, "Real\0Priority" },
    { DetailFactor,     9, "Priority\0Factor" },
-   { DetailResUsed,    6, "Whgted\0In Use" },
+   { DetailResUsed,    6, "Wghted\0In Use" },
    { DetailWtResUsed, 12, "Total Usage\0(wghted-hrs)" },
    { DetailUseTime1,  16, "Usage\0Start Time" },
    { DetailUseTime2,  16, "Last\0Usage Time" },

--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -407,6 +407,12 @@ type=string
 usage=to specify that each machine has its own UID space.
 tags=starter
 
+[ACCOUNTING_DOMAIN]
+default=$(UID_DOMAIN)
+type=string
+usage=Specifies the accounting namespace for submitters.
+tags=schedd
+
 [TRUST_UID_DOMAIN]
 default=
 type=string


### PR DESCRIPTION
This PR adds the concept of an "accounting namespace" (realized via the `ACCOUNTING_DOMAIN` variable) and allows the negotiator to map submitter ads from a remote namespace into the local one.

Additionally, it allows the negotiator administrator to delegate the management of a groups prio factors (and only that!) to an identity that otherwise only has `WRITE` access.  Note this means the `setpriofactor` RPC has evolved, allowing the negotiator to return a status code and (if needed) error message.