### PR TITLE
Improve oauth credmon default configuration

### DIFF
--- a/src/condor_credd/condor_credmon_oauth/examples/config/condor/40-oauth-credmon.conf
+++ b/src/condor_credd/condor_credmon_oauth/examples/config/condor/40-oauth-credmon.conf
@@ -17,7 +17,7 @@ use feature : OAUTH
 
 # MANDATORY for enabling the transfer of credentials from submit host
 # to execute hosts, if encryption is not already enabled.
-SEC_DEFAULT_ENCRYPTION = REQUIRED
+# SEC_DEFAULT_ENCRYPTION = REQUIRED
 
 #####################################################################################
 #

--- a/src/condor_credd/condor_credmon_oauth/examples/config/condor/40-oauth-credmon.conf
+++ b/src/condor_credd/condor_credmon_oauth/examples/config/condor/40-oauth-credmon.conf
@@ -4,14 +4,17 @@
 #
 use feature : OAUTH
 
-# MANDATORY for local credmon: Uncomment this line to have submitters
-# always create a credential (may conflict with Kerberos credmon)
+# MANDATORY for local credmon: Uncomment these lines to have submitters always
+# locally create a scitokens credential.  Job submit files then need to have
+#    use_oauth_services = scitokens
+# to send the credentials to the jobs.
 #
-# SEC_CREDENTIAL_PRODUCER = /usr/sbin/scitokens_credential_producer
+# LOCAL_CREDMON_PROVIDER_NAME = scitokens
+# SEC_PROCESS_SUBMIT_TOKENS = false
 
 # MANDATORY for enabling the transfer of credentials from submit host
 # to execute hosts, if encryption is not already enabled.
-# SEC_DEFAULT_ENCRYPTION = REQUIRED
+SEC_DEFAULT_ENCRYPTION = REQUIRED
 
 #####################################################################################
 #

--- a/src/condor_credd/condor_credmon_oauth/examples/config/condor/40-oauth-credmon.conf
+++ b/src/condor_credd/condor_credmon_oauth/examples/config/condor/40-oauth-credmon.conf
@@ -7,7 +7,10 @@ use feature : OAUTH
 # MANDATORY for local credmon: Uncomment these lines to have submitters always
 # locally create a scitokens credential.  Job submit files then need to have
 #    use_oauth_services = scitokens
-# to send the credentials to the jobs.
+# to send the credentials to the jobs,
+# or a job transform should be added to the schedd config
+# to always add `scitokens` to the list of `OAuthServicesNeeded`
+# and set `SendCredential = True`
 #
 # LOCAL_CREDMON_PROVIDER_NAME = scitokens
 # SEC_PROCESS_SUBMIT_TOKENS = false


### PR DESCRIPTION
In my testing I found that different settings were needed for the local scitokens issuer than the default configuration had in a comment.  This PR adds more helpful comments.

I also found that encryption was also always needed, so this PR uncomments that setting.  The original scitokens-credmon [Dockerfile](https://github.com/htcondor/scitokens-credmon/blob/master/Dockerfile#L58) uncommented it with a sed command.