### PR TITLE
Improve distro detection

### DIFF
--- a/src/condor_contrib/bosco/bosco_cluster
+++ b/src/condor_contrib/bosco/bosco_cluster
@@ -289,21 +289,23 @@ ssh_detect_linux_distro () {
     os_release=`ssh $remote_host "cat /etc/os-release" 2> /dev/null`
     [[ $? -eq 0 ]] || return 1
 
-    dist=`echo "$os_release" | awk -F '=' '/^ID(_LIKE)*=/ {print $2}'`
+    dist_id=`echo "$os_release" | awk -F '=' '/^ID=/ {print $2}'`
+    dist_id_like=`echo "$os_release" | awk -F '=' '/^ID_LIKE=/ {print $2}'`
     ver=`echo "$os_release" | awk -F '=' '/^VERSION_ID=/ {print $2}' | tr -d '"'`
     major_ver="${ver%%.*}"
 
-    case "$dist" in
-        (*rhel*|*centos*|*scientific*)
-            echo "CentOS${major_ver}" ;;
-        *ubuntu*)
-            echo "Ubuntu${major_ver}" ;;
-        *debian*)
-            echo "Debian${major_ver}" ;;
-        (*)
-            return 1
-            ;;
-    esac
+    if [[ $dist_id_like = *rhel* ]]; then
+        echo "CentOS${major_ver}"
+    else
+        case "$dist_id" in
+            debian)
+                echo "Debian${major_ver}" ;;
+            ubuntu)
+                echo "Ubuntu${major_ver}" ;;
+            *)
+                return 1 ;;
+        esac
+    fi
     return 0
 }
 

--- a/src/condor_contrib/bosco/bosco_cluster
+++ b/src/condor_contrib/bosco/bosco_cluster
@@ -289,17 +289,17 @@ ssh_detect_linux_distro () {
     os_release=`ssh $remote_host "cat /etc/os-release" 2> /dev/null`
     [[ $? -eq 0 ]] || return 1
 
-    dist=`echo "$os_release" | awk -F '=' '/^ID=/ {print $2}' | tr -d '"'`
+    dist=`echo "$os_release" | awk -F '=' '/^ID(_LIKE)*=/ {print $2}'`
     ver=`echo "$os_release" | awk -F '=' '/^VERSION_ID=/ {print $2}' | tr -d '"'`
     major_ver="${ver%%.*}"
 
     case "$dist" in
-        (rhel|centos|scientific)
+        (*rhel*|*centos*|*scientific*)
             echo "CentOS${major_ver}" ;;
-        debian)
-            echo "Debian${major_ver}" ;;
-        ubuntu)
+        *ubuntu*)
             echo "Ubuntu${major_ver}" ;;
+        *debian*)
+            echo "Debian${major_ver}" ;;
         (*)
             return 1
             ;;

--- a/src/condor_contrib/bosco/bosco_cluster
+++ b/src/condor_contrib/bosco/bosco_cluster
@@ -294,7 +294,7 @@ ssh_detect_linux_distro () {
     ver=`echo "$os_release" | awk -F '=' '/^VERSION_ID=/ {print $2}' | tr -d '"'`
     major_ver="${ver%%.*}"
 
-    if [[ $dist_id_like = *rhel* ]]; then
+    if [[ $dist_id_like =~ (rhel|centos|fedora) ]]; then
         echo "CentOS${major_ver}"
     else
         case "$dist_id" in


### PR DESCRIPTION
1.  RHEL-variants (CentOS, SL, Alma, Rocky) all appear to be pretty
    good about putting at least 'rhel fedora' in ID_LIKE so capturing
    ID_LIKE in addition to ID should give us a good chance of
    detecting new RHEL-variants without having to update bosco_cluster
2.  Ubuntu has 'ID_LIKE="debian"' so we still need to capture ID to
    differentiate it from Debian
3.  Debian doesn't set ID_LIKE so it's yet another reason to capture ID