### PR TITLE
Fix readthedocs build

### DIFF
--- a/docs/full_conf.py
+++ b/docs/full_conf.py
@@ -303,7 +303,7 @@ def modify_signature(app, what, name, obj, options, signature, return_annotation
 
 
 def setup(app):
-    app.add_stylesheet('css/htcondor-manual.css')
+    app.add_css_file('css/htcondor-manual.css')
     app.connect('autodoc-process-docstring', modify_docstring)
     app.connect('autodoc-process-signature', modify_signature)
 


### PR DESCRIPTION
I got an error building htcondor-vault.readthedocs.io and this is the fix.  I presume you will also need this for htcondor.readhthedocs.io.   The error was
```
AttributeError: 'Sphinx' object has no attribute 'add_stylesheet'
```
The fix came from this [Sphinx issue](https://github.com/sphinx-doc/sphinx/issues/7747).