### PR TITLE
HTCondor-899: Declare variable conditionally to prevent unused variable compiler errors

### DIFF
--- a/src/condor_utils/xform_utils.cpp
+++ b/src/condor_utils/xform_utils.cpp
@@ -46,8 +46,10 @@
 #include <set>
 
 // values for hashtable defaults, these are declared as char rather than as const char to make g++ on fedora shut up.
-static char OneString[] = "1", ZeroString[] = "0";
-//static char ParallelNodeString[] = "#pArAlLeLnOdE#";
+#if defined(WIN32) || defined(LINUX)
+static char OneString[] = "1"
+#endif
+static char ZeroString[] = "0";
 static char UnsetString[] = "";
 
 
@@ -67,7 +69,6 @@ static condor_params::string_value IsLinuxMacroDef = { ZeroString, 0 };
 static condor_params::string_value IsWinMacroDef = { ZeroString, 0 };
 #endif
 static condor_params::string_value UnliveRulesFileMacroDef = { UnsetString, 0 };
-//static condor_params::string_value UnliveClusterMacroDef = { OneString, 0 };
 static condor_params::string_value UnliveProcessMacroDef = { ZeroString, 0 };
 static condor_params::string_value UnliveStepMacroDef = { ZeroString, 0 };
 static condor_params::string_value UnliveRowMacroDef = { ZeroString, 0 };

--- a/src/condor_utils/xform_utils.cpp
+++ b/src/condor_utils/xform_utils.cpp
@@ -47,7 +47,7 @@
 
 // values for hashtable defaults, these are declared as char rather than as const char to make g++ on fedora shut up.
 #if defined(WIN32) || defined(LINUX)
-static char OneString[] = "1"
+static char OneString[] = "1";
 #endif
 static char ZeroString[] = "0";
 static char UnsetString[] = "";


### PR DESCRIPTION
This PR addresses an 'unused variable' compiler error on macOS by only defining the relevant variable on platforms where it will be used.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) ) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
