### PR TITLE
Skip FS check for client/server on different hosts

### DIFF
--- a/docs/admin-manual/configuration-macros.rst
+++ b/docs/admin-manual/configuration-macros.rst
@@ -9186,6 +9186,12 @@ macros are described in the :doc:`/admin-manual/security` section.
     the timeout to use for different types of commands, for example
     ``SEC_CLIENT_AUTHENTICATION_TIMEOUT``.
 
+:macro-def:`SEC_FS_SKIP_HOSTNAME_CHECK`
+    Whether the server should check that the client has the same hostname
+    and skip the ``FS`` authentication method on a mismatch.  If set to
+    ``true``, then the server will always try ``FS`` when enabled.  Deffaults
+    to ``false``.
+
 :macro-def:`SEC_PASSWORD_FILE`
     For Unix machines, the path and file name of the file containing the
     pool password for password authentication.

--- a/docs/version-history/development-release-series-89.rst
+++ b/docs/version-history/development-release-series-89.rst
@@ -19,6 +19,8 @@ New Features:
   include the batch name, if defined, and the submitting directory,
   so the user has a better idea of which job the job id is. HTCONDOR-71
 
+- Enhance the filesystem authentication method so it will not be attempted
+  if the client and server are not on the same host. :jira:`87`
 
 Bugs Fixed:
 

--- a/src/condor_includes/condor_attributes.h
+++ b/src/condor_includes/condor_attributes.h
@@ -74,6 +74,7 @@
 #define ATTR_CAPABILITY  "Capability"
 #define ATTR_CE_REQUIREMENTS  "CERequirements"
 #define ATTR_CLAIM_STARTD  "ClaimStartd"
+#define ATTR_CLIENT_HOSTNAME "ClientHostname"
 #define ATTR_COD_CLAIMS  "CODClaims"
 #define ATTR_COLLECTOR_HOST  "CollectorHost"
 #define ATTR_COMMAND  "Command"

--- a/src/condor_includes/condor_auth_fs.h
+++ b/src/condor_includes/condor_auth_fs.h
@@ -54,6 +54,14 @@ class Condor_Auth_FS : public Condor_Auth_Base {
     // RETURNS: 1 -- true; 0 -- false
     //------------------------------------------
 
+    /**
+     *  Metadata needed prior to starting authorization
+     *
+     *  If the client and server don't appear to be on the same machine, then we
+     *  will return false and remove FS from the list of  protocols.
+     */
+    static bool preauth_metadata(classad::ClassAd &ad, const classad::ClassAd *cli_ad, const classad::ClassAd *srv_ad);
+
  private:
 
 	std::string m_new_dir;

--- a/src/condor_includes/condor_auth_passwd.h
+++ b/src/condor_includes/condor_auth_passwd.h
@@ -152,8 +152,11 @@ class Condor_Auth_Passwd : public Condor_Auth_Base {
 		const std::vector<std::string> &authz_list, long lifetime, std::string &token,
 		int ident, CondorError *err);
 
-	/** Metadata needed prior to starting authorization */
-	static bool preauth_metadata(classad::ClassAd &ad);
+	/**
+         *  Metadata needed prior to starting authorization
+         *  Currently the client and server ad are ignored.
+         */
+	static bool preauth_metadata(classad::ClassAd &ad, const classad::ClassAd *cli_ad, const classad::ClassAd *srv_ad);
 
 	void set_remote_issuer(const std::string &issuer) {m_server_issuer = issuer;}
 	void set_remote_keys(const std::vector<std::string> &keys);

--- a/src/condor_includes/condor_secman.h
+++ b/src/condor_includes/condor_secman.h
@@ -315,7 +315,10 @@ public:
 		// Once the authentication methods are known, fill in metadata from
 		// the relevant subclass; this may allow the remote client to skip a
 		// authentication which has no chance to succeed.
-	void UpdateAuthenticationMetadata(ClassAd &ad);
+		//
+		// If available (i.e., during the server-side reconcilation of security policies),
+		// the security policy ads from the client and server will be available.
+	void UpdateAuthenticationMetadata(ClassAd &ad, const ClassAd *cli_ad, const ClassAd *srv_ad);
 
 	// Attributes for cached Security Policy Ad
 	DCpermission m_cached_auth_level;

--- a/src/condor_io/condor_auth_passwd.cpp
+++ b/src/condor_io/condor_auth_passwd.cpp
@@ -2818,7 +2818,7 @@ Condor_Auth_Passwd::key_strength_bytes() const
 
 
 bool
-Condor_Auth_Passwd::preauth_metadata(classad::ClassAd &ad)
+Condor_Auth_Passwd::preauth_metadata(classad::ClassAd &ad, const classad::ClassAd * /*cli_ad*/, const classad::ClassAd * /*srv_ad*/)
 {
 	dprintf(D_SECURITY, "Inserting pre-auth metadata for TOKEN.\n");
 	std::vector<std::string> creds;

--- a/src/condor_io/condor_crypt.cpp
+++ b/src/condor_io/condor_crypt.cpp
@@ -96,8 +96,6 @@ Condor_Crypto_State::~Condor_Crypto_State() {
 }
 
 void Condor_Crypto_State::reset() {
-    dprintf(D_SECURITY | D_VERBOSE, "CRYPTO: resetting m_ivec(len %i) and m_num\n", m_ivec_len);
-
     if(m_ivec) {
 	memset(m_ivec, 0, m_ivec_len);
     }

--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -2473,6 +2473,11 @@ default=
 type=string
 tags=misc_utils
 
+[SEC_FS_SKIP_HOSTNAME_CHECK]
+default=false
+type=string
+tags=condor_auth_fs
+
 [SEC_PASSWORD_FILE]
 default=$(SEC_PASSWORD_DIRECTORY)/POOL
 type=string


### PR DESCRIPTION
This PR causes the client to advertise its hostname in the pre-auth classad handshake and the server to compare the remote hostname versus the local one.

If there's a mismatch, the server will remove `FS` from the list of potential authentication methods.  If the client doesn't advertise the hostname, then the server always tries `FS`.

The prior behavior (always try `FS`), can be restored by setting `SEC_FS_SKIP_HOSTNAME_CHECK=true` in the server config.