### PR TITLE
Improvements for `condor_nsenter` (performance, CR/NL issue)

### DIFF
--- a/src/condor_tools/nsenter.cpp
+++ b/src/condor_tools/nsenter.cpp
@@ -343,6 +343,7 @@ int main( int argc, char *argv[] )
 		tcgetattr(0, &tio);
 		pty_is_raw = true;
 		old_tio = tio;
+		tio.c_iflag &= ~(ICRNL);
 		tio.c_oflag &= ~(OPOST);
 		tio.c_cflag |= (CS8);
 		tio.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);

--- a/src/condor_tools/nsenter.cpp
+++ b/src/condor_tools/nsenter.cpp
@@ -371,10 +371,10 @@ int main( int argc, char *argv[] )
 			select(masterPty + 1, &readfds, &writefds, &exceptfds, nullptr);
 
 			if (FD_ISSET(masterPty, &readfds)) {
-				char buf;
-				int r = read(masterPty, &buf, 1);
+				char buf[4096];
+				int r = read(masterPty, buf, 4096);
 				if (r > 0) {	
-					int ret = write(1, &buf, 1);
+					int ret = write(1, buf, r);
 					if (ret < 0) {
 						reset_pty_and_exit(0);
 					}
@@ -384,10 +384,10 @@ int main( int argc, char *argv[] )
 			}
 
 			if (FD_ISSET(0, &readfds)) {
-				char buf;
-				int r = read(0, &buf, 1);
+				char buf[4096];
+				int r = read(0, buf, 4096);
 				if (r > 0) {	
-					int ret = write(masterPty, &buf, 1);
+					int ret = write(masterPty, buf, r);
 					if (ret < 0) {
 						reset_pty_and_exit(0);
 					}


### PR DESCRIPTION
These two commits address two issues:
* Keypresses of "enter" were previously translated to newlines, since the TTY opened by `condor_nsenter` did not unset `ICRNL`. This breaks some applications, notably `nano` (trying to press "enter" to save a file fails). 
* When shuffling a lot of characters through the TTY (e.g. running `cat` on a large file or looking at logs), both `sshd` and `condor_nsenter` would use up to one CPU core each for the `read` / `write` syscalls shuffling the data through character by character. This is addressed by using an on-stack buffer. 

Pinging @GregThain as the inventor of this useful tool :+1: . 

It would be nice to also see this in the 8.8 series (if there is still a release planned), if I should do a PR against both `master` and the 8.8 branch just let me know :smile: . 