### PR TITLE
Fix backward compatible default for SEC_TOKEN_POOL_SIGNING_KEY_FILE.

### DIFF
--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -2514,7 +2514,7 @@ type=string
 tags=condor_auth_passwd
 
 [SEC_TOKEN_POOL_SIGNING_KEY_FILE]
-default=$(SEC_PASSWORD_DIRECTORY)/POOL
+default=$(SEC_PASSWORD_FILE)
 win32_default=$(RELEASE_DIR)\tokens.sk\POOL
 type=path
 description=Path to the POOL token signing key


### PR DESCRIPTION
For HTCONDOR-370

This changes the default value of `SEC_TOKEN_POOL_SIGNING_KEY_FILE`,
restoring the default location of the POOL signing key to the same as
8.9.11.