### PR TITLE
Fix Python invocation in bosco_cluster per TimT

### DIFF
--- a/src/condor_contrib/bosco/bosco_cluster
+++ b/src/condor_contrib/bosco/bosco_cluster
@@ -253,7 +253,7 @@ ssh_find_remote () {
     # Find the platform of the remote host
     # 1. remote host
     remote_host=$1
-    cmd_out=`ssh $remote_host "python -c \"import sys; import platform; mydist = platform.dist(); print('%s %s%s' % (sys.platform, mydist[0], mydist[1]))\"" 2>/dev/null`
+    cmd_out=`ssh $remote_host "python3 -c \"import sys; import platform; mydist = platform.dist(); print('%s %s%s' % (sys.platform, mydist[0], mydist[1]))\"" 2>/dev/null`
     if [ $? -eq 0 ]; then
         # check for linux
         case "$cmd_out" in 


### PR DESCRIPTION
One other place to worry about is: https://github.com/htcondor/htcondor/blob/master/src/condor_contrib/bosco/bosco_cluster#L326. Though it's not clear to me what the right thing to do is since we don't necessarily know what version of Python they're running on the remote host