### PR TITLE
HTCONDOR-839: Remove old SYS_ARCH hack on OSX

### DIFF
--- a/build/cmake/CondorConfigure.cmake
+++ b/build/cmake/CondorConfigure.cmake
@@ -18,10 +18,7 @@
 
 # OS pre mods
 if(${OS_NAME} STREQUAL "DARWIN")
-	# All recent versions of Mac OS X are 64-bit, but 'uname -p'
-	# (the source for SYS_ARCH) reports 'i386'.
-	# Override that to set the actual architecture.
-	set (SYS_ARCH "X86_64")
+	#this needs to be evaluated in order due to WIN collision.
 elseif(${OS_NAME} MATCHES "WIN")
 	set(WINDOWS ON)
 


### PR DESCRIPTION
This PR removes an old hack which forces `SYS_ARCH` to `X86_64` on all macOS versions, which will definitely break builds on arm macs.

This hasn't been required since cmake-3.0.0,
see https://gitlab.kitware.com/cmake/cmake/-/commit/9d2a0900ed48eb4ae2df0e7672b9ede5af28e193

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) ) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
