### PR TITLE
Implement a first class transfer of archives

### DIFF
--- a/build/cmake/CondorConfigure.cmake
+++ b/build/cmake/CondorConfigure.cmake
@@ -468,6 +468,11 @@ if( NOT WINDOWS)
 		endif()
 	endif()
 
+	find_multiple( "archive" ARCHIVE_FOUND )
+	if ( ARCHIVE_FOUND )
+		set( HAVE_LIBARCHIVE TRUE )
+	endif()
+
     find_multiple( "z" ZLIB_FOUND)
 	find_multiple( "expat" EXPAT_FOUND )
 	find_multiple( "uuid" LIBUUID_FOUND )

--- a/src/condor_includes/config.h.cmake
+++ b/src/condor_includes/config.h.cmake
@@ -190,6 +190,9 @@
 /* Do we have the globus external (USED)*/
 #cmakedefine HAVE_EXT_GLOBUS 1
 
+/* Do we have archive */
+#cmakedefine HAVE_LIBARCHIVE 1
+
 /* Do we have the krb5 external (USED)*/
 #cmakedefine HAVE_EXT_KRB5 1
 

--- a/src/condor_includes/reli_sock.h
+++ b/src/condor_includes/reli_sock.h
@@ -170,6 +170,14 @@ public:
 	int get_file_with_permissions(filesize_t *size, const char *desination,
 								  bool flush_buffers=false, filesize_t max_bytes=-1,
 								  class DCTransferQueue *xfer_q=NULL);
+
+	int put_archive_file(const std::string &filename, filesize_t max_bytes,
+		DCTransferQueue &xfer_q, filesize_t &total_sent, CondorError &err);
+
+	int get_archive(const std::string &destination,
+	                filesize_t max_bytes, class DCTransferQueue &xfer_q,
+	                filesize_t &size, CondorError &err);
+
     /// returns <0 on failure, 0 for ok
 	//  failure codes: GET_FILE_OPEN_FAILED  (errno contains specific error)
 	//                 -1                    (all other errors)

--- a/src/condor_includes/sock.h
+++ b/src/condor_includes/sock.h
@@ -243,7 +243,7 @@ public:
             if (crypto_state_->m_keyInfo.getProtocol() != CONDOR_AESGCM) return plaintext_size;
 
             int cs = ((Condor_Crypt_AESGCM*)crypto_)->ciphertext_size_with_cs(plaintext_size, &(crypto_state_->m_stream_crypto_state));
-            dprintf(D_NETWORK, "Sock::ciphertext_size: went from plaintext_size %i to ciphertext_size %i.\n", plaintext_size, cs);
+            dprintf(D_NETWORK|D_FULLDEBUG, "Sock::ciphertext_size: went from plaintext_size %i to ciphertext_size %i.\n", plaintext_size, cs);
             return cs;
         }
 

--- a/src/condor_io/reli_sock.cpp
+++ b/src/condor_io/reli_sock.cpp
@@ -1014,7 +1014,7 @@ read_packet:
 			}
 			memcpy(aad_data + 2*md_size, hdr, header_size);
 			char hex[3*(32*2 + 5) + 1];
-			dprintf(D_NETWORK, "Expecting AAD with handshake digest %s\n",
+			dprintf(D_NETWORK|D_FULLDEBUG, "Expecting AAD with handshake digest %s\n",
 				debug_hex_dump(hex, reinterpret_cast<char*>(aad_data), 32*2 + 5));
 		}
 
@@ -1170,14 +1170,14 @@ int ReliSock::SndMsg::snd_packet( char const *peer_description, int _sock, int e
 			return false;
 		}
 		char hex[3*5 + 1];
-		dprintf(D_NETWORK, "Send Header contents: %s\n",
+		dprintf(D_NETWORK|D_FULLDEBUG, "Send Header contents: %s\n",
 			debug_hex_dump(hex, reinterpret_cast<char*>(hdr), header_size));
 
 		if (1 != EVP_DigestUpdate(p_sock->m_send_md_ctx.get(), buf.get_ptr(), buf.num_untouched())) {
 			dprintf(D_NETWORK, "IO: Failed to update the message digest.\n");
 			return false;
 		}
-		dprintf(D_NETWORK, "AESGCM: Send digest added %u + %d bytes \n", header_size, buf.num_untouched());
+		dprintf(D_NETWORK|D_FULLDEBUG, "AESGCM: Send digest added %u + %d bytes \n", header_size, buf.num_untouched());
 	}
 
 		// AES-GCM mode encrypts the whole message at send() time; do this now and
@@ -1244,7 +1244,7 @@ int ReliSock::SndMsg::snd_packet( char const *peer_description, int _sock, int e
 			}
 			memcpy(aad_data + 2*md_size, hdr, header_size);
 			char hex[3*(32*2 + 5) + 1];
-			dprintf(D_NETWORK, "Sending AAD with handshake digest %s\n",
+			dprintf(D_NETWORK|D_FULLDEBUG, "Sending AAD with handshake digest %s\n",
 				debug_hex_dump(hex, reinterpret_cast<char*>(aad_data), 32*2 + 5));
 		}
 

--- a/src/condor_utils/CMakeLists.txt
+++ b/src/condor_utils/CMakeLists.txt
@@ -595,6 +595,9 @@ condor_shared_lib(condor_utils
 	$<TARGET_OBJECTS:condor_utils_objects>
 	$<TARGET_OBJECTS:condor_extra_objects>
 )
+if (HAVE_LIBARCHIVE)
+	target_link_libraries(condor_utils ${ARCHIVE_FOUND})
+endif()
 
 if ( ${PACKAGE_VERSION} MATCHES "([0-9]+)[.]([0-9]+)[.]([0-9]+)" )
 	set( UTILS_LIB_NAME "condor_utils_${CMAKE_MATCH_1}_${CMAKE_MATCH_2}_${CMAKE_MATCH_3}" )
@@ -617,6 +620,9 @@ if (LINUX OR DARWIN)
    set_target_properties( condor_utils_s PROPERTIES OUTPUT_NAME "${UTILS_LIB_NAME}" )
    if (HAVE_GNU_LD)
 	target_link_libraries( condor_utils_s -Wl,--wrap,exit )
+   endif()
+   if (HAVE_LIBARCHIVE)
+      target_link_libraries(condor_utils_s  ${ARCHIVE_FOUND})
    endif()
 endif(LINUX OR DARWIN)
 


### PR DESCRIPTION
This branch takes an archive (anything supported by libarchive - cpio or tar, compressed or not) and the receiver will automatically unpack into the destination directory instead of writing out the tarfile.

Why?  As far as we can tell, the condor file transfer protocol is perfectly adept at moving directories.  However, some users prefer to reduce the number of files on the submit side by keeping tarballs in order to avoid hitting file quotas or to simplify management of their input data.