### PR TITLE
Skip boost configuration completely if not building python bindings

### DIFF
--- a/externals/bundles/boost/1.68.0/CMakeLists.txt
+++ b/externals/bundles/boost/1.68.0/CMakeLists.txt
@@ -16,6 +16,9 @@
  #
  ###############################################################
 
+# boost is only used for python bindings
+if(WITH_PYTHON_BINDINGS)
+
 # Search for system's boost libraries.
 if (WINDOWS)
 	condor_pre_external( BOOST boost-1.68.0 "lib;boost" "done")
@@ -201,3 +204,5 @@ if (BOOST_VER)
 else(BOOST_VER)
 	message (WARNING "**boost not found **")
 endif(BOOST_VER)
+
+endif(WITH_PYTHON_BINDINGS)


### PR DESCRIPTION
I presume `boost` used to be used for other things, but right now its only used for python bindings. This patch modifies the latest external boost configuration to skip _everything_ if the builder disabled the python bindings.

This is deliberately the laziest possible implementation, mainly to have a minimal diff, so I'm happy to make it 'better' if asked (indentation, etc).