### PR TITLE
Ensure that the condor user is the same across containers

### DIFF
--- a/build/docker/services/base/Dockerfile
+++ b/build/docker/services/base/Dockerfile
@@ -16,9 +16,9 @@ LABEL org.label-schema.name="htcondor/base:${VERSION}-el${EL}${SUFFIX}" \
       org.label-schema.license="Apache-2.0"
 
 # Ensure that the 'condor' UID/GID matches across containers
-RUN groupadd -g 64 -r condor
-RUN useradd -r -g condor -d /var/lib/condor -s /sbin/nologin \
-    -u 64 -c "Owner of HTCondor Daemons" condor
+RUN groupadd -g 64 -r condor && \
+    useradd -r -g condor -d /var/lib/condor -s /sbin/nologin \
+      -u 64 -c "Owner of HTCondor Daemons" condor
 
 # EPEL is needed for supervisor
 # As of 2020-01-03, the GPG key must be downloaded separately

--- a/build/docker/services/base/Dockerfile
+++ b/build/docker/services/base/Dockerfile
@@ -15,6 +15,11 @@ LABEL org.label-schema.name="htcondor/base:${VERSION}-el${EL}${SUFFIX}" \
       org.label-schema.vendor="HTCondor" \
       org.label-schema.license="Apache-2.0"
 
+# Ensure that the 'condor' UID/GID matches across containers
+RUN groupadd -g 64 -r condor
+RUN useradd -r -g condor -d /var/lib/condor -s /sbin/nologin \
+    -u 64 -c "Owner of HTCondor Daemons" condor
+
 # EPEL is needed for supervisor
 # As of 2020-01-03, the GPG key must be downloaded separately
 # openssh-clients and openssh-server are for condor_ssh_to_job


### PR DESCRIPTION
Using the RedHat assigned UID/GID for the condor user