### PR TITLE
Fix typo: 'attribue' -> 'attribute'.

### DIFF
--- a/docs/users-manual/submitting-a-job.rst
+++ b/docs/users-manual/submitting-a-job.rst
@@ -303,7 +303,7 @@ file.
     ``$(Process)`` or ``$(ProcId)`` will have the same value as the job
     ClassAd attribute ``ProcId``.
 
-``$$(a_machine_classad_attribue)``
+``$$(a_machine_classad_attribute)``
     When the machine is matched to this job for it to run on, any
     dollar-dollar expressions are looked up from the machine ad, and then
     expanded.  This lets you put the value of some machine ad attribute

--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -2091,7 +2091,7 @@ type=string
 tags=submit
 
 [SUBMIT_GENERATE_CUSTOM_RESOURCE_REQUIREMENTS]
-description=Submit should generate requirements clauses for job attribues that begin with Request
+description=Submit should generate requirements clauses for job attributes that begin with Request
 default=true
 type=bool
 tags=submit


### PR DESCRIPTION
`attribue` occurs in 2 places, change it to `attribute`.