### PR TITLE
HTCONDOR-834 Remove use of Carbon framework on macOS

### DIFF
--- a/docs/platform-specific/macintosh-osx.rst
+++ b/docs/platform-specific/macintosh-osx.rst
@@ -5,10 +5,8 @@ Macintosh OS X
 
 This section provides information specific to the Macintosh OS X port of
 HTCondor. The Macintosh port of HTCondor is more accurately a port of
-HTCondor to Darwin, the BSD core of OS X. HTCondor uses the Carbon
-library only to detect keyboard activity, and it does not use Cocoa at
-all. HTCondor on the Macintosh is a relatively new port, and it is not
-yet well-integrated into the Macintosh environment.
+HTCondor to Darwin, the BSD layer of OS X.
+It is not well-integrated into the Macintosh environment beyond that.
 
 HTCondor on the Macintosh has a few shortcomings:
 
@@ -17,4 +15,3 @@ HTCondor on the Macintosh has a few shortcomings:
 -  The memory size of threaded programs is reported incorrectly.
 -  No Macintosh-based installer is provided.
 -  The example start up scripts do not follow Macintosh conventions.
--  Kerberos is not supported.

--- a/src/condor_startd.V6/CMakeLists.txt
+++ b/src/condor_startd.V6/CMakeLists.txt
@@ -17,10 +17,6 @@
  ############################################################### 
 
 
-if (DARWIN)
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework IOKit -framework Carbon")
-endif()
-
 set(startdElements
 backfill_mgr.cpp
 claim.cpp

--- a/src/condor_sysapi/idle_time.cpp
+++ b/src/condor_sysapi/idle_time.cpp
@@ -18,36 +18,18 @@
  ***************************************************************/
 
 
-#ifdef Darwin
-/*
-  This is REALLY evil, but it works (for now).  Carbon.h defines a
-  bunch of stuff as enums that the regular system header files declare
-  with #define.  If you include all the system headers first and
-  *then* include Carbon.h, this enum crap creates header file parse
-  error madness on TCP_NODELAY (for example).  However, if you include
-  Carbon.h first, it all works, since Carbon.h does its own #define
-  and the system headers check #ifdef before they do their own
-  #define.  Even though it goes against everything else we say about
-  condor_common.h always being included first, for this 1 .C file
-  (since it's the only place we include Carbon.h), for this 1
-  platform, it seems that this is an easy work-around and this file
-  still compiles.  Derek <wright@cs.wisc.edu> 2005-09-11.
-*/
-#define dprintf dprintf_hide
-
-#include <mach/mach.h>
-#include <IOKit/IOKitLib.h>
-#include <IOKit/hid/IOHIDLib.h>
-#include <CoreFoundation/CoreFoundation.h>
-#include <Carbon/Carbon.h>
-#undef dprintf
-#endif
-
 #include "condor_common.h"
 #include "condor_config.h"
 #include "condor_debug.h"
 #include "sysapi.h"
 #include "sysapi_externs.h"
+
+#if defined(DARWIN)
+#include <mach/mach.h>
+#include <IOKit/IOKitLib.h>
+#include <IOKit/hid/IOHIDLib.h>
+#include <CoreFoundation/CoreFoundation.h>
+#endif
 
 /* define some static functions */
 #if defined(WIN32)
@@ -780,8 +762,7 @@ extract_idle_time(
     CFMutableDictionaryRef  properties)
 {
     time_t    idle_time = -1;
-	UInt64  nanoseconds, billion, seconds_64, remainder;
-	UInt32  seconds;
+	int64_t nanoseconds;
     CFTypeRef object = CFDictionaryGetValue(properties, CFSTR(kIOHIDIdleTimeKey));
 	CFRetain(object);
  
@@ -807,11 +788,9 @@ extract_idle_time(
             dprintf(D_ALWAYS, "IDLE: Idle time didnt match CFDataGetTypeID.\n");
 			CFRelease(object);
 			return idle_time;
-		}	
-		billion = U64SetU(1000000000);
-		seconds_64 = U64Divide(nanoseconds, billion, &remainder);
-		seconds = U32SetU(seconds_64);
-		idle_time = seconds;
+		}
+		// Convert from nanoseconds to seconds
+		idle_time = nanoseconds / 1000000000;
     }
 	// CFRelease seems to be hip with taking a null object. This seems
 	// strange to me, but hey, at least I thought about it


### PR DESCRIPTION
We were using functions that allowed basic handling of 64-bit integers
on 32-bit architectures.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) ) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
