### PR TITLE
HTCONDOR-697 job proxy handling without GSI

### DIFF
--- a/src/condor_gridmanager/proxymanager.cpp
+++ b/src/condor_gridmanager/proxymanager.cpp
@@ -231,7 +231,6 @@ AcquireProxy( const ClassAd *job_ad, std::string &error,
 		email = x509_proxy_email( proxy_path.c_str() );
 
 		fqan = NULL;
-#if defined(HAVE_EXT_GLOBUS)
 		int rc = extract_VOMS_info_from_file( proxy_path.c_str(), 0, NULL,
 											  &first_fqan, &fqan );
 		if ( rc != 0 && rc != 1 ) {
@@ -242,7 +241,6 @@ AcquireProxy( const ClassAd *job_ad, std::string &error,
 			free( email );
 			return NULL;
 		}
-#endif
 		if ( fqan ) {
 			has_voms_attrs = true;
 		} else {

--- a/src/condor_schedd.V6/qmgmt.cpp
+++ b/src/condor_schedd.V6/qmgmt.cpp
@@ -5534,7 +5534,7 @@ void AddClusterEditedAttributes(std::set<std::string> & ad_keys)
 bool
 ReadProxyFileIntoAd( const char *file, const char *owner, ClassAd &x509_attrs )
 {
-#if !defined(HAVE_EXT_GLOBUS)
+#if defined(WIN32)
 	(void)file;
 	(void)owner;
 	(void)x509_attrs;

--- a/src/condor_schedd.V6/schedd.cpp
+++ b/src/condor_schedd.V6/schedd.cpp
@@ -284,7 +284,7 @@ void AuditLogJobProxy( const Sock &sock, PROC_ID job_id, const char *proxy_file 
 			 job_id.cluster, job_id.proc );
 	dprintf( D_AUDIT, sock, "proxy path: %s\n", proxy_file );
 
-#if defined(HAVE_EXT_GLOBUS)
+#if !defined(WIN32)
 	X509Credential* proxy_handle = x509_proxy_read( proxy_file );
 
 	if ( proxy_handle == NULL ) {

--- a/src/condor_utils/submit_utils.cpp
+++ b/src/condor_utils/submit_utils.cpp
@@ -2476,7 +2476,7 @@ int SubmitHash::SetGSICredentials()
 		std::string full_proxy_file = full_path( proxy_file );
 		free(proxy_file);
 		proxy_file = NULL;
-#if defined(HAVE_EXT_GLOBUS)
+#if !defined(WIN32)
 // this code should get torn out at some point (8.7.0) since the SchedD now
 // manages these attributes securely and the values provided by submit should
 // not be trusted.  in the meantime, though, we try to provide some cross


### PR DESCRIPTION
Now that we do job proxy handling without GSI, remove the check for
having GSI. Exclude windows for now, since there's some
privilege-switching code that would need some work.