### PR TITLE
HTCONDOR-878 Fix blahp build dependencies

### DIFF
--- a/src/blahp/src/CMakeLists.txt
+++ b/src/blahp/src/CMakeLists.txt
@@ -65,8 +65,8 @@ add_library(libblahp STATIC
 
 # These are not actually libraies, but rather a cmake
 # virtual holder of .o files
-add_library(libbfunctions OBJECT Bfunctions.c)
-add_library(libblfunctions OBJECT BLfunctions.c)
+add_library(libbfunctions STATIC Bfunctions.c)
+add_library(libblfunctions STATIC BLfunctions.c)
 
 # programs for 'sbin'
 add_executable(blahpd_daemon main_daemon.c)
@@ -90,7 +90,7 @@ if(NOT CONDOR_PACKAGE_NAME)
 endif()
 target_link_libraries(blah_job_registry_scan_by_subject ${ClassAd_LIBRARY})
 add_executable(blah_check_config blah_check_config.c)
-target_link_libraries(blah_check_config $<TARGET_OBJECTS:libbfunctions> libblahp)
+target_link_libraries(blah_check_config libbfunctions libblahp)
 
 add_executable(blah_job_registry_dump blah_job_registry_dump.c)
 target_link_libraries(blah_job_registry_dump libblahp)
@@ -109,34 +109,34 @@ target_link_libraries(blahpd -lpthread ${ClassAd_LIBRARY})
 
 # programs for 'libexec'
 add_executable(BLClient BLClient.c)
-target_link_libraries(BLClient $<TARGET_OBJECTS:libblfunctions> libblahp)
+target_link_libraries(BLClient libblfunctions libblahp)
 
 add_executable(BLParserLSF BLParserLSF.c)
 target_link_libraries(BLParserLSF -lpthread)
-target_link_libraries(BLParserLSF $<TARGET_OBJECTS:libblfunctions> libblahp)
+target_link_libraries(BLParserLSF libblfunctions libblahp)
 
 add_executable(BLParserPBS BLParserPBS.c)
 target_link_libraries(BLParserPBS -lpthread)
-target_link_libraries(BLParserPBS $<TARGET_OBJECTS:libblfunctions> libblahp)
+target_link_libraries(BLParserPBS libblfunctions libblahp)
 
 add_executable(BUpdaterCondor BUpdaterCondor.c)
 target_link_libraries(BUpdaterCondor -lpthread)
-target_link_libraries(BUpdaterCondor $<TARGET_OBJECTS:libbfunctions> libblahp)
+target_link_libraries(BUpdaterCondor libbfunctions libblahp)
 
 add_executable(BNotifier BNotifier.c)
 target_link_libraries(BNotifier -lpthread)
-target_link_libraries(BNotifier $<TARGET_OBJECTS:libbfunctions> libblahp)
+target_link_libraries(BNotifier libbfunctions libblahp)
 
 add_executable(BUpdaterLSF BUpdaterLSF.c)
 target_link_libraries(BUpdaterLSF -lpthread -lm)
-target_link_libraries(BUpdaterLSF $<TARGET_OBJECTS:libbfunctions> libblahp)
+target_link_libraries(BUpdaterLSF libbfunctions libblahp)
 
 add_executable(BUpdaterPBS BUpdaterPBS.c)
 target_link_libraries(BUpdaterPBS -lpthread -lm)
-target_link_libraries(BUpdaterPBS $<TARGET_OBJECTS:libbfunctions> libblahp)
+target_link_libraries(BUpdaterPBS libbfunctions libblahp)
 
 add_executable(BUpdaterSGE BUpdaterSGE.c)
-target_link_libraries(BUpdaterSGE $<TARGET_OBJECTS:libbfunctions> libblahp)
+target_link_libraries(BUpdaterSGE libbfunctions libblahp)
 
 add_executable(blparser_master blparser_master.c)
 target_link_libraries(blparser_master libblahp)


### PR DESCRIPTION
Turn libbfunctions and libblfunctions into actual static libraries in
the cmake files. Otherwise, cmake doesn't ensure that their source files
are built before the binaries that depend on them.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
