### PR TITLE
Drop Python-based remote OS/distro detection (HTCONDOR-242)

### DIFF
--- a/src/condor_contrib/bosco/bosco_cluster
+++ b/src/condor_contrib/bosco/bosco_cluster
@@ -282,8 +282,8 @@ ssh_detect_linux_distro () {
     os_release=`ssh $remote_host "cat /etc/os-release" 2> /dev/null`
     [[ $? -eq 0 ]] || return 1
 
-    dist=`awk -F '=' '/^ID=/ {print $2}' <<< $os_release | tr -d '"'`
-    ver=`awk -F '=' '/^VERSION_ID=/ {print $2}' <<< $os_release | tr -d '"'`
+    dist=`echo "$os_release" | awk -F '=' '/^ID=/ {print $2}' | tr -d '"'`
+    ver=`echo "$os_release | "awk -F '=' '/^VERSION_ID=/ {print $2}' | tr -d '"'`
     major_ver="${ver%%.*}"
 
     case "$dist" in

--- a/src/condor_contrib/bosco/bosco_cluster
+++ b/src/condor_contrib/bosco/bosco_cluster
@@ -287,7 +287,7 @@ ssh_detect_linux_distro () {
     major_ver="${ver%%.*}"
 
     case "$dist" in
-        (redhat|centos)
+        (rhel|centos)
             echo "CentOS${major_ver}" ;;
         debian)
             echo "Debian${major_ver}" ;;

--- a/src/condor_contrib/bosco/bosco_cluster
+++ b/src/condor_contrib/bosco/bosco_cluster
@@ -253,31 +253,51 @@ ssh_find_remote () {
     # Find the platform of the remote host
     # 1. remote host
     remote_host=$1
-    cmd_out=`ssh $remote_host "python3 -c \"import sys; import platform; mydist = platform.dist(); print('%s %s%s' % (sys.platform, mydist[0], mydist[1]))\"" 2>/dev/null`
-    if [ $? -eq 0 ]; then
-        # check for linux
-        case "$cmd_out" in 
-            (*redhat7* | *centos7*)
-                echo "CentOS7" ;;
-            (*redhat8* | *centos8*)
-                echo "CentOS8" ;;
-            (*debian9*)
-                echo "Debian9" ;;
-            (*debian10*)
-                echo "Debian10" ;;
-            (*Ubuntu16*)
-                echo "Ubuntu16" ;;
-            (*Ubuntu18*)
-                echo "Ubuntu18" ;;
-            (*Ubuntu20*)
-                echo "Ubuntu20" ;;
-            (*darwin*)
-                echo "MacOSX" ;;
-            (*) ;;
-        esac
-        return 0
-    fi
-    return 1
+
+    # Returns 'Darwin' for Mac OS X or 'Linux'
+    detect_os=`ssh $remote_host "uname -s"`
+    [[ $? -eq 0 ]] || return 1
+
+    case "$detect_os" in
+        Linux)
+            ssh_detect_linux_distro "$remote_host"
+            return $?
+            ;;
+        Darwin)
+            echo "MacOSX"
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+
+ssh_detect_linux_distro () {
+    # Find the linux distro of the remote host
+    # 1. remote host
+    remote_host=$1
+
+    os_release=`ssh $remote_host "cat /etc/os-release" 2> /dev/null`
+    [[ $? -eq 0 ]] || return 1
+
+    dist=`awk -F '=' '/^ID=/ {print $2}' <<< $os_release | tr -d '"'`
+    ver=`awk -F '=' '/^VERSION_ID=/ {print $2}' <<< $os_release | tr -d '"'`
+    major_ver="${ver%%.*}"
+
+    case "$dist" in
+        (redhat|centos)
+            echo "CentOS${major_ver}" ;;
+        debian)
+            echo "Debian${major_ver}" ;;
+        ubuntu)
+            echo "Ubuntu${major_ver}" ;;
+        (*)
+            return 1
+            ;;
+    esac
+    return 0
 }
 
 


### PR DESCRIPTION
`platform.dist()` and `platform.linux_distribution()` were removed in Python 3.8 (equivalents are available via [distro](https://pypi.org/project/distro/)) so we need another method to detect the OS distro