### PR TITLE
Fix various typos in the config macros

### DIFF
--- a/docs/admin-manual/configuration-macros.rst
+++ b/docs/admin-manual/configuration-macros.rst
@@ -905,7 +905,7 @@ and :ref:`admin-manual/configuration-macros:shared file system configuration fil
 :macro-def:`IGNORE_TARGET_PROTOCOL_PREFERENCE`
     A string (treated as a boolean). If
     ``IGNORE_TARGET_PROTOCOL_PREFERENCE`` evaluates to ``True``, the
-    target's listed protocol preferences will be ignored; othwerwise
+    target's listed protocol preferences will be ignored; otherwise
     they will not. Defaults to ``$(PREFER_IPV4)``.
 
 :macro-def:`IGNORE_DNS_PROTOCOL_PREFERENCE`
@@ -1540,7 +1540,7 @@ a file that receives job events, but across all users and user's jobs.
     ``LEGACY``
         Set all time formatting flags to be compatible with older versions of HTCondor.
 
-    All of the above options are case-insensitive, and can be preceeded by a ! to invert their meaning,
+    All of the above options are case-insensitive, and can be preceded by a ! to invert their meaning,
     so configuring ``!UTC, !ISO_DATE, !SUB_SECOND`` gives the same result as configuring ``LEGACY``.
 
 :macro-def:`EVENT_LOG_USE_XML`
@@ -2326,7 +2326,7 @@ using a shared file system`.
     when the *condor_starter* and *condor_shadow* are on the same
     machine. If this parameter is set to ``True``, then the
     *condor_shadow* 's ``UID_DOMAIN`` doesn't have to be a substring
-    its hostname. If this paramater is set to ``False``, then
+    its hostname. If this parameter is set to ``False``, then
     ``UID_DOMAIN`` controls whether this substring requirement is
     enforced by the *condor_starter*. The default is ``True``.
 
@@ -2946,7 +2946,7 @@ section.
 :macro-def:`DEFAULT_DRAINING_START_EXPR`
     An alternate ``START`` expression to use while draining when the
     drain command is sent without a ``-start`` argument.  When this
-    confiuration parameter is not set and the drain command does not specify
+    configuration parameter is not set and the drain command does not specify
     a ``-start`` argument, ``START`` will have the value ``undefined``
     and ``Requirements`` will be ``false`` while draining. This will prevent new
     jobs from matching.  To allow evictable jobs to match while draining,
@@ -3530,8 +3530,8 @@ section.
     For Docker Universe jobs, any directories that are mounted under
     scratch are also volume mounted on the same paths inside the
     container. That is, any reads or writes to files in those
-    directories goes to the host filesytem under the scratch directory.
-    This is useful if a container has limited space to grow a filesytem.
+    directories goes to the host filesystem under the scratch directory.
+    This is useful if a container has limited space to grow a filesystem.
 
 :macro-def:`MOUNT_PRIVATE_DEV_SHM`
     This boolean value, which defaults to ``True`` tells the *condor_starter*
@@ -4171,7 +4171,7 @@ details.
     context of the job ad and the machine ad, when true, runs the docker
     container with the command line option -drop-all-capabilities.
     Admins should be very careful with this setting, and only allow
-    trusted users to run with full linux capabilities within the
+    trusted users to run with full Linux capabilities within the
     container.
 
 :macro-def:`DOCKER_PERFORM_TEST`
@@ -5452,7 +5452,7 @@ These macros control the *condor_schedd*.
     to their account.
     Most often, this should be set to name of the OAuth2 service
     (e.g. ``box``, ``gdrive``, ``onedrive``, etc.).
-    The dervied return URL is passed on to the *condor_credmon_oauth*
+    The derived return URL is passed on to the *condor_credmon_oauth*
     when a job requests OAuth2 credentials
     for a configured OAuth2 service.
 
@@ -5612,7 +5612,7 @@ These settings affect the *condor_starter*.
 :macro-def:`DISABLE_SETUID`
     HTCondor can prevent jobs from running setuid executables
     on Linux by setting the no-new-privileges flag.  This can be
-    enabled (i.e. to disallow setuid binaries) by setting ``DISABLE_SETIUD``
+    enabled (i.e. to disallow setuid binaries) by setting ``DISABLE_SETUID``
     to true.
 
 :macro-def:`EXEC_TRANSFER_ATTEMPTS`
