### PR TITLE
Ensure that Google Cloud Custom metadata values are properly quoted

### DIFF
--- a/src/condor_scripts/common-cloud-attributes-google.py
+++ b/src/condor_scripts/common-cloud-attributes-google.py
@@ -148,7 +148,7 @@ def convert_metadata_to_classad(
         safe_val = getattr(metadata.instance.attributes, key, None)
         if safe_val:
             safe_attr = safe_htcondor_attribute(key)
-            ad[safe_attr] = safe_val
+            ad[safe_attr] = f'"{safe_val}"'
     return ad
 
 


### PR DESCRIPTION
I am testing the use of the Common Cloud Attributes feature and found that we aren't properly quoting custom metadata values on Google Cloud.

This specific example

```
use feature:CommonCloudAttributesGoogle("-c created-by")
```

produces an actual ClassAd like this

```
CloudCreatedBy = projects / 615838180790 / regions / us - central1 / instanceGroupManagers / htc - type1 - mig
```

@Todd-L-Miller 

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
