### PR TITLE
Prevent credmon web service from crashing when looking up gdrive user

### DIFF
--- a/src/condor_credd/condor_credmon_oauth/credmon/utils/api_endpoints.py
+++ b/src/condor_credd/condor_credmon_oauth/credmon/utils/api_endpoints.py
@@ -19,7 +19,7 @@ def user(token_url):
 
     url = {
         'box':          'https://api.box.com/2.0/users/me',
-        'gdrive':       'https://www.googleapis.com/drive/v3/about',
+        'gdrive':       'https://www.googleapis.com/drive/v3/about&fields=user',
         'onedrive':     'https://graph.microsoft.com/v1.0/me',
         'dropbox':      'https://api.dropboxapi.com/2/users/get_account',
     }


### PR DESCRIPTION
I found that without this, attempting to use gdrive credentials caused a credmon python crash (in CredMonOAuthLog) when it was trying to look up the user.

I also found that even with this, refresh tokens cannot be retrieved with gdrive.  [The google API document](https://developers.google.com/identity/protocols/oauth2/web-server#creatingclient) and the [python requests-oauthlib docs](https://requests-oauthlib.readthedocs.io/en/latest/oauth2_workflow.html#web-application-flow) indicate that `access_type=offline` needs to be added to the authorization_url.  However, I tried it and got an error saying access_type was unrecognized.  I assume that's because the el7 python2-requests-oauthlib package is too old.  I do not find a corresponding rpm available with python3 on el7, so the only solution I see to make gdrive work completely is to separately install a newer version of the library.

I ended up giving up on gdrive and using box instead for testing condor-credmon-oauth.