### PR TITLE
HTCONDOR-785 build scripts work with bsd tar

### DIFF
--- a/build/cmake/macros/TarGz.cmake
+++ b/build/cmake/macros/TarGz.cmake
@@ -1,4 +1,5 @@
 if (NOT WINDOWS)
+    set( OWNER_OPTION --owner=0 --group=0 )
     if (LINUX)
 		set( TAR_COMMAND tar)
     else()
@@ -11,6 +12,7 @@ if (NOT WINDOWS)
 		if (NOT TAR_COMMAND)
 			# Could not find gtar, use "tar" and hope for the best
 			set( TAR_COMMAND tar)
+			set( OWNER_OPTION --uid=0 --gid=0 )
 		endif()
     endif()
 
@@ -21,7 +23,7 @@ if (NOT WINDOWS)
 	# For reasons we just can't explain, occasionally, on macos only, 
 	# tar fails with "file changed as we read it", because the mtime
 	# of a .a file moved.  Just retry the tar if it fails for any reason
-        COMMAND ${TAR_COMMAND} ARGS czf ${CPACK_PACKAGE_FILE_NAME}.tar.gz --owner=0 --group=0 --numeric-owner ${CPACK_PACKAGE_FILE_NAME} || ${TAR_COMMAND} ARGS czf ${CPACK_PACKAGE_FILE_NAME}.tar.gz --owner=0 --group=0 --numeric-owner ${CPACK_PACKAGE_FILE_NAME}
+        COMMAND ${TAR_COMMAND} ARGS czf ${CPACK_PACKAGE_FILE_NAME}.tar.gz ${OWNER_OPTION} --numeric-owner ${CPACK_PACKAGE_FILE_NAME} || ${TAR_COMMAND} ARGS czf ${CPACK_PACKAGE_FILE_NAME}.tar.gz ${OWNER_OPTION} --numeric-owner ${CPACK_PACKAGE_FILE_NAME}
         COMMAND mv ARGS ${CPACK_PACKAGE_FILE_NAME} ${CMAKE_INSTALL_PREFIX}
     )
     add_custom_target(targz DEPENDS ${CPACK_PACKAGE_FILE_NAME}.tar.gz)


### PR DESCRIPTION
The build scripts use --owner and --group for tar, which are available
in GNU tar but not BSD tar. The latter has equivlent options --uid and
--gid. Use those on macOS if GNU tar is not available.