### PR TITLE
HTCONDOR-892: create etc/condor before putting stuff into it

### DIFF
--- a/build/packaging/srpm/condor.spec
+++ b/build/packaging/srpm/condor.spec
@@ -836,9 +836,6 @@ make tests-tar-pkg
 cp -p %{_builddir}/%{name}-%{version}/condor_tests-*.tar.gz %{buildroot}/%{_libdir}/condor/condor_tests-%{version}.tar.gz
 %endif
 
-# Drop in a symbolic link for backward compatibility
-ln -s ../..%{_libdir}/condor/condor_ssh_to_job_sshd_config_template %{buildroot}/%_sysconfdir/condor/condor_ssh_to_job_sshd_config_template
-
 %if %uw_build
 %if 0%{?rhel} == 7 && ! 0%{?amzn}
 # Drop in a link for backward compatibility for small shadow
@@ -850,6 +847,10 @@ populate /usr/share/doc/condor-%{version}/examples %{buildroot}/usr/share/doc/co
 #rm -rf %{buildroot}/usr/share/doc/condor-%{version}/etc
 
 mkdir -p %{buildroot}/%{_sysconfdir}/condor
+
+# Drop in a symbolic link for backward compatibility
+ln -s ../..%{_libdir}/condor/condor_ssh_to_job_sshd_config_template %{buildroot}/%_sysconfdir/condor/condor_ssh_to_job_sshd_config_template
+
 # the default condor_config file is not architecture aware and thus
 # sets the LIB directory to always be /usr/lib, we want to do better
 # than that. this is, so far, the best place to do this


### PR DESCRIPTION
https://opensciencegrid.atlassian.net/browse/HTCONDOR-892

The symbolic link dropped into place in /etc/condor is linked in before the directory is created. This is obviously wrong. However, for some reason it worked until the 9.5.0 release branch. See koji build https://koji.opensciencegrid.org/koji/getfile?taskID=352828&volume=DEFAULT&name=build.log&offset=-4000

Since the ordering is obviously wrong, I am making this change in the stable branch.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
