### PR TITLE
fix last_nodes_total_check_time

### DIFF
--- a/src/condor_scripts/condor_watch_q
+++ b/src/condor_scripts/condor_watch_q
@@ -490,7 +490,7 @@ def watch_q(
                     )
                     and time.time() - last_nodes_total_check_time > 60
                 ):
-                    last_nodes_total_check_time = datetime.datetime.now()
+                    last_nodes_total_check_time = time.time()
                     (
                         batch_name_to_nodes_total,
                         cluster_ids_with_nodes_total,


### PR DESCRIPTION
I noticed the following error when running `condor_watch_q` with python 3.8 and `htcondor=8.9.10` and figured I would submit a patch as it is a simple fix.

The issue is that `last_nodes_total_check_time` is first defined using the `time` but then reassigned as a `datetime.datetime`. This PR makes sure that `time.time` is used consistently. It looks like this variable isn't used outside these few lines, so I couldn't see anything else that this might break.

```python
Processing new events...Traceback (most recent call last):
  File "***/bin/condor_watch_q", line 1402, in <module>
    cli()
  File "***/bin/condor_watch_q", line 387, in cli
    abbreviate_path_components=args.abbreviate,
  File "***/bin/condor_watch_q", line 491, in watch_q
    and time.time() - last_nodes_total_check_time > 60
TypeError: unsupported operand type(s) for -: 'float' and 'datetime.datetime'
```