### PR TITLE
Provide a transform mechanism for collector ads. HTCONDOR-93

### DIFF
--- a/src/condor_collector.V6/CMakeLists.txt
+++ b/src/condor_collector.V6/CMakeLists.txt
@@ -32,6 +32,7 @@ set(CollectorLibSrcs
 	collector_engine.cpp
 	view_server.cpp
 	collector.cpp
+        ad_transforms.cpp
 )
 
 #

--- a/src/condor_collector.V6/ad_transforms.cpp
+++ b/src/condor_collector.V6/ad_transforms.cpp
@@ -1,0 +1,127 @@
+/***************************************************************
+ *
+ * Copyright (C) 1990-2020, Condor Team, Computer Sciences Department,
+ * University of Wisconsin-Madison, WI.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "condor_common.h"
+#include "condor_debug.h"
+#include "condor_config.h"
+#include "ad_transforms.h"
+#include "condor_attributes.h"
+
+constexpr char AdTransforms::m_param_prefix[];
+
+void 
+AdTransforms::config()
+{
+	int rval;
+
+	// Setup xform_utils hashtable, and record a ckpt
+	m_mset.clear();
+	m_mset.init();
+	m_mset_ckpt = m_mset.save_state();
+
+	m_transforms_list.clear();
+
+	std::string adtransNames;
+	if( !param( adtransNames, (std::string(m_param_prefix) + "_TRANSFORM_NAMES").c_str() ) ) {
+		return;
+	}
+	StringList nameList(adtransNames.c_str());
+	nameList.rewind();
+	const char *name = nullptr;
+	while( (name = nameList.next()) ) {
+
+		if (!strcasecmp(name, "NAMES") ) { continue; }  // prevent recursion!
+
+		std::string attributeName = std::string(m_param_prefix) + "_TRANSFORM_" + name;
+
+		// fetch unexpanded param, we will only expand it now for the old (classad) style transforms.
+		const char * raw_transform_text = param_unexpanded(attributeName.c_str());
+		if (!raw_transform_text) {
+			dprintf(D_ALWAYS, (std::string(m_param_prefix) + "_TRANSFORM_%s not defined, ignoring.\n").c_str(), name);
+			continue;
+		}
+
+		std::unique_ptr<MacroStreamXFormSource> xfm(new MacroStreamXFormSource(name));
+
+		// Always assume that the native xform is used, not the
+		// new-ClassAd style used by the JobRouter and JOB_TRANSFORM_*
+		std::string errmsg = "";
+		int offset = 0;
+		if ( (rval=xfm->open(raw_transform_text, offset, errmsg)) < 0 ) {
+			dprintf(D_ALWAYS, (std::string(m_param_prefix) + "_TRANSFORM_%s macro stream malformed, ignoring. (err=%d) %s\n").c_str(),
+				name, rval, errmsg.c_str());
+			continue;
+		}
+
+		// Finally, append the xfm to the end our list (order is important here!)
+		m_transforms_list.emplace_back(std::move(xfm));
+		std::string xfm_text;
+		dprintf(D_ALWAYS, 
+			(std::string(m_param_prefix) + "_TRANSFORM_%s setup as transform rule #%lu :\n%s\n").c_str(),
+			name, m_transforms_list.size(), m_transforms_list.back()->getFormattedText(xfm_text, "\t") );
+	}
+}
+
+int
+AdTransforms::transform(ClassAd *ad, CondorError *errorStack)
+{
+	if (!shouldTransform()) {return 0;}
+
+	int transforms_applied = 0;
+	int transforms_considered = 0;
+	StringList attrs_changed;
+	int rval;
+	std::string errmsg;
+	std::string applied_names;
+
+	// Revert variables hashtable so it doesn't grow idefinitely
+	m_mset.rewind_to_state(m_mset_ckpt, false);
+
+	// Apply our ordered list of transforms to the ad, changing it in-place.
+	for (const auto &xfm : m_transforms_list) {
+		transforms_considered++;
+
+		if (!xfm->matches(ad)) {continue;}
+
+		rval = TransformClassAd(ad, *xfm, m_mset, errmsg);
+
+		if (rval < 0) {
+			dprintf(D_ALWAYS,
+				"ad transforms: ERROR applying transform %s (err=-3,rval=%d,msg=%s)\n",
+				xfm->getName(), rval, errmsg.c_str());
+			if (errorStack)
+				errorStack->pushf("TRANSFORM", 3, "ERROR applying transform %s: %s",
+					xfm->getName(), errmsg.c_str());
+			return -3;
+		} 
+
+		if (IsFulldebug(D_FULLDEBUG)) {
+			if (transforms_applied) applied_names += ",";
+			applied_names += xfm->getName();
+		}
+		transforms_applied++;
+	}
+	
+	dprintf( D_FULLDEBUG,
+		"ad transform: %d considered, %d applied (%s)\n",
+		transforms_considered, transforms_applied,
+		transforms_applied > 0 ? applied_names.c_str() : "<none>" );
+
+	return 0;
+}

--- a/src/condor_collector.V6/ad_transforms.h
+++ b/src/condor_collector.V6/ad_transforms.h
@@ -1,0 +1,48 @@
+/***************************************************************
+ *
+ * Copyright (C) 1990-2020, Condor Team, Computer Sciences Department,
+ * University of Wisconsin-Madison, WI.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#ifndef _CONDOR_AD_TRANSFORMS_H
+#define _CONDOR_AD_TRANSFORMS_H
+
+#include <vector>
+#include <memory>
+
+#include "xform_utils.h"
+
+class AdTransforms {
+	public:
+		AdTransforms() {}
+		~AdTransforms() {}
+
+		void config();
+
+		int transform(ClassAd *ad, CondorError *errorStack);
+
+		bool shouldTransform() { return !m_transforms_list.empty(); }
+
+	private:
+		std::vector<std::unique_ptr<MacroStreamXFormSource>> m_transforms_list;
+		XFormHash m_mset;
+			// m_mset owns this pointer; we do not manage it.
+		MACRO_SET_CHECKPOINT_HDR *m_mset_ckpt;
+
+		static constexpr char m_param_prefix[] = "FORWARD_AD";
+};
+
+#endif

--- a/src/condor_collector.V6/collector.cpp
+++ b/src/condor_collector.V6/collector.cpp
@@ -119,6 +119,8 @@ int CollectorDaemon::pending_query_workers = 0;
 bool CollectorDaemon::want_track_queries_by_subsys = false;
 #endif
 
+AdTransforms CollectorDaemon::m_ad_xfm;
+
 //---------------------------------------------------------
 
 
@@ -1992,6 +1994,9 @@ void CollectorDaemon::Config()
 	}
 
 	forwardClaimedPrivateAds = param_boolean("COLLECTOR_FORWARD_CLAIMED_PRIVATE_ADS", true);
+
+	m_ad_xfm.config();
+
 	return;
 }
 
@@ -2202,6 +2207,10 @@ CollectorDaemon::forward_classad_to_view_collector(int cmd,
 		dprintf( D_FULLDEBUG, "Trying to forward ad on, but %s=False\n", ATTR_SHOULD_FORWARD );
 		return;
 	}
+
+	// Transform ad
+	//
+	m_ad_xfm.transform(theAd, nullptr);
 
     for (auto e(vc_list.begin());  e != vc_list.end();  ++e) {
         DCCollector* view_coll = e->collector;

--- a/src/condor_collector.V6/collector.h
+++ b/src/condor_collector.V6/collector.h
@@ -31,6 +31,7 @@
 #include "collector_stats.h"
 #include "dc_collector.h"
 #include "offline_plugin.h"
+#include "ad_transforms.h"
 
 //----------------------------------------------------------------
 // Simple job universe stats
@@ -217,6 +218,7 @@ private:
 
 	static int setAttrLastHeardFrom( ClassAd* cad, unsigned long time );
 
+	static AdTransforms m_ad_xfm;
 };
 
 #endif


### PR DESCRIPTION
This provides a way to use HTCondor's ad transform language to change ads as they are forwarded from child to parent collector.