### PR TITLE
Enable vault integration by default

### DIFF
--- a/build/packaging/srpm/condor.spec
+++ b/build/packaging/srpm/condor.spec
@@ -9,7 +9,6 @@
 # % define fedora   16
 # % define osg      0
 # % define uw_build 1
-# % define vaultcred 1
 # % define devtoolset 0
 
 %define python 0
@@ -36,13 +35,6 @@
 
 %if 0%{?hcc}
 %define blahp 0
-%endif
-
-# enable vaultcred by default for osg
-%if %undefined vaultcred
-%if 0%{?osg}
-%define vaultcred 1
-%endif
 %endif
 
 %define python 1
@@ -555,7 +547,6 @@ OAuth2 endpoints and to use those credentials securely inside running jobs.
 %endif
 
 
-%if 0%{?vaultcred}
 #######################
 %package credmon-vault
 Summary: Vault credmon for HTCondor.
@@ -574,7 +565,6 @@ Conflicts: %name-credmon-oauth
 %description credmon-vault
 The Vault credmon allows users to obtain credentials from Vault using
 htgettoken and to use those credentials securely inside running jobs.
-%endif
 
 #######################
 %package bosco
@@ -917,24 +907,16 @@ mv %{buildroot}/usr/share/doc/condor-%{version}/examples/condor_credmon_oauth/co
 mv %{buildroot}/usr/share/doc/condor-%{version}/examples/condor_credmon_oauth/README.credentials %{buildroot}/%{_var}/lib/condor/oauth_credentials/README.credentials
 %endif
 
-%if 0%{?vaultcred}
 # Move vault credmon config file out of examples and into config.d
 mv %{buildroot}/usr/share/doc/condor-%{version}/examples/condor_credmon_oauth/config/condor/40-vault-credmon.conf %{buildroot}/%{_sysconfdir}/condor/config.d/40-vault-credmon.conf
-%else
-# Otherwise remove installed vault credmon files from the buildroot
-rm -f %{buildroot}/%{_sbindir}/condor_credmon_vault
-rm -f %{buildroot}/%{_bindir}/condor_vault_storer
-%endif
 
 # For non-EL7, remove oauth credmon from the buildroot
 %if 0%{?rhel} > 7 || 0%{?fedora}
 rm -f %{buildroot}/%{_libexecdir}/condor/condor_credmon_oauth.wsgi
 rm -f %{buildroot}/%{_sbindir}/condor_credmon_oauth
 rm -f %{buildroot}/%{_sbindir}/scitokens_credential_producer
-%if ! 0%{?vaultcred}
 rm -rf %{buildroot}/%{_libexecdir}/condor/credmon
 rm -rf %{buildroot}/usr/share/doc/condor-%{version}/examples/condor_credmon_oauth
-%endif
 %endif
 
 ###
@@ -1575,7 +1557,6 @@ rm -rf %{buildroot}
 ###
 %endif
 
-%if 0%{?vaultcred}
 %files credmon-vault
 %doc examples/condor_credmon_oauth
 %_sbindir/condor_credmon_vault
@@ -1584,7 +1565,6 @@ rm -rf %{buildroot}
 %config(noreplace) %_sysconfdir/condor/config.d/40-vault-credmon.conf
 %ghost %_var/lib/condor/oauth_credentials/CREDMON_COMPLETE
 %ghost %_var/lib/condor/oauth_credentials/pid
-%endif
 
 %files bosco
 %defattr(-,root,root,-)

--- a/docs/admin-manual/configuration-macros.rst
+++ b/docs/admin-manual/configuration-macros.rst
@@ -9394,20 +9394,18 @@ macros are described in the :doc:`/admin-manual/security` section.
     using the kerberos type of credentials.  No parameters are passed,
     and credentials most be sent to stdout.
 
