### PR TITLE
Record server's X509 certificate for the client. HTCONDOR-43

### DIFF
--- a/src/condor_includes/condor_auth_x509.h
+++ b/src/condor_includes/condor_auth_x509.h
@@ -125,7 +125,11 @@ class Condor_Auth_X509 : public Condor_Auth_Base {
     CondorAuthX509Retval authenticate_server_gss_post(CondorError* errstack, bool non_blocking);
 	int authenticate_continue(CondorError* /*errstack*/, bool /*non_blocking*/);
 
-    char * get_server_info();
+	// Retrieve the human-readable version of the server name and, if available,
+	// the full public certificate as a PEM-formatted string.
+	//
+	// Returns false on failure.
+    bool get_server_info(std::string &name, std::string &cred);
 
 #ifdef WIN32
 	int ParseMapFile();

--- a/src/condor_includes/globus_utils.h
+++ b/src/condor_includes/globus_utils.h
@@ -245,6 +245,8 @@ typedef enum
 #ifdef HAVE_EXT_GLOBUS
 extern int (*globus_thread_set_model_ptr)(
 	const char *);
+extern globus_result_t (*globus_gsi_cred_get_cert_ptr)(
+	globus_gsi_cred_handle_t, X509 **);
 extern OM_uint32 (*globus_gss_assist_display_status_str_ptr)(
 	char **, char *, OM_uint32, OM_uint32, int);
 extern globus_result_t (*globus_gss_assist_map_and_authorize_ptr)(

--- a/src/condor_io/condor_auth_x509.cpp
+++ b/src/condor_io/condor_auth_x509.cpp
@@ -642,14 +642,13 @@ StringList * getDaemonList(char const *param_name,char const *fqh)
     return expanded_names;
 }
 
-char * Condor_Auth_X509::get_server_info()
+bool Condor_Auth_X509::get_server_info(std::string &name, std::string &cred)
 {
     OM_uint32	major_status = 0;
     OM_uint32	minor_status = 0;            
     OM_uint32   lifetime, flags;
     gss_OID     mech, name_type;
     gss_buffer_desc name_buf;
-    char *      server = NULL;
 
     if ( !m_globusActivated ) {
         return NULL;
@@ -667,7 +666,7 @@ char * Condor_Auth_X509::get_server_info()
                                        NULL);
     if (major_status != GSS_S_COMPLETE) {
         dprintf(D_SECURITY, "Unable to obtain target principal name\n");
-        return NULL;
+        return false;
     }
 
 	major_status = (*gss_display_name_ptr)(&minor_status,
@@ -676,15 +675,31 @@ char * Condor_Auth_X509::get_server_info()
 									&name_type);
 	if( major_status != GSS_S_COMPLETE) {
 		dprintf(D_SECURITY, "Unable to convert target principal name\n");
-		return NULL;
+		return false;
 	}
-
-	server = new char[name_buf.length+1];
-	memset(server, 0, name_buf.length+1);
-	memcpy(server, name_buf.value, name_buf.length);
+	name = std::string(static_cast<char*>(name_buf.value), name_buf.length);
 	(*gss_release_buffer_ptr)( &minor_status, &name_buf );
 
-    return server;
+	globus_gsi_cred_handle_t peer_cred = context_handle->peer_cred_handle->cred_handle;
+	X509 *cert_raw = NULL;
+	auto ret = (*globus_gsi_cred_get_cert_ptr)(peer_cred, &cert_raw);
+	if (ret != GLOBUS_SUCCESS) {
+		return false;
+	}
+	std::unique_ptr<X509, decltype(&X509_free)> cert(cert_raw, X509_free);
+
+	std::unique_ptr<BIO, decltype(&BIO_free)> bio(BIO_new( BIO_s_mem() ), BIO_free);
+
+	if (!PEM_write_bio_X509(bio.get(), cert.get())) {
+		return false;
+	}
+	char *pem_raw;
+	auto len = BIO_get_mem_data(bio.get(), &pem_raw);
+	if (len) {
+		cred = std::string(pem_raw, len);
+	}
+
+	return true;
 }   
 
 int Condor_Auth_X509::authenticate_self_gss(CondorError* errstack)
@@ -864,10 +879,18 @@ int Condor_Auth_X509::authenticate_client_gss(CondorError* errstack)
             goto clear; 
         }
 
