### PR TITLE
Fix basic use of USER_IS_THE_NEW_OWNER

### DIFF
--- a/src/condor_schedd.V6/qmgmt.cpp
+++ b/src/condor_schedd.V6/qmgmt.cpp
@@ -4346,9 +4346,9 @@ SetAttribute(int cluster_id, int proc_id, const char *attr_name,
 			YourStringNoCase sock_domain(Q_SOCK->getDomain());
 
 			if (uid_domain != sock_domain &&
-				!strcmp("family", Q_SOCK->getDomain()) &&
-				!strcmp("parent", Q_SOCK->getDomain()) &&
-				!strcmp("child", Q_SOCK->getDomain()))
+				strcmp("family", Q_SOCK->getDomain()) &&
+				strcmp("parent", Q_SOCK->getDomain()) &&
+				strcmp("child", Q_SOCK->getDomain()))
 			{
 				new_value.clear();
 				attr_value = "\"nobody\"";

--- a/src/condor_schedd.V6/qmgmt.cpp
+++ b/src/condor_schedd.V6/qmgmt.cpp
@@ -5716,9 +5716,10 @@ AddSessionAttributes(const std::list<std::string> &new_ad_keys)
 		GetAttributeString(job.cluster, job.proc, ATTR_X509_USER_PROXY, x509up);
 		GetAttributeString(job.cluster, job.proc, ATTR_JOB_IWD, iwd);
 
-#if 0 // tj: pretty sure this unnecessary, it certainly doesn't belong here...
+		// While we're populating attributes with information from the security session,
+		// we need to ensure that ATTR_USER is set for this job; in `user_is_the_new_owner`
+		// mode, this is a mandatory attribute.
 		if (user_is_the_new_owner && job.proc == -1) {
-			// Ensure that the user is set for all clusters
 			std::string user;
 			GetAttributeString(job.cluster, job.proc, ATTR_USER, user);
 			if (user.empty()) {
@@ -5728,7 +5729,6 @@ AddSessionAttributes(const std::list<std::string> &new_ad_keys)
 				SetAttribute(job.cluster, job.proc, ATTR_USER, "UNDEFINED");
 			}
 		}
-#endif
 
 		if (job.proc != -1 && x509up.empty()) {
 			if (iwd.empty()) {

--- a/src/condor_schedd.V6/schedd.cpp
+++ b/src/condor_schedd.V6/schedd.cpp
@@ -3425,7 +3425,13 @@ Scheduler::get_submitter_and_owner(JobQueueJob * job, SubmitterData * & submitte
 	if ( ! job->LookupString(attr_JobUser,real_owner) ) {
 		return NULL;
 	}
-	if (strcmp(UidDomain, AccountingDomain.c_str())) {
+		// If USER_IS_THE_NEW_OWNER, we always put the user in the
+		// accounting domain.  This code must match the logic in
+		// `get_job_prio` otherwise we have submitter ads named differently
+		// than the name used in the  prio rec array.
+	if (strcmp(UidDomain, AccountingDomain.c_str()) ||
+		user_is_the_new_owner)
+	{
 		auto last_at = real_owner.find_last_of('@');
 		if (last_at != std::string::npos) {
 			real_owner = real_owner.substr(0, last_at) + "@" + AccountingDomain;


### PR DESCRIPTION
This fixes up a few warts of the experimental `USER_IS_THE_NEW_OWNER` feature noticed by U.Chicago and Nebraska when they were trying to utilize it.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
