### PR TITLE
/usr/share/condor/config.d directory

### DIFF
--- a/build/packaging/srpm/condor.spec
+++ b/build/packaging/srpm/condor.spec
@@ -853,6 +853,10 @@ populate %_sysconfdir/condor/config.d %{buildroot}/usr/share/doc/condor-%{versio
 populate %_sysconfdir/condor/config.d %{buildroot}/usr/share/doc/condor-%{version}/examples/00-minicondor
 populate %_sysconfdir/condor/config.d %{buildroot}/usr/share/doc/condor-%{version}/examples/50ec2.config
 
+# Install a second config.d directory under /usr/share, used for the
+# convenience of software built on top of Condor such as GlideinWMS.
+mkdir -p -m0755 %{buildroot}/usr/share/condor/config.d
+
 mkdir -p -m0755 %{buildroot}/%{_var}/log/condor
 # Note we use %{_var}/lib instead of %{_sharedstatedir} for RHEL5 compatibility
 mkdir -p -m0755 %{buildroot}/%{_var}/lib/condor/spool
@@ -1131,6 +1135,7 @@ rm -rf %{buildroot}
 %dir %_sysconfdir/condor/tokens.d/
 %dir %_sysconfdir/condor/config.d/
 %config(noreplace) %{_sysconfdir}/condor/config.d/00-htcondor-9.0.config
+%dir /usr/share/condor/config.d/
 %_libdir/condor/condor_ssh_to_job_sshd_config_template
 %_sysconfdir/condor/condor_ssh_to_job_sshd_config_template
 %_sysconfdir/bash_completion.d/condor

--- a/src/condor_examples/condor_config.generic
+++ b/src/condor_examples/condor_config.generic
@@ -34,9 +34,11 @@ LOCAL_CONFIG_FILE = $(LOCAL_DIR)/condor_config.local
 ##  If the local config file is not present, is it an error? (WARNING: This is a potential security issue.)
 #REQUIRE_LOCAL_CONFIG_FILE = true
 
-##  The normal way to do configuration with RPMs is to read all of the
+##  The normal way to do configuration with RPM and Debian packaging is to read all of the
 ##  files in a given directory that don't match a regex as configuration files.
 ##  Config files are read in lexicographic order.
+##  Multiple directories may be specified, separated by commas; directories
+##  are read in left-to-right order.
 LOCAL_CONFIG_DIR = $(LOCAL_DIR)/config
 #LOCAL_CONFIG_DIR_EXCLUDE_REGEXP = ^((\..*)|(.*~)|(#.*)|(.*\.rpmsave)|(.*\.rpmnew))$
 

--- a/src/condor_examples/condor_config.generic.debian.patch
+++ b/src/condor_examples/condor_config.generic.debian.patch
@@ -1,6 +1,6 @@
---- condor_config.generic	2019-08-04 17:15:38.663989094 -0500
-+++ condor_config.patched	2019-08-04 18:44:20.953175955 -0500
-@@ -19,25 +19,23 @@
+--- condor_config.generic	2021-04-05 12:48:19.304849066 -0500
++++ condor_config.patched	2021-04-05 12:48:25.084722896 -0500
+@@ -19,27 +19,25 @@
  ######################################################################
  
  ##  Where have you installed the bin, sbin and lib condor directories?
@@ -23,15 +23,17 @@
 -#REQUIRE_LOCAL_CONFIG_FILE = true
 +REQUIRE_LOCAL_CONFIG_FILE = false
  
- ##  The normal way to do configuration with RPMs is to read all of the
+ ##  The normal way to do configuration with RPM and Debian packaging is to read all of the
  ##  files in a given directory that don't match a regex as configuration files.
  ##  Config files are read in lexicographic order.
+ ##  Multiple directories may be specified, separated by commas; directories
+ ##  are read in left-to-right order.
 -LOCAL_CONFIG_DIR = $(LOCAL_DIR)/config
-+LOCAL_CONFIG_DIR = /etc/condor/config.d
++LOCAL_CONFIG_DIR = /usr/share/condor/config.d,/etc/condor/config.d
  #LOCAL_CONFIG_DIR_EXCLUDE_REGEXP = ^((\..*)|(.*~)|(#.*)|(.*\.rpmsave)|(.*\.rpmnew))$
  
  ##
-@@ -67,5 +65,36 @@ LOCAL_CONFIG_DIR = $(LOCAL_DIR)/config
+@@ -68,5 +66,36 @@
  #FLOCK_TO = condor.cs.wisc.edu, cm.example.edu
  
  ##--------------------------------------------------------------------

--- a/src/condor_examples/condor_config.generic.redhat
+++ b/src/condor_examples/condor_config.generic.redhat
@@ -89,6 +89,8 @@ LOCAL_DIR		= $(TILDE)
 
 ##  Where are optional machine-specific local config files located?
 ##  Config files are included in lexicographic order.
+##  Multiple directories may be specified, separated by commas; directories
+##  are read in left-to-right order.
 ##  No default.
 LOCAL_CONFIG_DIR        = $(ETC)/config.d
 

--- a/src/condor_examples/condor_config.generic.rpm.patch
+++ b/src/condor_examples/condor_config.generic.rpm.patch
@@ -1,6 +1,6 @@
---- condor_config.generic	2019-08-04 17:15:38.663989094 -0500
-+++ condor_config.patched	2019-08-04 17:16:45.739011862 -0500
-@@ -19,25 +19,23 @@
+--- condor_config.generic	2021-04-05 12:52:19.157916116 -0500
++++ condor_config.patched	2021-04-05 12:56:22.740721796 -0500
+@@ -19,20 +19,18 @@
  ######################################################################
  
  ##  Where have you installed the bin, sbin and lib condor directories?
@@ -23,15 +23,9 @@
 -#REQUIRE_LOCAL_CONFIG_FILE = true
 +REQUIRE_LOCAL_CONFIG_FILE = false
  
- ##  The normal way to do configuration with RPMs is to read all of the
+ ##  The normal way to do configuration with RPM and Debian packaging is to read all of the
  ##  files in a given directory that don't match a regex as configuration files.
- ##  Config files are read in lexicographic order.
--LOCAL_CONFIG_DIR = $(LOCAL_DIR)/config
-+LOCAL_CONFIG_DIR = /etc/condor/config.d
- #LOCAL_CONFIG_DIR_EXCLUDE_REGEXP = ^((\..*)|(.*~)|(#.*)|(.*\.rpmsave)|(.*\.rpmnew))$
- 
- ##
-@@ -67,5 +65,28 @@ LOCAL_CONFIG_DIR = $(LOCAL_DIR)/config
+@@ -68,5 +66,28 @@
  #FLOCK_TO = condor.cs.wisc.edu, cm.example.edu
  
  ##--------------------------------------------------------------------


### PR DESCRIPTION
This a WIP PR is for [HTCONDOR-45: Add config.d directory for packagers](https://opensciencegrid.atlassian.net/browse/HTCONDOR-45); the idea is we create a second /usr/share/condor/config.d directory where packagers of downstream software (such as GlideinWMS) place their default configs that users aren't supposed to edit. This directory is parsed first so users can override stuff by using /etc.


