### PR TITLE
Remove the JSON from the local issued token

### DIFF
--- a/src/condor_credd/condor_credmon_oauth/credmon/CredentialMonitors/LocalCredmon.py
+++ b/src/condor_credd/condor_credmon_oauth/credmon/CredentialMonitors/LocalCredmon.py
@@ -2,6 +2,7 @@
 import os
 import glob
 import json
+import tempfile
 
 import scitokens
 import htcondor

--- a/src/condor_credd/condor_credmon_oauth/credmon/CredentialMonitors/LocalCredmon.py
+++ b/src/condor_credd/condor_credmon_oauth/credmon/CredentialMonitors/LocalCredmon.py
@@ -1,6 +1,7 @@
 
 import os
 import glob
+import json
 
 import scitokens
 import htcondor
@@ -23,6 +24,7 @@ class LocalCredmon(OAuthCredmon):
         self.token_issuer = None
         self.authz_template = "read:/user/{username} write:/user/{username}"
         self.token_lifetime = 60*20
+        self.token_use_json = True
         if htcondor != None:
             self._private_key_location = htcondor.param.get('LOCAL_CREDMON_PRIVATE_KEY', "/etc/condor/scitokens-private.pem")
             if self._private_key_location != None and os.path.exists(self._private_key_location):
@@ -35,6 +37,7 @@ class LocalCredmon(OAuthCredmon):
             self.token_issuer = htcondor.param.get("LOCAL_CREDMON_ISSUER", self.token_issuer)
             self.authz_template = htcondor.param.get("LOCAL_CREDMON_AUTHZ_TEMPLATE", self.authz_template)
             self.token_lifetime = htcondor.param.get("LOCAL_CREDMON_TOKEN_LIFETIME", self.token_lifetime)
+            self.token_use_json = htcondor.param.get("LOCAL_CREDMON_TOKEN_USE_JSON", self.token_use_json)
         else:
             self._private_key_location = None
         if not self.token_issuer:
@@ -66,7 +69,17 @@ class LocalCredmon(OAuthCredmon):
         # copied from the Vault credmon
         (tmp_fd, tmp_access_token_path) = tempfile.mkstemp(dir = self.cred_dir)
         with os.fdopen(tmp_fd, 'w') as f:
-            f.write(serialized_token.decode()+'\n')
+            if self.token_use_json:
+                # use JSON if configured to do so, i.e. when
+                # LOCAL_CREDMON_TOKEN_USE_JSON = True (default)
+                f.write(json.dumps({
+                    "access_token": serialized_token.decode(),
+                    "expires_in":   int(self.token_lifetime),
+                }))
+            else:
+                # otherwise write a bare token string when
+                # LOCAL_CREDMON_TOKEN_USE_JSON = False
+                f.write(serialized_token.decode()+'\n')
 
         access_token_path = os.path.join(self.cred_dir, username, token_name + '.use')
 

--- a/src/condor_credd/condor_credmon_oauth/credmon/CredentialMonitors/LocalCredmon.py
+++ b/src/condor_credd/condor_credmon_oauth/credmon/CredentialMonitors/LocalCredmon.py
@@ -75,7 +75,7 @@ class LocalCredmon(OAuthCredmon):
             atomic_rename(tmp_access_token_path, access_token_path)
         except OSError as e:
             self.log.exception("Failure when writing out new access token to {}: {}.".format(
-                access_token_path, str(oe)))
+                access_token_path, str(e)))
             return False
         else:
             return True

--- a/src/condor_credd/condor_credmon_oauth/examples/config/condor/40-oauth-credmon.conf
+++ b/src/condor_credd/condor_credmon_oauth/examples/config/condor/40-oauth-credmon.conf
@@ -52,6 +52,11 @@ use feature : OAUTH
 # Each key must have a name that relying parties can look up; defaults to "local"
 # LOCAL_CREDMON_KEY_ID = local
 
+# Should the local issuer credmon write access tokens as JSON files (default)
+# LOCAL_CREDMON_TOKEN_USE_JSON = true
+# or as bare strings (LOCAL_CREDMON_TOKEN_USE_JSON = false)
+# LOCAL_CREDMON_TOKEN_USE_JSON = false
+
 # Override the location of the credential directory, credmon daemon, or credmon log
 # SEC_CREDENTIAL_DIRECTORY_OAUTH = /var/lib/condor/oauth_credentials
 # CREDMON_OAUTH_LOG = $(LOG)/CredMonOAuthLog

--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -5529,6 +5529,10 @@ default=$(SBIN)/condor_credmon_oauth
 win32_default=
 type=path
 
+[LOCAL_CREDMON_TOKEN_USE_JSON]
+default=true
+type=bool
+
 # standard API endpoints for common OAuth token providers
 [BOX_AUTHORIZATION_URL]
 default=https://account.box.com/api/oauth2/authorize


### PR DESCRIPTION
JSON in the token file is not a supported feature of the WLCG
token discovery proposal.  Further, every tool so far written
simply extracts the access_key from the json, without looking
at the expires attribute.