### PR TITLE
Improve handling of execute directory disappearing. #680

### DIFF
--- a/src/condor_starter.V6.1/jic_shadow.cpp
+++ b/src/condor_starter.V6.1/jic_shadow.cpp
@@ -928,11 +928,19 @@ JICShadow::notifyStarterError( const char* err_msg, bool critical, int hold_reas
 {
 	u_log->logStarterError( err_msg, critical );
 
-	StatInfo si(Starter->GetWorkingDir(false));
-	if( si.Error() == SINoFile ) {
-		dprintf(D_ALWAYS, "Scratch execute directory disappeared unexpectedly, declining to put job on hold.\n");
-		hold_reason_code = 0;
-		hold_reason_subcode = 0;
+	// If the scratch working directory has disappeared when it should exist,
+	// that is likely connected to the error. Don't tell the shadow to put
+	// the job on hold, as it's likely not the fault of the job.
+	// Make an exception for local universe jobs
+	// (SCHEDD_USES_STARTD_FOR_LOCAL_UNIVERSE=True), as they have nowhere
+	// else to go if this is a recurring problem.
+	if( Starter->WorkingDirExists() && job_universe != CONDOR_UNIVERSE_LOCAL ) {
+		StatInfo si(Starter->GetWorkingDir(false));
+		if( si.Error() == SINoFile ) {
+			dprintf(D_ALWAYS, "Scratch execute directory disappeared unexpectedly, declining to put job on hold.\n");
+			hold_reason_code = 0;
+			hold_reason_subcode = 0;
+		}
 	}
 
 	if( critical ) {

--- a/src/condor_starter.V6.1/starter.cpp
+++ b/src/condor_starter.V6.1/starter.cpp
@@ -80,6 +80,7 @@ Starter::Starter() :
 	Execute(NULL),
 	orig_cwd(NULL),
 	is_gridshell(false),
+	m_workingDirExists(false),
 #ifdef WIN32
 	has_encrypted_working_dir(false),
 #endif
@@ -153,6 +154,7 @@ Starter::Init( JobInfoCommunicator* my_jic, const char* original_cwd,
 			// scratch directory, we're just going to use whatever
 			// EXECUTE is, or our CWD if that's not defined...
 		WorkingDir = Execute;
+		m_workingDirExists = true;
 	} else {
 		formatstr( WorkingDir, "%s%cdir_%ld", Execute, DIR_DELIM_CHAR, 
 				 (long)daemonCore->getpid() );
@@ -2006,6 +2008,7 @@ Starter::createTempExecuteDir( void )
 	}
 	dprintf( D_FULLDEBUG, "Done moving to directory \"%s\"\n", WorkingDir.c_str() );
 	set_priv( priv );
+	m_workingDirExists = true;
 	return true;
 }
 
@@ -3766,6 +3769,9 @@ Starter::removeTempExecuteDir( void )
 		}
 	}
 
+	if (!has_failed) {
+		m_workingDirExists = false;
+	}
 	return !has_failed;
 }
 

--- a/src/condor_starter.V6.1/starter.h
+++ b/src/condor_starter.V6.1/starter.h
@@ -211,6 +211,10 @@ public:
 		}
 		return WorkingDir.c_str();
 	}
+		/* Should the temporary directory under Execute be expected to
+		 * exist?
+		 */
+	bool WorkingDirExists() const { return m_workingDirExists; }
 		/* Set the working dir from the perspective of the job. This may differ from
 		*  the Starter's WorkingDir value when the job is in a container.  For a containerized job
 		*  Working dir will be something like /var/lib/condor/execute/dir_nnnn  or C:\Condor\Execute\dir_nnnn
@@ -401,6 +405,7 @@ private:
 	char *orig_cwd;
 	std::string m_recoveryFile;
 	bool is_gridshell;
+	bool m_workingDirExists;
 #ifdef WIN32
 	bool has_encrypted_working_dir;
 #endif


### PR DESCRIPTION
When declining to put the job on hold when the execute directory is
missing, verify that the execute directory is expected to exist at that
point in time. Also, let the job go on hold if it's local universe, as
it has nowhere else to go if this is a recurring problem.