### PR TITLE
(HTCONDOR-778)  It makes gcc sad when values of an enum are excluded.

### DIFF
--- a/src/condor_utils/submit_utils.cpp
+++ b/src/condor_utils/submit_utils.cpp
@@ -5387,6 +5387,9 @@ int SubmitHash::SetExtendedJobExprs()
 				if (strchr(str.c_str(), ',')) { cmd[0].opts |= SimpleSubmitKeyword::f_as_list; }
 				else if (starts_with_ignore_case(str, "file")) { cmd[0].opts |= SimpleSubmitKeyword::f_genfile; }
 				} break;
+			default:
+				// SimpleSubmitKeyword::f_as_expr
+				break;
 			}
 		}
 		// apply the command


### PR DESCRIPTION
I talked to TJ about this code; he sets the desired default value for the other enumerated values before the switch.