-.. only:: Vault
-
-    :macro-def:`SEC_CREDENTIAL_STORER`
-        A script for *condor_submit* to execute to produce credentials while
-        using the OAuth2 type of credentials.  The oauth services specified
-        in the ``use_auth_services`` line in the submit file are passed as
-        parameters to the script, and the script should use
-        ``condor_store_cred`` to store credentials for each service.
-        Additional modifiers to each service may be passed: &handle=,
-        &scopes=, or &audience=.  The handle should be appended after
-        an underscore to the service name used with ``condor_store_cred``,
-        the comma-separated list of scopes should be passed to the command
-        with the -S option, and the audience should be passed to it with the
-        -A option.
+:macro-def:`SEC_CREDENTIAL_STORER`
+    A script for *condor_submit* to execute to produce credentials while
+    using the OAuth2 type of credentials.  The oauth services specified
+    in the ``use_auth_services`` line in the submit file are passed as
+    parameters to the script, and the script should use
+    ``condor_store_cred`` to store credentials for each service.
+    Additional modifiers to each service may be passed: &handle=,
+    &scopes=, or &audience=.  The handle should be appended after
+    an underscore to the service name used with ``condor_store_cred``,
+    the comma-separated list of scopes should be passed to the command
+    with the -S option, and the audience should be passed to it with the
+    -A option.
 
 :macro-def:`LEGACY_ALLOW_SEMANTICS`
     A boolean parameter that defaults to ``False``.

--- a/docs/admin-manual/setting-up-special-environments.rst
+++ b/docs/admin-manual/setting-up-special-environments.rst
@@ -362,35 +362,33 @@ used files.
 Enabling the Fetching and Use of OAuth2 Credentials
 ---------------------------------------------------
 
-.. only:: Vault
+HTCondor supports two distinct methods for using OAuth2 credentials.
+One uses its own native OAuth client or issuer, and one uses a separate
+Hashicorp Vault server as the OAuth client and secure refresh token
+storage.  Each method uses a separate credmon implementation and rpm
+and have their own advantages and disadvantages.
 
-    HTCondor supports two distinct methods for using OAuth2 credentials.
-    One uses its own native OAuth client or issuer, and one uses a separate
-    Hashicorp Vault server as the OAuth client and secure refresh token
-    storage.  Each method uses a separate credmon implementation and rpm
-    and have their own advantages and disadvantages.
+If the native OAuth client is used with a remote token issuer, then each
+time a new refresh token is needed the user has to reauthorize it through
+a web browser.  An hour after all jobs of a user are stopped (by default),
+the refresh tokens are deleted.  If the client is used with the native
+token issuer is used, then no web browser authorizations are needed but
+the public keys of every token issuer have to be managed by all the
+resource providers.  In both cases, the tokens are only available inside
+HTCondor jobs.
 
-    If the native OAuth client is used with a remote token issuer, then each
-    time a new refresh token is needed the user has to reauthorize it through
-    a web browser.  An hour after all jobs of a user are stopped (by default),
-    the refresh tokens are deleted.  If the client is used with the native
-    token issuer is used, then no web browser authorizations are needed but
-    the public keys of every token issuer have to be managed by all the
-    resource providers.  In both cases, the tokens are only available inside
-    HTCondor jobs.
+If on the other hand a Vault server is used as the OAuth client, it
+stores the refresh token long term (typically about a month since last
+use) for multiple use cases.  It can be used both by multiple HTCondor
+submit machines and by other client commands that need access tokens.
+Submit machines keep a medium term vault token (typically about a week)
+so at most users have to authorize in their web browser once a week.  If
+kerberos is also available, new vault tokens can be obtained automatically
+without any user intervention.  The HTCondor vault credmon also stores a
+longer lived vault token for use as long as jobs might run.
 
-    If on the other hand a Vault server is used as the OAuth client, it
-    stores the refresh token long term (typically about a month since last
-    use) for multiple use cases.  It can be used both by multiple HTCondor
-    submit machines and by other client commands that need access tokens.
-    Submit machines keep a medium term vault token (typically about a week)
-    so at most users have to authorize in their web browser once a week.  If
-    kerberos is also available, new vault tokens can be obtained automatically
-    without any user intervention.  The HTCondor vault credmon also stores a
-    longer lived vault token for use as long as jobs might run.
-
-    Using the native OAuth client and/or issuer
-    '''''''''''''''''''''''''''''''''''''''''''
+Using the native OAuth client and/or issuer
+'''''''''''''''''''''''''''''''''''''''''''
 
 HTCondor can be configured
 to allow users to request and securely store credentials
@@ -479,24 +477,22 @@ make sure users know which names (``<OAuth2ServiceName>s``) have been configured
 so that they know what they should put under ``use_oauth_services``
 in their job submit files.
 
-.. only:: Vault
+.. _installing_credmon_vault:
 
-    .. _installing_credmon_vault:
+Using Vault as the OAuth client
+'''''''''''''''''''''''''''''''
 
