### PR TITLE
Auto publish release to website

### DIFF
--- a/.github/workflows/delete_release_to_website.yml
+++ b/.github/workflows/delete_release_to_website.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-18.04
     env:
       publish_path: _news
-      publish_branch: preview-release
+      publish_branch: master
       publish_repo_ssh: git@github.com:htcondor/htcondor-web.git
     steps:
 
@@ -20,7 +20,7 @@ jobs:
       - run: |
           git clone ${{ env.publish_repo_ssh }} ./
           git fetch --all
-          git checkout -b ${{ env.publish_branch }} origin/${{ env.publish_branch }}
+          git checkout -b build-release-page origin/${{ env.publish_branch }}
 
           git rm -f ./${{ env.publish_path }}/${{ github.event.release.tag_name }}.md
 
@@ -28,4 +28,4 @@ jobs:
           git config user.name "Automatic Release Publish"
           git config user.email ""
           git commit -am "GHA: Delete Release"
-          git push
+          git push origin build-release-page:${{ env.publish_branch }}

--- a/.github/workflows/publish_release_to_website.yml
+++ b/.github/workflows/publish_release_to_website.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-18.04
     env:
       publish_path: _news
-      publish_branch: preview-release
+      publish_branch: master
       publish_repo_ssh: git@github.com:htcondor/htcondor-web.git
     steps:
 
@@ -28,7 +28,7 @@ jobs:
           git clone ${{ env.publish_repo_ssh }} ./website
           cd website
           git fetch --all
-          git checkout -b ${{ env.publish_branch }} origin/${{ env.publish_branch }}
+          git checkout -b build-release-page origin/${{ env.publish_branch }}
 
           mv ../*.md ./${{ env.publish_path }} # Move markdown created by the build_release_page action to branch
 
@@ -37,4 +37,4 @@ jobs:
           git config user.name "Automatic Release Publish"
           git config user.email ""
           git commit -am "GHA: Publish Release https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}"
-          git push
+          git push origin build-release-page:${{ env.publish_branch }}


### PR DESCRIPTION
Publishes releases to the website as news articles with the titles and bodies containing the content of the releases.

Works with the initial publish, edits and deletion of releases.

Supports all markdown that is used in Github md, with the exception of '@' references and '#' are not linked as they are in Github.

**Before merge a repo admin will have to add a deploy key for htcondor-web as a secret with the name 'HTCONDOR_WEB_DEPLOY_KEY'.**