### PR TITLE
Allow fine-grained control over rgahp SSH BatchMode (SOFTWARE-4239)

### DIFF
--- a/src/condor_gridmanager/remote_gahp
+++ b/src/condor_gridmanager/remote_gahp
@@ -150,7 +150,7 @@ SSH_ARGS=()
 
 #echo "** Follows output of: ssh ${SSH_ARGS[@]} $REMOTE_USER@$REMOTE_HOSTNAME /bin/bash -c \"'GLITE_LOCATION=$REMOTE_GLITE $REMOTE_GLITE/bin/batch_gahp $*'\""
 if [ "${REMOTE_CMD}" = "batch_gahp" ] ; then
-    ssh ${SSH_ARGS[@]} $REMOTE_USER@$REMOTE_HOSTNAME /bin/bash -l -c "'GLITE_LOCATION=$REMOTE_GLITE $REMOTE_GLITE/bin/batch_gahp $*'"
+    ssh "${SSH_ARGS[@]}" $REMOTE_USER@$REMOTE_HOSTNAME /bin/bash -l -c "'GLITE_LOCATION=$REMOTE_GLITE $REMOTE_GLITE/bin/batch_gahp $*'"
     SSH_STATUS=$?
 elif [ "${REMOTE_CMD}" = "condor_ft-gahp" ] ; then
     # We need to set up a tunnel from the remote machine for the file
@@ -176,7 +176,7 @@ elif [ "${REMOTE_CMD}" = "condor_ft-gahp" ] ; then
     fi
     while ((tries-- > 0 && SSH_STATUS == 255)) ; do
         let port=${RANDOM}+32768
-        ssh ${SSH_ARGS[@]} -R $port:$GRIDMANAGER_ADDRESS $REMOTE_USER@$REMOTE_HOSTNAME /bin/bash -l -c "'echo Allocated port $port for remote forward to 1>&2 ; CONDOR_CONFIG=$REMOTE_GLITE/etc/condor_config.ft-gahp $REMOTE_GLITE/bin/condor_ft-gahp -f $*'"
+        ssh "${SSH_ARGS[@]}" -R $port:$GRIDMANAGER_ADDRESS $REMOTE_USER@$REMOTE_HOSTNAME /bin/bash -l -c "'echo Allocated port $port for remote forward to 1>&2 ; CONDOR_CONFIG=$REMOTE_GLITE/etc/condor_config.ft-gahp $REMOTE_GLITE/bin/condor_ft-gahp -f $*'"
         SSH_STATUS=$?
     done
 else

--- a/src/condor_gridmanager/remote_gahp
+++ b/src/condor_gridmanager/remote_gahp
@@ -46,7 +46,7 @@ Options: \n \
  --rgahp-nopass \t\tno passphrase protecting ssh private key (same as empty rgahp-pass)\n \
  --rgahp-glite PATH \tpath to the directory of the script (~/bosco/glite)\n \
  --rgahp-script SCRIPT \tpath to script to start up blahp (PATH/bin/batch_gahp)\n \
- --rgahp-nobatchmode \t\tDisable SSH BatchMode (yes)\n \
+ --rgahp-nobatchmode \t\tDisable SSH BatchMode \n \
  --help, -h \t\t\tprint this\n \
  remote_hostname: USER@HOST same string that can be used to ssh to the host\n \
  remote arguments are passed to the REMOTE_CMD

--- a/src/condor_gridmanager/remote_gahp
+++ b/src/condor_gridmanager/remote_gahp
@@ -30,6 +30,8 @@ REMOTE_GLITE="~/bosco/glite"
 # We do this in case $HOME isn't set properly
 PASSPHRASE_LOCATION=`echo ~/.bosco/.pass`
 PRIVATE_KEY_LOCATION=`echo ~/.ssh/bosco_key.rsa`
+# Set 'ssh -o BatchMode yes' by default so we fail if a password is requested
+SSH_BATCHMODE=yes
 
 
 # Parse command line arguments 
@@ -44,6 +46,7 @@ Options: \n \
  --rgahp-nopass \t\tno passphrase protecting ssh private key (same as empty rgahp-pass)\n \
  --rgahp-glite PATH \tpath to the directory of the script (~/bosco/glite)\n \
  --rgahp-script SCRIPT \tpath to script to start up blahp (PATH/bin/batch_gahp)\n \