@@ -6663,7 +6663,7 @@ These macros affect the *condor_collector*.
     The default value is ``$(NEGOTIATOR_CONSIDER_PREEMPTION)``.
 
 :macro-def:`COLLECTOR_FORWARD_PROJECTION`
-    An expresion that evaluates to a string in the context of an update. The string is treated as a list
+    An expression that evaluates to a string in the context of an update. The string is treated as a list
     of attributes to forward.  If the string has no attributes, it is ignored. The intended use is to
     restrict the list of attributes forwarded for claimed Machine ads.
     When ``$(NEGOTIATOR_CONSIDER_PREEMPTION)`` is false, the negotiator needs only a few attributes from
@@ -7733,7 +7733,7 @@ These macros affect the *condor_job_router* daemon.
     Routes will be matched to jobs in the order their names are declared in this list.  Routes not
     declared in this list will be disabled.  
 
-    If routes are specifed in the deprecated `JOB_ROUTER_ENTRIES`, `JOB_ROUTER_ENTRIES_FILE`
+    If routes are specified in the deprecated `JOB_ROUTER_ENTRIES`, `JOB_ROUTER_ENTRIES_FILE`
     and `JOB_ROUTER_ENTRIES_CMD` configuration variables, then ``JOB_ROUTER_ROUTE_NAMES`` is optional.
     if it is empty, the order in which routes are considered will be the order in
     which their names hash.
@@ -7842,12 +7842,12 @@ These macros affect the *condor_job_router* daemon.
     an unlimited number of jobs may be routed.
 
 :macro-def:`JOB_ROUTER_DEFAULT_MAX_JOBS_PER_ROUTE`
-    An iteger value representing the maximum number of jobs that may be
+    An integer value representing the maximum number of jobs that may be
     routed to a single route when the route does not specify a ``MaxJobs``
     value. The default value is 100.
 
 :macro-def:`JOB_ROUTER_DEFAULT_MAX_IDLE_JOBS_PER_ROUTE`
-    An iteger value representing the maximum number of jobs in a single
+    An integer value representing the maximum number of jobs in a single
     route that may be in the idle state.  When the number of jobs routed
     to that site exceeds this number, no more jobs will be routed to it. 
     A route may specify ``MaxIdleJobs`` to override this number.
@@ -7963,7 +7963,7 @@ These macros affect the *condor_job_router* daemon.
 :macro-def:`JOB_ROUTER_ROUND_ROBIN_SELECTION`
     A boolean value that controls which route is chosen for a candidate
     job that matches multiple routes. When set to ``False``, the
-    default, the first matching route is awlays selected. When set to
+    default, the first matching route is always selected. When set to
     ``True``, the Job Router attempts to distribute jobs across all
     matching routes, round robin style.
 
@@ -8132,10 +8132,10 @@ General
     files. (Introduced in version 8.6.1.)
 
 :macro-def:`DAGMAN_USE_CONDOR_SUBMIT`
-    A boolan value that controls wither *condor_dagman* submits jobs using
+    A boolean value that controls whether *condor_dagman* submits jobs using
     *condor_submit* or by opening a direct connection to the *condor_schedd*.
     ``DAGMAN_USE_CONDOR_SUBMIT`` defaults to ``True``.  When set to ``False``
-    *condor_dagman* will submit jobs to the local Schedd by connnecting to it
+    *condor_dagman* will submit jobs to the local Schedd by connecting to it
     directly.  This is faster than using *condor_submit*, especially for very
     large DAGs; But this method will ignore some submit file features such as
     ``max_materialize`` and more than one ``QUEUE`` statement.
@@ -8151,7 +8151,7 @@ General
 :macro-def:`DAGMAN_PUT_FAILED_JOBS_ON_HOLD`
     A boolean value that controls what happens when a job in a DAG fails.
     When set to ``True``, *condor_dagman* will keep the job in the queue and
