### PR TITLE
Delete adstash limitation and minor fix when no passwd file is given

### DIFF
--- a/src/condor_scripts/adstash/config.py
+++ b/src/condor_scripts/adstash/config.py
@@ -79,11 +79,11 @@ def get_htcondor_config(name="ADSTASH"):
     }
 
     # Convert debug level
-    if conf.get("debug_levels") is not None:
+    if conf.get("debug_levels") is not None and conf.get("debug_levels") != "":
         conf["log_level"] = debug2level(conf["debug_levels"])
 
     # Grab password from password file
-    if conf.get("es_password_file") is not None:
+    if conf.get("es_password_file") is not None and conf.get("es_password_file") != "":
         passwd = Path(conf["es_password_file"])
         try:
             with passwd.open() as f:


### PR DESCRIPTION
Adstash limit (10000):
We wanted to use adstash to dump more than 10000 condor history entries into an elasticsearch DB.
This was not possible due to the hard limit of: match=min(10000, args.schedd_history_max_ads).
Therefore, I changed it to be freely defined by the adstash config via {name}_{SCHEDD,STARTD}_HISTORY_MAX_ADS.

Note that eventually also the "HISTORY_HELPER_MAX_HISTORY" in the scheduler's config has to be adapted accordingly!

+ some logging added

---------------
Small bug fix:
If no password file is specified, a small bug fix is necessary.
The `conf.get("es_password_file")` in `if conf.get("es_password_file") is not None:` never evaluates to `None`, since an empty string is returned by `"es_password_file": p.get(f"{name}_ES_PASSWORD_FILE")` (L76), if no password file is given with the adstash config.

Therefore, to avoid an exception in this case the additional comparison to an empty string was added.