-        char * server = get_server_info();
+		std::string server, cred;
+		if (!get_server_info(server, cred)) {
+			errstack->push("GSI", GSI_ERR_AUTHENTICATION_FAILED,
+				"Authentication to remote server appeared to succeed but we were unable"
+				" to extract the remote side's name");
+			dprintf(D_SECURITY, "Failed to extract a DN or hostcert from the remote server connection");
+			status = 0;
+			goto clear;
+		}
 
 		// store the raw subject name for later mapping
-		setAuthenticatedName(server);
+		setAuthenticatedName(server.c_str());
 
 		// Default to user name "gsi@unmapped".
 		// Later on, if configured, we will invoke the callout in nameGssToLocal.
@@ -898,15 +921,15 @@ int Condor_Auth_X509::authenticate_client_gss(CondorError* errstack)
         // anycase here, so if the host name and what we are looking for
         // are in different cases, then we will run into problems.
 		if( daemonNames ) {
-			status = daemonNames->contains_withwildcard(server) == TRUE? 1 : 0;
+			status = daemonNames->contains_withwildcard(server.c_str()) == TRUE? 1 : 0;
 
 			if( !status ) {
 				errstack->pushf("GSI", GSI_ERR_UNAUTHORIZED_SERVER,
 								"Failed to authenticate because the subject '%s' is not currently trusted by you.  "
-								"If it should be, add it to GSI_DAEMON_NAME or undefine GSI_DAEMON_NAME.", server);
+								"If it should be, add it to GSI_DAEMON_NAME or undefine GSI_DAEMON_NAME.", server.c_str());
 				dprintf(D_SECURITY,
 						"GSI_DAEMON_NAME is defined and the server %s is not specified in the GSI_DAEMON_NAME parameter\n",
-						server);
+						server.c_str());
 			}
 		}
 		else {
@@ -914,7 +937,7 @@ int Condor_Auth_X509::authenticate_client_gss(CondorError* errstack)
 		}
 
         if (status) {
-            dprintf(D_SECURITY, "valid GSS connection established to %s\n", server);            
+            dprintf(D_SECURITY, "valid GSS connection established to %s\n", server.c_str());
         }
 
         mySock_->encode();
@@ -925,7 +948,12 @@ int Condor_Auth_X509::authenticate_client_gss(CondorError* errstack)
             status = 0;
         }
 
-        delete [] server;
+		if (!cred.empty()) {
+			classad::ClassAd ad;
+			ad.InsertAttr("ServerPublicCert", cred);
+			mySock_->setPolicyAd(ad);
+		}
+
         delete daemonNames;
     }
  clear:

--- a/src/python-bindings/secman.cpp
+++ b/src/python-bindings/secman.cpp
@@ -286,6 +286,11 @@ SecManWrapper::ping(object locate_obj, object command_obj)
         // get_connect_addr() may return a different sinful string than was used to
         // create the socket, due to processing of things like private network interfaces.
         addr = sock->get_connect_addr();
+
+	// Get the policy stored in the socket.
+	ClassAd sock_policy;
+        sock->getPolicyAd(sock_policy);
+
         // Don't leak sock!
         delete sock;
         sock = NULL;
@@ -320,6 +325,7 @@ SecManWrapper::ping(object locate_obj, object command_obj)
         if (m_tag_set) {SecMan::setTag(origTag);}
         policy = k->policy();
         authz_ad->Update(*policy);
+	authz_ad->Update(sock_policy);
 
         return authz_ad;
 }


### PR DESCRIPTION
This records the observed X509 certificate from the server and puts it in the client's session.  With this, we can return the information to the invoking user for condor ping.

We are interested in the public cert so OSG can better debug authentication failures (and understand how widely a CA is used, for example) and allow sites to easily remotely monitor the certificate's expiration time.

@brianhlin 

Fixes: HTCONDOR-43