### PR TITLE
HTCONDOR-888 adstash startd fix

### DIFF
--- a/docs/version-history/stable-release-series-90.rst
+++ b/docs/version-history/stable-release-series-90.rst
@@ -42,6 +42,10 @@ Bugs Fixed:
   handler in *condor_credmon_oauth* when using Python 3.
   :jira:`633`
 
+- Fixed a bug in *condor_adstash* where setting a list of *condor_startds*
+  to query in the config lead to no *condor_startds* being queried.
+  :jira:`888`
+
 .. _lts-version-history-908:
 
 Version 9.0.8

--- a/src/condor_scripts/adstash/utils.py
+++ b/src/condor_scripts/adstash/utils.py
@@ -89,7 +89,7 @@ def get_startds(args=None):
             for ad in name_ads:
                 try:
                     if ad["Name"][0:6] == "slot1@" or not ("@" in ad["Name"]):
-                        if args.startds and not (startd["Machine"] in args.startds.split(",")):
+                        if args.startds and not (ad["Machine"] in args.startds.split(",")):
                             continue
                         # Remote history bindings only exist in startds running 8.9.7+
                         version = tuple([int(x) for x in ad["CondorVersion"].split()[1].split(".")])


### PR DESCRIPTION
Fixes an issue where comparing a list of startds from the collector with a list of startds in the config lead to an empty list, even if some startds actually existed in both places.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