-    put it on hold. If the failure was due to a transient error (ie. a
+    put it on hold. If the failure was due to a transient error (i.e. a
     temporary network outage), this gives users an opportunity to fix the
     problem, release the job and continue their DAG execution. Defaults 
     to ``False``.
@@ -8336,7 +8336,7 @@ Node job submission/removal
     node jobs itself when it is removed (in addition to the
     *condor_schedd* removing them). Note that setting
     ``DAGMAN_REMOVE_NODE_JOBS`` to ``True`` is the safer option (setting
-    it to ``False`` means that there is some chance of endig up with
+    it to ``False`` means that there is some chance of ending up with
     "orphan" node jobs). Setting ``DAGMAN_REMOVE_NODE_JOBS`` to
     ``False`` is a performance optimization (decreasing the load on the
     *condor_schedd* when a *condor_dagman* job is removed). Note that
@@ -8794,16 +8794,16 @@ macros are described in the :doc:`/admin-manual/security` section.
     settings untouched.
 
 :macro-def:`WARN_ON_GSI_CONFIGURATION"`
-    A boolean varaiables that controls whether a warning is printed
-    whenver GSI seen in a configured list of authentication methods.
+    A boolean variables that controls whether a warning is printed
+    whenever GSI seen in a configured list of authentication methods.
     Daemons will print the warning to their log (no more frequently than
     once every 12 hours).
     Tools will print the warning to their stderr.
     The default value is ``True``.
 
 :macro-def:`WARN_ON_GSI_USAGE`
-    A boolean varaiables that controls whether a warning is printed
-    whenver GSI is used for authentication over a network connection with
+    A boolean variables that controls whether a warning is printed
+    whenever GSI is used for authentication over a network connection with
     an HTCondor daemon.
     Daemons will print the warning to their log (no more frequently than
     once every 12 hours).
@@ -9128,7 +9128,7 @@ macros are described in the :doc:`/admin-manual/security` section.
 
 :macro-def:`SEC_TOKEN_REQUEST_LIMITS`
     If set, this is a comma-separated list of authorization levels that limit
-    the authorizations a token request can recieve.  For example, if
+    the authorizations a token request can receive.  For example, if
     ``SEC_TOKEN_REQUEST_LIMITS`` is set to ``READ, WRITE``, then a token
     cannot be issued with the authorization ``DAEMON`` even if this would
     otherwise be permissible.
@@ -9305,7 +9305,7 @@ macros are described in the :doc:`/admin-manual/security` section.
 
 :macro-def:`SEC_CREDENTIAL_PRODUCER`
     A script for *condor_submit* to execute to produce credentials while
-    using the kerberos type of credentials.  No parameters are passed,
+    using the Kerberos type of credentials.  No parameters are passed,
     and credentials most be sent to stdout.
 
 :macro-def:`SEC_CREDENTIAL_STORER`
@@ -9713,12 +9713,12 @@ These macros affect the high availability operation of HTCondor.
 :macro-def:`HAD_FIPS_MODE`
     Controls what type of checksum will be sent along with files that are replicated.
     Set it to 0 for MD5 checksums and to 1 for SHA-2 checksums. Default value is 0.
-    Prior to verions 8.8.13 and 8.9.12 only MD5 checksums are supported. In the 9.0 and
+    Prior to versions 8.8.13 and 8.9.12 only MD5 checksums are supported. In the 9.0 and
     later release of HTCondor, MD5 support will be removed and only SHA-2 will be
     supported.  This configuration variable is intended to provide a transition
     between the 8.8 and 9.0 releases.  As soon as all of machines involved in replication
     are running HTCondor 8.8.13 or 8.9.12 or later you should set this configuration variable
-    to 1 to prepare for the transiation to 9.0
+    to 1 to prepare for the transition to 9.0
 
 :macro-def:`REPLICATION_LIST`
     A comma-separated list of all *condor_replication* daemons in the
@@ -10628,7 +10628,7 @@ general discussion of *condor_defrag* may be found in
 :macro-def:`DEFRAG_DRAINING_START_EXPR`
     A ClassAd expression that replaces the machine's ``START``
     :index:`START` expression while it's draining. Slots which
-    accepted a job after the machine begain draining set the machine ad
+    accepted a job after the machine began draining set the machine ad
     attribute ``AcceptedWhileDraining`` to ``true``. When the last job
     which was not accepted while draining exits, all other jobs are
     immediately evicted with a ``MaxJobRetirementTime`` of 0; job vacate


### PR DESCRIPTION
I noticed a typo and one thing lead to another...