### PR TITLE
Support using scitokens-cpp without dlopen

### DIFF
--- a/src/condor_utils/condor_scitokens.cpp
+++ b/src/condor_utils/condor_scitokens.cpp
@@ -131,6 +131,7 @@ htcondor::init_scitokens()
 	}
 
 #ifndef WIN32
+#if defined(DLOPEN_SECURITY_LIBS)
 	dlerror();
 	void *dl_hdl = nullptr;
 	if (
@@ -154,6 +155,18 @@ htcondor::init_scitokens()
 		scitoken_get_claim_string_list_ptr = (int (*)(const SciToken token, const char *key, char ***value, char **err_msg))dlsym(dl_hdl, "scitoken_get_claim_string_list");
 		scitoken_free_string_list_ptr = (void (*)(char **value))dlsym(dl_hdl, "scitoken_free_string_list");
 	}
+#else
+	scitoken_deserialize_ptr = scitoken_deserialize;
+	scitoken_get_claim_string_ptr = scitoken_get_claim_string;
+	scitoken_destroy_ptr = scitoken_destroy;
+	enforcer_create_ptr = enforcer_create;
+	enforcer_destroy_ptr = enforcer_destroy;
+	enforcer_generate_acls_ptr = enforcer_generate_acls;
+	enforcer_acl_free_ptr = enforcer_acl_free;
+	scitoken_get_expiration_ptr = scitoken_get_expiration;
+	scitoken_get_claim_string_list_ptr = scitoken_get_claim_string_list;
+	scitoken_free_string_list_ptr = scitoken_free_string_list;
+#endif
 #else
 	dprintf(D_SECURITY, "SciTokens is not supported on Windows.\n");
 	g_init_success = false;

--- a/src/condor_utils/condor_scitokens.cpp
+++ b/src/condor_utils/condor_scitokens.cpp
@@ -39,7 +39,7 @@ static void (*enforcer_acl_free_ptr)(Acl *acls) = nullptr;
 static int (*scitoken_get_expiration_ptr)(const SciToken token, long long *value, char **err_msg) =
 	nullptr;
 static int (*scitoken_get_claim_string_list_ptr)(const SciToken token, const char *key, char ***value, char **err_msg) = nullptr;
-static int (*scitoken_free_string_list_ptr)(char **value) = nullptr;
+static void (*scitoken_free_string_list_ptr)(char **value) = nullptr;
 
 #define LIBSCITOKENS_SO "libSciTokens.so.0"
 
@@ -152,7 +152,7 @@ htcondor::init_scitokens()
 			// Note: these methods are only in a more recent version of the SciTokens library; hence, if they
 			// are missing it's considered non-fatal.
 		scitoken_get_claim_string_list_ptr = (int (*)(const SciToken token, const char *key, char ***value, char **err_msg))dlsym(dl_hdl, "scitoken_get_claim_string_list");
-		scitoken_free_string_list_ptr = (int (*)(char **value))dlsym(dl_hdl, "scitoken_free_string_list");
+		scitoken_free_string_list_ptr = (void (*)(char **value))dlsym(dl_hdl, "scitoken_free_string_list");
 	}
 #else
 	dprintf(D_SECURITY, "SciTokens is not supported on Windows.\n");


### PR DESCRIPTION
This PR patches `condor_scitokens.cpp` to enable dynamic linking of `libSciTokens` at build time, rather than using `dlopen` at run time, as is supported in a bunch of other places.