### PR TITLE
Use File::Temp to create temporary directories. HTCONDOR-763

### DIFF
--- a/src/condor_tests/cmd_wait_shows-all.run
+++ b/src/condor_tests/cmd_wait_shows-all.run
@@ -22,6 +22,7 @@
 use CondorTest;
 use CondorUtils;
 use Cwd;
+use File::Temp;
 #use Time::localtime;
 use strict;
 use warnings;
@@ -29,15 +30,13 @@ use warnings;
 my $cmd = "cmd_wait_shows.cmd";
 my $debuglevel = 2;
 
-my $pid = $$;
-runcmd("rm -rf $pid");
-runcmd("mkdir $pid");
 my $curcwd = getcwd();
+my $dir = File::Temp->newdir(CLEANUP => 0, DIR => $curcwd);
 CondorTest::debug("current directory is $curcwd\n",$debuglevel);
 
 my $socketname = "cmd_wait";
-my $resultfile = $curcwd . "/" . $pid . "/results";
-my $flowlog = $curcwd . "/" . $pid . "/cmd_wait_shows-all.log";
+my $resultfile = $dir->dirname . "/results";
+my $flowlog = $dir->dirname . "/cmd_wait_shows-all.log";
 my $writelog = "./x_write_joblog_events.exe";
 
 CondorTest::debug("Result File is $resultfile\n",$debuglevel);

--- a/src/condor_tests/cmd_wait_shows-base.run
+++ b/src/condor_tests/cmd_wait_shows-base.run
@@ -23,21 +23,20 @@ use CondorTest;
 use Cwd;
 use CondorUtils;
 #use Time::localtime;
+use File::Temp;
 use strict;
 use warnings;
 
 my $cmd = "cmd_wait_shows.cmd";
 my $debuglevel = 2;
 
-my $pid = $$;
-runcmd("rm -rf $pid");
-runcmd("mkdir $pid");
 my $curcwd = getcwd();
+my $dir = File::Temp->newdir(CLEANUP => 0, DIR => $curcwd);
 CondorTest::debug("current directory is $curcwd\n",$debuglevel);
 
 my $socketname = "cmd_wait";
-my $resultfile = $curcwd . "/" . $pid . "/results";
-my $flowlog = $curcwd . "/" . $pid . "/cmd_wait_shows-base.log";
+my $resultfile = $dir->dirname . "/results";
+my $flowlog = $dir->dirname . "/cmd_wait_shows-base.log";
 my $writelog = "./x_write_joblog_events.exe";
 
 CondorTest::debug("Result File is $resultfile\n",$debuglevel);

--- a/src/condor_tests/cmd_wait_shows-notimeout.run
+++ b/src/condor_tests/cmd_wait_shows-notimeout.run
@@ -23,21 +23,20 @@ use CondorTest;
 use Cwd;
 use CondorUtils;
 #use Time::localtime;
+use File::Temp;
 use strict;
 use warnings;
 
 my $cmd = "cmd_wait_shows.cmd";
 my $debuglevel = 2;
 
-my $pid = $$;
-runcmd("rm -rf $pid");
-runcmd("mkdir $pid");
 my $curcwd = getcwd();
+my $dir = File::Temp->newdir(CLEANUP => 0, DIR => $curcwd);
 CondorTest::debug("current directory is $curcwd\n",$debuglevel);
 
 my $socketname = "cmd_wait";
-my $resultfile = $curcwd . "/" . $pid . "/results";
-my $flowlog = $curcwd . "/" . $pid . "/cmd_wait_shows-notimeout.log";
+my $resultfile = $dir->dirname . "/results";
+my $flowlog = $dir->dirname . "/cmd_wait_shows-notimeout.log";
 my $writelog = "./x_write_joblog_events.exe";
 
 CondorTest::debug("Result File is $resultfile\n",$debuglevel);
