### PR TITLE
HTCONDOR-838: Always install condor-blahp

### DIFF
--- a/build/packaging/srpm/condor.spec
+++ b/build/packaging/srpm/condor.spec
@@ -275,6 +275,8 @@ Requires: condor-procd = %{version}-%{release}
 Requires: %name-externals = %version-%release
 %endif
 
+Requires: %name-blahp = %version-%release
+
 # Useful tools are using the Python bindings
 Requires: python3-condor
 # The use the python-requests library in EPEL is based Python 3.6


### PR DESCRIPTION
https://opensciencegrid.atlassian.net/browse/HTCONDOR-838

We used to always install blahp with HTCondor. OSG depends on this behavior. So, let's restore it.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