-    Using Vault as the OAuth client
-    '''''''''''''''''''''''''''''''
-
-    To instead configure HTCondor to use Vault as the OAuth client,
-    install the ``condor-credmon-vault`` rpm.  Also install the htgettoken
-    (`https://github.com/fermitools/htgettoken <https://github.com/fermitools/htgettoken>`_)
-    rpm on the submit machine.  Additionally, on the submit machine
-    set the ``SEC_CREDENTIAL_GETTOKEN_OPTS`` configuration option to
-    ``-a <vault.name>`` where <vault.name> is the fully qualified domain name
-    of the Vault machine.  *condor_submit* users will then be able to select
-    the oauth services that are defined on the Vault server.  See the
-    htvault-config
-    (`https://github.com/fermitools/htvault-config <https://github.com/fermitools/htvault-config>`_)
-    documentation to see how to set up and configure the Vault server.
+To instead configure HTCondor to use Vault as the OAuth client,
+install the ``condor-credmon-vault`` rpm.  Also install the htgettoken
+(`https://github.com/fermitools/htgettoken <https://github.com/fermitools/htgettoken>`_)
+rpm on the submit machine.  Additionally, on the submit machine
+set the ``SEC_CREDENTIAL_GETTOKEN_OPTS`` configuration option to
+``-a <vault.name>`` where <vault.name> is the fully qualified domain name
+of the Vault machine.  *condor_submit* users will then be able to select
+the oauth services that are defined on the Vault server.  See the
+htvault-config
+(`https://github.com/fermitools/htvault-config <https://github.com/fermitools/htvault-config>`_)
+documentation to see how to set up and configure the Vault server.
 
 Configuring HTCondor for Multiple Platforms
 -------------------------------------------

--- a/docs/users-manual/submitting-a-job.rst
+++ b/docs/users-manual/submitting-a-job.rst
@@ -1170,31 +1170,29 @@ a user can still request multiple credentials by affixing handles to
     cloudboxdrive_oauth_permissions_personal =
     cloudboxdrive_oauth_permissions_public =
 
-.. only:: Vault
+When the Vault credential monitor is configured, the service name may
+optionally be split into two parts with an underscore between them,
+where the first part is the issuer and the second part is the role.  In
+this example the issuer is "dune" and the role is "production", both
+as configured by the administrator of the Vault server:
 
-    When the Vault credential monitor is configured, the service name may
-    optionally be split into two parts with an underscore between them,
-    where the first part is the issuer and the second part is the role.  In
-    this example the issuer is "dune" and the role is "production", both
-    as configured by the administrator of the Vault server:
+.. code-block:: condor-submit
 
-    .. code-block:: condor-submit
+    use_oauth_services = dune_production
 
-        use_oauth_services = dune_production
+Vault does not require permissions or resources to be
+set, but they may be set to reduce the default permissions or restrict
+the resources that may use the credential.  The full service name
+including an underscore may be used in an ``oauth_permissions`` or
+``oauth_resource``.  Avoid using handles that might be confused as
+role names.  For example, the following will result in a conflict
+between two credentials called ``dune_production.use``:
 
-    Vault server.  Vault does not require permissions or resources to be
-    set, but they may be set to reduce the default permissions or restrict
-    the resources that may use the credential.  The full service name
-    including an underscore may be used in an ``oauth_permissions`` or
-    ``oauth_resource``.  Avoid using handles that might be confused as
-    role names.  For example, the following will result in a conflict
-    between two credentials called ``dune_production.use``:
+.. code-block:: condor-submit
 
-    .. code-block:: condor-submit
-
-        use_oauth_services = dune, dune_production
-        dune_oauth_permissions_production =
-        dune_production_oauth_permissions =
+    use_oauth_services = dune, dune_production
+    dune_oauth_permissions_production =
+    dune_production_oauth_permissions =
 
 
 Jobs That Require GPUs


### PR DESCRIPTION
This PR enables the vault integration by default, in the rpm and in documentation.  I did leave one difference between the default build and the osg build, in that the osg build Requires htgettoken.  I'm not sure if that is preferred or not, because the condor_submit part does not work without htgettoken.  It might be better to leave the Requires in and leave it up to the user to find a yum repo with htgettoken in it if they install htcondor-credmon-vault.  Or, if desired, htgettoken could probably be included in the htcondor yum repository in addition to the osg yum repository.