### PR TITLE
HTCONDOR-871 Condor-C don't resubmit after failure

### DIFF
--- a/docs/version-history/stable-release-series-90.rst
+++ b/docs/version-history/stable-release-series-90.rst
@@ -22,7 +22,9 @@ New Features:
 
 Bugs Fixed:
 
-- None.
+- When a grid universe job of type ``condor`` fails on the remote system,
+  the local job is now put on hold, instead of automatically resubmitted.
+  :jira:`871`
 
 Version 9.0.8
 -------------

--- a/src/condor_gridmanager/condorjob.cpp
+++ b/src/condor_gridmanager/condorjob.cpp
@@ -901,7 +901,15 @@ void CondorJob::doEvaluateState()
 				gmState = GM_HOLD;
 				break;
 			}
-			if ( num_ads != 1 ) {
+			if ( num_ads == 0 ) {
+				dprintf( D_ALWAYS,
+						 "(%d.%d) condor_job_status_constrained() returned %d ads\n",
+						 procID.cluster, procID.proc, num_ads );
+				errorString = "Job disappeared from remote schedd";
+				SetRemoteJobId( NULL );
+				gmState = GM_HOLD;
+				break;
+			} else if ( num_ads != 1 ) {
 				dprintf( D_ALWAYS,
 						 "(%d.%d) condor_job_status_constrained() returned %d ads\n",
 						 procID.cluster, procID.proc, num_ads );
@@ -1060,7 +1068,7 @@ void CondorJob::doEvaluateState()
 				gmState = GM_DELETE;
 			} else {
 				SetRemoteJobId( NULL );
-				gmState = GM_CLEAR_REQUEST;
+				gmState = GM_HOLD;
 			}
 			} break;
 		case GM_DELETE: {


### PR DESCRIPTION
Put Condor-C jobs on hold after failure, instead of resubmitting immediately.

https://opensciencegrid.atlassian.net/browse/HTCONDOR-871

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