+ --rgahp-nobatchmode \t\tDisable SSH BatchMode (yes)\n \
  --help, -h \t\t\tprint this\n \
  remote_hostname: USER@HOST same string that can be used to ssh to the host\n \
  remote arguments are passed to the REMOTE_CMD
@@ -68,6 +71,8 @@ while [ $# != 0 ] ; do
             shift 2;;
         --rgahp-script ) REMOTE_CMD="$2"
             shift 2;;
+        --rgahp-nobatchmode ) SSH_BATCHMODE=no
+            shift ;;
         --rgahp-* ) echo "Unknown option: $1" 1>&2
             echo -e "$USAGE"
             exit 1;;
@@ -138,10 +143,14 @@ fi
 # remove hostname from arglist
 shift
 
-# use BatchMode so we fail if a password is requested
-#echo "** Follows output of: ssh -o \"BatchMode yes\" $REMOTE_USER@$REMOTE_HOSTNAME /bin/bash -c \"'GLITE_LOCATION=$REMOTE_GLITE $REMOTE_GLITE/bin/batch_gahp $*'\""
+SSH_ARGS=()
+# Some HPCs require a PIN when specifying "-o BatchMode yes", so we should allow users
+# https://opensciencegrid.atlassian.net/browse/SOFTWARE-4239
+[[ $SSH_BATCHMODE == "yes" ]] && SSH_ARGS+=(-o "BatchMode yes")
+
+#echo "** Follows output of: ssh ${SSH_ARGS[@]} $REMOTE_USER@$REMOTE_HOSTNAME /bin/bash -c \"'GLITE_LOCATION=$REMOTE_GLITE $REMOTE_GLITE/bin/batch_gahp $*'\""
 if [ "${REMOTE_CMD}" = "batch_gahp" ] ; then
-    ssh -o "BatchMode yes" $REMOTE_USER@$REMOTE_HOSTNAME /bin/bash -l -c "'GLITE_LOCATION=$REMOTE_GLITE $REMOTE_GLITE/bin/batch_gahp $*'"
+    ssh ${SSH_ARGS[@]} $REMOTE_USER@$REMOTE_HOSTNAME /bin/bash -l -c "'GLITE_LOCATION=$REMOTE_GLITE $REMOTE_GLITE/bin/batch_gahp $*'"
     SSH_STATUS=$?
 elif [ "${REMOTE_CMD}" = "condor_ft-gahp" ] ; then
     # We need to set up a tunnel from the remote machine for the file
@@ -160,14 +169,14 @@ elif [ "${REMOTE_CMD}" = "condor_ft-gahp" ] ; then
     GRIDMANAGER_ADDRESS=`echo "$CONDOR_INHERIT" | sed 's/[^<]*<\([^?>]*\).*/\1/'`
     SSH_STATUS=255
     if [[ `ssh -V 2>&1` =~ ^OpenSSH_[5-9].* ]] ; then
-        SSH_ARGS="-o ExitOnForwardFailure=yes"
+        SSH_ARGS+=(-o ExitOnForwardFailure=yes)
         tries=3
     else
         tries=1
     fi
     while ((tries-- > 0 && SSH_STATUS == 255)) ; do
         let port=${RANDOM}+32768
-        ssh $SSH_ARGS -R $port:$GRIDMANAGER_ADDRESS -o "BatchMode yes" $REMOTE_USER@$REMOTE_HOSTNAME /bin/bash -l -c "'echo Allocated port $port for remote forward to 1>&2 ; CONDOR_CONFIG=$REMOTE_GLITE/etc/condor_config.ft-gahp $REMOTE_GLITE/bin/condor_ft-gahp -f $*'"
+        ssh ${SSH_ARGS[@]} -R $port:$GRIDMANAGER_ADDRESS $REMOTE_USER@$REMOTE_HOSTNAME /bin/bash -l -c "'echo Allocated port $port for remote forward to 1>&2 ; CONDOR_CONFIG=$REMOTE_GLITE/etc/condor_config.ft-gahp $REMOTE_GLITE/bin/condor_ft-gahp -f $*'"
         SSH_STATUS=$?
     done
 else


### PR DESCRIPTION
When connecting to some HPCs with "-o BatchMode yes", we get kicked to
a password or PIN prompt. This gives administrators an option of
disabling BatchMode

https://opensciencegrid.atlassian.net/browse/SOFTWARE-4239