### PR TITLE
HTCONDOR-886 spooled user log written in wrong directory

### DIFF
--- a/docs/version-history/stable-release-series-90.rst
+++ b/docs/version-history/stable-release-series-90.rst
@@ -36,6 +36,11 @@ Bugs Fixed:
   handler in *condor_credmon_oauth* when using Python 3.
   :jira:`633`
 
+- Fixed a bug where the user job log could be written in the wrong
+  directory when a spooled job's output was retrieved with
+  *condor_transfer_data*.
+  :jira:`886`
+
 .. _lts-version-history-908:
 
 Version 9.0.8

--- a/src/condor_schedd.V6/qmgmt.cpp
+++ b/src/condor_schedd.V6/qmgmt.cpp
@@ -7123,11 +7123,15 @@ rewriteSpooledJobAd(ClassAd *job_ad, int cluster, int proc, bool modify_ad)
 				command_parts.next();
 				auto dest = command_parts.next();
 				if (IsUrl(dest)) {
+					if (!url_remap_commands.empty()) {
+						url_remap_commands += ";";
+					}
 					url_remap_commands += command;
-					url_remap_commands += ";";
 				} else {
+					if (!remap_commands.empty()) {
+						remap_commands += ";";
+					}
 					remap_commands += command;
-					remap_commands += ";";
 				}
 			}
 			if (modify_ad) {


### PR DESCRIPTION
User log can be written to wrong directory when retrieving output of spooled jobs.

https://opensciencegrid.atlassian.net/browse/HTCONDOR-886

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
