### PR TITLE
(HTCONDOR-658)  Don't initialize inotify until we need it.

### DIFF
--- a/src/condor_scripts/condor_watch_q
+++ b/src/condor_scripts/condor_watch_q
@@ -459,25 +459,6 @@ def watch_q(
         users, cluster_ids, event_logs, batches, collector=collector, schedd=schedd,
     )
 
-    max_watches = None
-
-    try:
-        with open('/proc/sys/user/max_inotify_instances') as limitfile:
-            max_watches = int(limitfile.readline())
-    except IOError:
-        pass
-
-    try:
-        with open('/proc/sys/fs/inotify/max_user_instances') as limitfile:
-            max_watches = int(limitfile.readline())
-    except IOError:
-        pass
-
-    if max_watches is not None:
-        if max_watches != 0 and len(event_logs) >= max_watches:
-            warning("Too many log files to watch at once.  You can ask your administrator to increase '/proc/sys/user/max_inotify_instances' for you, or watch fewer jobs.")
-            sys.exit(0)
-
     tracker = JobStateTracker(event_logs, batch_names)
     if len(event_logs) == 0:
         warning("No jobs found, exiting...")

--- a/src/condor_utils/file_modified_trigger.h
+++ b/src/condor_utils/file_modified_trigger.h
@@ -45,6 +45,7 @@ class FileModifiedTrigger {
 #if defined( LINUX )
 		int read_inotify_events( void );
 		int inotify_fd;
+		bool inotify_initialized;
 #endif
 		int statfd;
 		off_t lastSize;


### PR DESCRIPTION
This should resolve the condor_watch_q problem, because condor_watch_q never actually blocks on a JobEventLog.