### PR TITLE
Use the latest Bosco tarball for Ubuntu (SOFTWARE-4337)

### DIFF
--- a/src/condor_contrib/bosco/bosco_findplatform
+++ b/src/condor_contrib/bosco/bosco_findplatform
@@ -31,7 +31,7 @@ URL_DICT={
   RH7: "https://research.cs.wisc.edu/htcondor/bosco/1.3/bosco-1.3-x86_64_RedHat7.tar.gz",
   RH8: "https://research.cs.wisc.edu/htcondor/bosco/1.3/bosco-1.3-x86_64_RedHat8.tar.gz",
   UBUNTU16: "https://research.cs.wisc.edu/htcondor/bosco/1.2/bosco-1.2-x86_64_Ubuntu16.tar.gz",
-  UBUNTU18: "https://research.cs.wisc.edu/htcondor/bosco/1.2/bosco-1.2-x86_64_Ubuntu18.tar.gz",
+  UBUNTU18: "https://research.cs.wisc.edu/htcondor/bosco/1.3/bosco-1.3-x86_64_Ubuntu18.tar.gz",
   UBUNTU20: "https://research.cs.wisc.edu/htcondor/bosco/1.2/bosco-1.2-x86_64_Ubuntu20.tar.gz",
 }
 


### PR DESCRIPTION
We'll need to set up the 1.3 -> specific version symlink as well