### PR TITLE
Switch handshake to use ECDH for session key derivation. HTCONDOR-283

### DIFF
--- a/src/condor_daemon_core.V6/daemon_command.cpp
+++ b/src/condor_daemon_core.V6/daemon_command.cpp
@@ -927,59 +927,77 @@ DaemonCommandProtocol::CommandProtocolResult DaemonCommandProtocol::ReadCommand(
 					m_sid = strdup(tmpStr.c_str());
 
 					if (will_authenticate == SecMan::SEC_FEAT_ACT_YES) {
-
-						char *crypto_method = NULL;
-						if (!m_policy->LookupString(ATTR_SEC_CRYPTO_METHODS, &crypto_method)) {
+						std::string crypto_method;
+						if (!m_policy->LookupString(ATTR_SEC_CRYPTO_METHODS, crypto_method)) {
 							dprintf ( D_ALWAYS, "DC_AUTHENTICATE: tried to enable encryption for request from %s, but we have none!\n", m_sock->peer_description() );
-							m_result = FALSE;
+							m_result = false;
 							return CommandProtocolFinished;
 						}
+						Protocol method = SecMan::getCryptProtocolNameToEnum(crypto_method.c_str());
 
-						unsigned char* rkey = Condor_Crypt_Base::randomKey(GENERATED_KEY_LENGTH_V9);
-						unsigned char  rbuf[GENERATED_KEY_LENGTH_V9];
-						if (rkey) {
-							memcpy (rbuf, rkey, GENERATED_KEY_LENGTH_V9);
-							// this was malloced in randomKey
-							free (rkey);
+							// If the client provided a EC key, we'll respond in kind.
+						std::string peer_ec;
+						if (m_auth_info.EvaluateAttrString("ECP256pub", peer_ec)) {
+							m_peer_pubkey_encoded = peer_ec;
+							if (!(m_keyexchange = SecMan::GenerateKeyExchange(m_errstack))) {
+								dprintf(D_ALWAYS, "DC_AUTHENTICATE: Error in generating key: %s\n", m_errstack->getFullText().c_str());
+								return CommandProtocolFinished;
+							}
+							std::string encoded_pubkey;
+							if (!SecMan::EncodePubkey(m_keyexchange.get(), encoded_pubkey, m_errstack)) {
+								dprintf(D_ALWAYS, "DC_AUTHENTICATE: Error in encoded key: %s\n", m_errstack->getFullText().c_str());
+								return CommandProtocolFinished;
+							}
+							if (!m_policy->InsertAttr("ECP256pub", encoded_pubkey)) {
+								dprintf(D_ALWAYS, "DC_AUTHENTICATE: Failed to add pubkey to policy ad.\n");
+								return CommandProtocolFinished;
+							}
+
+								// We will derive the key post-authentication.
+							m_key = nullptr;
 						} else {
-							memset (rbuf, 0, GENERATED_KEY_LENGTH_V9);
-							dprintf ( D_ALWAYS, "DC_AUTHENTICATE: unable to generate key for request from %s - no crypto available!\n", m_sock->peer_description() );							
-							free( crypto_method );
-							crypto_method = NULL;
-							m_result = FALSE;
-							return CommandProtocolFinished;
+								// Server will explicitly send the key to the client during the authentication; we need
+								// to generate it first.
+
+							unsigned char* rkey = Condor_Crypt_Base::randomKey(GENERATED_KEY_LENGTH_V9);
+							unsigned char  rbuf[GENERATED_KEY_LENGTH_V9];
+							if (rkey) {
+								memcpy (rbuf, rkey, GENERATED_KEY_LENGTH_V9);
+								// this was malloced in randomKey
+								free (rkey);
+							} else {
+								memset (rbuf, 0, GENERATED_KEY_LENGTH_V9);
+								dprintf ( D_ALWAYS, "DC_AUTHENTICATE: unable to generate key for request from %s - no crypto available!\n", m_sock->peer_description() );
+								m_result = FALSE;
+								return CommandProtocolFinished;
+							}
+							switch (method) {
+								case CONDOR_BLOWFISH:
+									dprintf (D_SECURITY, "DC_AUTHENTICATE: generating BLOWFISH key for session %s...\n", m_sid);
+									m_key = new KeyInfo(rbuf, GENERATED_KEY_LENGTH_OLD, CONDOR_BLOWFISH, 0);
+									break;
+								case CONDOR_3DES:
+									dprintf (D_SECURITY, "DC_AUTHENTICATE: generating 3DES key for session %s...\n", m_sid);
+									m_key = new KeyInfo(rbuf, GENERATED_KEY_LENGTH_OLD, CONDOR_3DES, 0);
+									break;
+								case CONDOR_AESGCM: {
+									dprintf (D_SECURITY, "DC_AUTHENTICATE: generating AES-GCM key for session %s...\n", m_sid);
+									m_key = new KeyInfo(rbuf, GENERATED_KEY_LENGTH_V9, CONDOR_AESGCM, 0);
+									}
+									break;
+								default:
+									dprintf (D_SECURITY, "DC_AUTHENTICATE: generating RANDOM key for session %s...\n", m_sid);
+									m_key = new KeyInfo(rbuf, GENERATED_KEY_LENGTH_OLD, CONDOR_NO_PROTOCOL, 0);
+									break;
+							}
+
+							if (!m_key) {
+								m_result = FALSE;
+								return CommandProtocolFinished;
+							}
+
+							m_sec_man->key_printf (D_SECURITY, m_key);
 						}
-
-						Protocol method = SecMan::getCryptProtocolNameToEnum(crypto_method);
-						switch (method) {
-							case CONDOR_BLOWFISH:
-								dprintf (D_SECURITY, "DC_AUTHENTICATE: generating BLOWFISH key for session %s...\n", m_sid);
-								m_key = new KeyInfo(rbuf, GENERATED_KEY_LENGTH_OLD, CONDOR_BLOWFISH, 0);
-								break;
-							case CONDOR_3DES:
-								dprintf (D_SECURITY, "DC_AUTHENTICATE: generating 3DES key for session %s...\n", m_sid);
-								m_key = new KeyInfo(rbuf, GENERATED_KEY_LENGTH_OLD, CONDOR_3DES, 0);
-								break;
-							case CONDOR_AESGCM: {
-								dprintf (D_SECURITY, "DC_AUTHENTICATE: generating AES-GCM key for session %s...\n", m_sid);
-								m_key = new KeyInfo(rbuf, GENERATED_KEY_LENGTH_V9, CONDOR_AESGCM, 0);
-								}
-								break;
-							default:
-								dprintf (D_SECURITY, "DC_AUTHENTICATE: generating RANDOM key for session %s...\n", m_sid);
-								m_key = new KeyInfo(rbuf, GENERATED_KEY_LENGTH_OLD, CONDOR_NO_PROTOCOL, 0);
-								break;
-						}
-
-						free( crypto_method );
-						crypto_method = NULL;
-
-						if (!m_key) {
-							m_result = FALSE;
-							return CommandProtocolFinished;
-						}
-
-						m_sec_man->key_printf (D_SECURITY, m_key);
 
 						// Update the session policy to reflect the
 						// crypto method we're using
@@ -1005,6 +1023,8 @@ DaemonCommandProtocol::CommandProtocolResult DaemonCommandProtocol::ReadCommand(
 						m_result = FALSE;
 						return CommandProtocolFinished;
 					}
+					// We don't need our encoded pubkey anymore
+					m_policy->Delete("ECP256pub");
 					m_sock->decode();
 				} else {
 					dprintf( D_SECURITY, "SECMAN: Enact was '%s', not sending response.\n",
@@ -1199,6 +1219,29 @@ DaemonCommandProtocol::CommandProtocolResult DaemonCommandProtocol::Authenticate
 	if( auth_success ) {
 		dprintf (D_SECURITY, "DC_AUTHENTICATE: authentication of %s complete.\n", m_sock->peer_ip_str());
 		m_sock->getPolicyAd(*m_policy);
+
+		if (m_keyexchange) {
+			std::string crypto_method;
+			if (!m_policy->LookupString(ATTR_SEC_CRYPTO_METHODS, crypto_method)) {
+				dprintf ( D_ALWAYS, "DC_AUTHENTICATE: No crypto methods enabled for request from %s.\n", m_sock->peer_description() );
+				m_result = false;
+				return CommandProtocolFinished;
+			}
+			Protocol method = SecMan::getCryptProtocolNameToEnum(crypto_method.c_str());
+
+			size_t keylen = method == CONDOR_AESGCM ? GENERATED_KEY_LENGTH_V9 : GENERATED_KEY_LENGTH_OLD;
+			std::unique_ptr<unsigned char, decltype(&free)> rbuf(
+				static_cast<unsigned char *>(malloc(keylen)),
+				&free);
+			if (!SecMan::FinishKeyExchange(std::move(m_keyexchange), m_peer_pubkey_encoded.c_str(), rbuf.get(), keylen, m_errstack)) {
+				dprintf(D_ALWAYS, "DC_AUTHENTICATE: Failed to generate a symmetric key for session with %s: %s.\n", m_sock->peer_description(), m_errstack->getFullText().c_str());
+				m_result = false;
+				return CommandProtocolFinished;
+			}
+
+			dprintf (D_SECURITY, "DC_AUTHENTICATE: generating %s key for session %s...\n", crypto_method.c_str(), m_sid);
+			m_key = new KeyInfo(rbuf.get(), keylen, method, 0);
+		}
 	}
 	else {
 		bool auth_required = true;

--- a/src/condor_daemon_core.V6/daemon_command.h
+++ b/src/condor_daemon_core.V6/daemon_command.h
@@ -83,6 +83,11 @@ private:
 	int m_cmd_index;
 	CondorError *m_errstack;
 
+		// The base64-encoded copy of our peer's public key (for key exchange).
+	std::string m_peer_pubkey_encoded;
+		// Our keypair for key exchange.
+	std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> m_keyexchange{nullptr, &EVP_PKEY_free};
+
 	bool m_new_session;
 	SecMan::sec_feat_act m_will_enable_encryption;
 	SecMan::sec_feat_act m_will_enable_integrity;

--- a/src/condor_includes/condor_secman.h
+++ b/src/condor_includes/condor_secman.h
@@ -262,6 +262,16 @@ public:
 
 	static classad::References* getResumeProj() { return &m_resume_proj; };
 
+		// Generate a EC P256 keypair for key exchange
+	static std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> GenerateKeyExchange(CondorError *errstack);
+
+		// Given the local key and a base64-encoded EC P256 peerkey, generate a key appropriate
+		// for use as a symmetric key.  The resulting key is passed through HKDF.
+	static bool FinishKeyExchange(std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> mykey, const char *encoded_peerkey, unsigned char *outkey, size_t outlen, CondorError *errstack);
+
+		// Given a keypair, encode the pubkey to base64-encoded DER.
+	static bool EncodePubkey(const EVP_PKEY *pkey, std::string &encoded_pkey, CondorError *errstack);
+
 		// Create a security session from scratch (without doing any
 		// security negotation with the peer).  The session id and
 		// key will presumably be communicated to the peer using some


### PR DESCRIPTION
This causes the client and server to exchange public keys from the P256 EC during the initial handshake.  If there's a keypair available, they key exchange post-authentication is skipped and, instead, the keypair is derived using ECDH.

As a side-effect, this causes the initial handshake to always be unique, preventing replay attacks for the first connection of a session.