@@ -59,7 +58,7 @@ while(!(-f $flowlog)) {
 	CondorTest::debug("<<$flowlog>> should have been here by now....\n",$debuglevel);
 	$count += 1;
 	if($count > 20) {
-		runcmd("ls -lR $pid");
+		runcmd("ls -lR " . $dir->dirname);
 		print "bad\n";
 		die "Flowlog should have existed by now\n";
 	}

--- a/src/condor_tests/cmd_wait_shows-partial.run
+++ b/src/condor_tests/cmd_wait_shows-partial.run
@@ -23,6 +23,7 @@ use CondorTest;
 use Cwd;
 use CondorUtils;
 #use Time::localtime;
+use File::Temp;
 use strict;
 use warnings;
 
@@ -36,18 +37,16 @@ CONDOR_TESTREQ_CONFIG
 
 my $debuglevel = 2;
 
-my $pid = $$;
-runcmd("rm -rf $pid");
-runcmd("mkdir $pid");
 my $curcwd = getcwd();
+my $dir = File::Temp->newdir(CLEANUP => 0, DIR => $curcwd);
 CondorTest::debug("current directory is $curcwd\n",$debuglevel);
 
 my $socketname = "cmd_wait";
-my $resultfile = $curcwd . "/" . $pid . "/results";
-my $outputfile = $curcwd . "/" . $pid . "/condor_wait.out";
+my $resultfile = $dir->dirname . "/results";
+my $outputfile = $dir->dirname . "/condor_wait.out";
 CondorTest::debug("condor_wait output is in $outputfile\n",$debuglevel);
 
-my $flowlog = $curcwd . "/" . $pid . "/cmd_wait_shows-partial.log";
+my $flowlog = $dir->dirname . "/cmd_wait_shows-partial.log";
 my $writelog = "./x_write_joblog_events.exe";
 
 CondorTest::debug("Result File is $resultfile\n",$debuglevel);

--- a/src/condor_tests/job_core_priority_van.run
+++ b/src/condor_tests/job_core_priority_van.run
@@ -22,17 +22,17 @@ use CondorTest;
 use CondorUtils;
 
 use Cwd;
+use File::Temp;
 
 $flowlog = "job_core_priority_van.data";
 $cmd = "job_core_priority_van.cmd";
 
-my $pid = $$;
-system("mkdir $pid");
 my $curcwd = getcwd();
+my $dir = File::Temp->newdir(CLEANUP => 0, DIR => $curcwd);
 CondorTest::debug("current directory is $curcwd\n",1);
 
 my $socketname = "priority";
-my $newsocketname = $curcwd . "/" . $pid . "/priority";
+my $newsocketname = $dir->dirname . "/priority";
 CondorTest::debug("current directory is $newsocketname\n",1);
 
 # start a server for this test
@@ -52,7 +52,7 @@ sleep(60);
 @filestoedit = qw/job_core_priority2/;
 @filestochmod = qw/job_core_priority2.pl/;
 
-# now make sure each place using socket refers to pid specific directory!
+# now make sure each place using socket refers to temporary directory!
 foreach $name (@filestoedit)
 {
 	CondorTest::debug("Correcting socket name in $name\n",1);

--- a/src/condor_tests/job_core_queue_sched.run
+++ b/src/condor_tests/job_core_queue_sched.run
@@ -23,6 +23,7 @@ use CondorTest;
 use CondorUtils;
 use Cwd;
 use Sys::Hostname;
+use File::Temp;
 
 $cmd = 'job_core_queue_sched.cmd';
 $testdesc =  'condor_submit queue - scheduler U';
@@ -30,18 +31,17 @@ $testname = "job_core_queue_sched";
 $queuelog = "submit_queue_scheduler_log.log";
 
 
-my $pid = $$;
-runcmd("mkdir $pid");
 my $curcwd = getcwd();
+my $dir = File::Temp->newdir(CLEANUP => 0, DIR => $curcwd);
 CondorTest::debug("current directory is $curcwd\n",1);
 
 my $socketname = "/tmp/queuetest";
-my $newsocketname = $curcwd . "/" . $pid . "/queuetest";
+my $newsocketname = $dir->dirname . "/queuetest";
 CondorTest::debug("current directory is $newsocketname\n",1);
 @filestoedit = qw/job_core_queue.pl/;
 @filestochmod = qw/job_core_queue.pl/;
 
-# now make sure each place using socket refers to pid specific directory!
+# now make sure each place using socket refers to the temporary directory!
 foreach $name (@filestoedit)
 {
 	CondorTest::debug("Correcting socket name in $name\n",1);

--- a/src/condor_tests/job_dagman_maxpostscripts.run
+++ b/src/condor_tests/job_dagman_maxpostscripts.run
@@ -22,6 +22,7 @@
 use CondorTest;
 use CondorUtils;
 use Cwd;
+use File::Temp;
 
 my $iswindows = CondorUtils::is_windows();
 
@@ -30,15 +31,14 @@ $cmd = 'job_dagman_maxpostscripts.dag';
 
 $serversubFile = "job_dagman_maxpostscripts-srvr.cmd";
 
-my $pid = "pdir$$";
-runcmd("mkdir -p $pid");
 my $curcwd = getcwd();
+my $dir = File::Temp->newdir(CLEANUP => 0, DIR => $curcwd);
 CondorTest::debug("current directory is $curcwd\n",1);
 
 my $socketname = "maxpostsock";
 my $appendfile =  "filetoappendto";
-my $newsocketname = $curcwd . "/" . $pid . "/maxpostsock";
-my $flowlog = $curcwd . "/" . $pid . "/job_dagman_maxpostscripts-srvr-log.log";
+my $newsocketname = $dir->dirname . "/maxpostsock";
+my $flowlog = $dir->dirname . "/job_dagman_maxpostscripts-srvr-log.log";
 if($iswindows) {
 	$_ = $flowlog;
 	s/\//\\\\/g;

--- a/src/condor_tests/job_dagman_maxprescripts.run
+++ b/src/condor_tests/job_dagman_maxprescripts.run
@@ -22,21 +22,21 @@
 use Cwd;
 use CondorUtils;
 use CondorTest;
+use File::Temp;
 
 my $iswindows = CondorUtils::is_windows();
 
 $cmd = 'job_dagman_maxprescripts.dag';
 
 
-my $pid = $$;
-runcmd("mkdir -p $pid");
 my $curcwd = getcwd();
+my $dir = File::Temp->newdir(CLEANUP => 0, DIR => $curcwd);
 CondorTest::debug("current directory is $curcwd\n",1);
 $serversubFile = "job_dagman_maxprescripts-srvr.cmd";
 
 my $socketname = "maxpresock";
-my $newsocketname = $curcwd . "/" . $pid . "/maxpresock";
-my $flowlog = $curcwd . "/" . $pid . "/job_dagman_maxprescripts-srvr-log.log";
+my $newsocketname = $dir->dirname . "/maxpresock";
+my $flowlog = $dir->dirname . "/job_dagman_maxprescripts-srvr-log.log";
 my $appendfile = "filetoappwndto";
 if($iswindows) {
 	$_ = $flowlog;

--- a/src/condor_tests/job_dagman_prepost.run
+++ b/src/condor_tests/job_dagman_prepost.run
@@ -22,6 +22,7 @@
 use CondorTest;
 use CondorUtils;
 use Cwd;
+use File::Temp;
 
 my $iswindows = CondorUtils::is_windows();
 
@@ -29,15 +30,14 @@ $cmd = 'job_dagman_prepost.dag';
 
 $serversubFile = "job_dagman_prepost-srvr.cmd";
 
-my $pid = $$;
-runcmd("mkdir $pid");
 my $curcwd = getcwd();
+my $dir = File::Temp->newdir(CLEANUP => 0, DIR => $curcwd);
 CondorTest::debug("current directory is $curcwd\n",1);
 CondorTest::LoadExemption("job_dagman_prepost,no,DC_AUTHENTICATE unable to receive auth_info!");
 
 my $socketname = "prepostsock";
-my $newsocketname = $curcwd . "/" . $pid . "/prepostsock";
-my $flowlog = $curcwd . "/" . $pid . "/job_dagman_prepost-srvr-log.log";
+my $newsocketname = $dir->dirname . "/prepostsock";
+my $flowlog = $dir->dirname . "/job_dagman_prepost-srvr-log.log";
 if($iswindows) {
 	$_ = $flowlog;
 	s/\//\\\\/g;
@@ -63,7 +63,7 @@ if(!($iswindows)) {
 @filestoedit = qw/job_dagman_prepost-prehello job_dagman_prepost-posthello/;
 @filestochmod = qw/job_dagman_prepost-prehello.pl job_dagman_prepost-posthello.pl/;
 
-# now make sure each place using socket refers to pid specific directory!
+# now make sure each place using socket refers to temp directory!
 foreach $name (@filestoedit)
 {
 	CondorTest::debug("Correcting socket name in $name\n",1);

--- a/src/condor_tests/lib_auth_protocol-gsi.run
+++ b/src/condor_tests/lib_auth_protocol-gsi.run
@@ -22,7 +22,7 @@ use CondorTest;
 use CondorUtils;
 
 use Cwd;
-
+use File::Temp;
 
 my $topleveldir = getcwd();
 
@@ -50,9 +50,9 @@ print scalar localtime() . "\n";
 $pid = $$;
 $mypid = $pid;
 
-$pidleveldir = $topleveldir . "/" . $mypid;
-system("mkdir -p $pidleveldir");
-chdir("$pidleveldir");
+my $dir = File::Temp->newdir(CLEANUP => 0, DIR => $topleveldir);
+$uniquedir = $dir->dirname;
+chdir("$uniquedir");
 system("tar -zxvf ../$mygsicerts");
 system("pwd;ls");
 # while here edit user into the mapfile
@@ -137,27 +137,27 @@ while(<CONFIGTPLATE>)
 	CondorUtils::fullchomp($_);
 	$line = $_;
 	if($line =~ /^GSI_DAEMON_CERT\s*=\s*XXXXX(\/.*)$/) {
-		$tmp = $pidleveldir . $1;
+		$tmp = $uniquedir . $1;
 		print CONFIG "GSI_DAEMON_CERT = $tmp\n";
 	} elsif($line =~ /^GSI_DAEMON_KEY\s*=\s*XXXXX(\/.*)$/) {
-		$tmp = $pidleveldir . $1;
+		$tmp = $uniquedir . $1;
 		print CONFIG "GSI_DAEMON_KEY = $tmp\n";
 	} elsif($line =~ /^GSI_DAEMON_TRUSTED_CA_DIR\s*=\s*XXXXX(\/.*)$/) {
-		$tmp = $pidleveldir . $1;
+		$tmp = $uniquedir . $1;
 		print CONFIG "GSI_DAEMON_TRUSTED_CA_DIR = $tmp\n";
 	} elsif($line =~ /^GSI_DAEMON_DIRECTORY\s*=\s*XXXXX(\/.*)$/) {
-		$tmp = $pidleveldir . $1;
+		$tmp = $uniquedir . $1;
 		print CONFIG "GSI_DAEMON_DIRECTORY = $tmp\n";
 	} elsif($line =~ /^GRIDMAP\s*=\s*XXXXX(\/.*)$/) {
-		$tmp = $pidleveldir . $1;
+		$tmp = $uniquedir . $1;
 		print CONFIG "GRIDMAP = $tmp\n";
 	} elsif($line =~ /^X509_CERT_DIR\s*=\s*XXXXX(\/.*)$/) {
-		$tmp = $pidleveldir . $1;
+		$tmp = $uniquedir . $1;
 		print CONFIG "X509_CERT_DIR = $tmp\n";
 		$ENV{X509_CERT_DIR} = $tmp;
 		CondorTest::debug("Set $ENV{X509_CERT_DIR} into the environment\n",1);
 	} elsif($line =~ /^X509_USER_PROXY\s*=\s*XXXXX(\/.*)$/) {
-		$tmp = $pidleveldir . $1;
+		$tmp = $uniquedir . $1;
 		print CONFIG "X509_USER_PROXY = $tmp\n";
 		$ENV{X509_USER_PROXY} = $tmp;
 		CondorTest::debug("Set $ENV{X509_USER_PROXY} into the environment\n",1);


### PR DESCRIPTION
Replace use of `mkdir $$` for unique directory creation with actual temporary directory creation.  This was causing sporadic failures in the Batlab when PIDs were reused.