### PR TITLE
HTCONDOR-899  Clean up ConnectQ() arguments

### DIFF
--- a/nmi_tools/check_nmi_queue_depth.pl
+++ b/nmi_tools/check_nmi_queue_depth.pl
@@ -57,7 +57,7 @@ if($SEND_EMAIL) {
         $subject .= " (" . scalar(@missing) . " platforms missing?)";
     }
 
-    if(not open(MAIL, "|/bin/mail -s \"$subject\" $SEND_EMAIL >/dev/null 2>&1")) {
+    if(not open(MAIL, "|/usr/bin/mail -s \"$subject\" $SEND_EMAIL >/dev/null 2>&1")) {
         print "Results:";
         print @email;
         logger("Failed to send mail!\n");
@@ -66,11 +66,11 @@ if($SEND_EMAIL) {
     print MAIL @email;
     if(not close(MAIL)) {
         if($!) {
-            logger("Error - failure while closing /bin/mail: $!");
+            logger("Error - failure while closing /usr/bin/mail: $!");
             return 0;
         }
         else {
-            logger("Error - /bin/mail returned exit status $?");
+            logger("Error - /usr/bin/mail returned exit status $?");
             return 0;
         }
     }

--- a/src/condor_c-gahp/schedd_client.cpp
+++ b/src/condor_c-gahp/schedd_client.cpp
@@ -587,7 +587,7 @@ doContactSchedd()
 	Qmgr_connection * qmgr_connection;
 
 	errstack.clear();
-	if ((qmgr_connection = ConnectQ(dc_schedd.addr(), QMGMT_TIMEOUT, false, &errstack, NULL, dc_schedd.version() )) == NULL) {
+	if ((qmgr_connection = ConnectQ(dc_schedd, QMGMT_TIMEOUT, false, &errstack)) == NULL) {
 		error = TRUE;
 		formatstr( error_msg, "Error connecting to schedd %s: %s", ScheddAddr,
 				   errstack.getFullText().c_str() );
@@ -1092,7 +1092,7 @@ submit_report_result:
 	if (qmgr_connection != NULL)
 	{
 		DisconnectQ(qmgr_connection, FALSE);
-		if ((qmgr_connection = ConnectQ(dc_schedd.addr(), QMGMT_TIMEOUT, true, &errstack, NULL, dc_schedd.version() )) == NULL)
+		if ((qmgr_connection = ConnectQ(dc_schedd, QMGMT_TIMEOUT, true, &errstack )) == NULL)
 		{
 			formatstr(error_msg, "Error connecting to schedd %s for read-only commands: %s", ScheddAddr, errstack.getFullText().c_str());
 			dprintf(D_ALWAYS, "%s\n", error_msg.c_str());

--- a/src/condor_contrib/campus_factory/share/glidein_jobs/glidein_condor_config
+++ b/src/condor_contrib/campus_factory/share/glidein_jobs/glidein_condor_config
@@ -27,7 +27,6 @@ MAXJOBRETIREMENTTIME = 34800
 LOG = $(LOCAL_DIR)/log
 EXECUTE = $(LOCAL_DIR)/execute
 
-MAIL = /bin/mail
 DAEMON_LIST = MASTER, STARTD
 MASTER_ADDRESS_FILE = $(LOG)/.master_address
 MASTER = $(SBIN)/condor_master

--- a/src/condor_contrib/campus_factory/share/glidein_jobs/job.submit.template
+++ b/src/condor_contrib/campus_factory/share/glidein_jobs/job.submit.template
@@ -22,7 +22,6 @@ Environment = 	_condor_CONDOR_HOST=$(GLIDEIN_HOST); \
 				_condor_NUM_CPUS=1; \
 				_condor_UID_DOMAIN=$(GLIDEIN_HOST); \
 				_condor_FILESYSTEM_DOMAIN=$(GLIDEIN_HOST); \
-				_condor_MAIL=/bin/mail; \
 				_condor_STARTD_NOCLAIM_SHUTDOWN=1200; \
 				_campusfactory_wntmp=$(WN_TMP); \
 				_condor_GLIDEIN_Site="$(GLIDEIN_Site)"; \

--- a/src/condor_credd/condor_credmon_oauth/docker/10-docker.conf
+++ b/src/condor_credd/condor_credmon_oauth/docker/10-docker.conf
@@ -13,9 +13,6 @@ LOCK = $(LOCAL_DIR)/lock_condor
 
 CONDOR_ADMIN=noone@nohost.com
 
-# I wonder if this setting is really required.  The RPM page said it is.
-MAIL=/usr/bin/mail
-
 USE Role : Personal
 
 # Possibly unnecessary.

--- a/src/condor_dagman/dagman_classad.cpp
+++ b/src/condor_dagman/dagman_classad.cpp
@@ -38,8 +38,7 @@ ScheddClassad::OpenConnection() const
 		check_warning_strictness( DAG_STRICT_3 );
 		return NULL;
 	}
-	Qmgr_connection *queue = ConnectQ( _schedd->addr(), 0, false,
-				&errstack, NULL, _schedd->version() );
+	Qmgr_connection *queue = ConnectQ( *_schedd, 0, false, &errstack );
 	if ( !queue ) {
 		debug_printf( DEBUG_QUIET,
 					"WARNING: failed to connect to queue manager (%s)\n",

--- a/src/condor_dagman/dagman_submit.cpp
+++ b/src/condor_dagman/dagman_submit.cpp
@@ -582,6 +582,7 @@ direct_condor_submit(const Dagman &dm, Job* node,
 	char * qline = NULL;
 	const char * queue_args = NULL;
 	MacroStreamFile ms;
+	DCSchedd schedd;
 
 	// If the submitDesc hash is not set, we need to parse it from the file
 	if (!node->GetSubmitDesc()) {
@@ -629,7 +630,7 @@ direct_condor_submit(const Dagman &dm, Job* node,
 
 	submitHash->init_base_ad(time(NULL), owner);
 
-	qmgr = ConnectQ(NULL);
+	qmgr = ConnectQ(schedd);
 	if (qmgr) {
 		int cluster_id = NewCluster();
 		if (cluster_id <= 0) {

--- a/src/condor_gridmanager/gridmanager.cpp
+++ b/src/condor_gridmanager/gridmanager.cpp
@@ -633,7 +633,7 @@ doContactSchedd()
 	}
 
 
-	schedd = ConnectQ( ScheddAddr, QMGMT_TIMEOUT, false, NULL, myUserName, CondorVersion() );
+	schedd = ConnectQ( *ScheddObj, QMGMT_TIMEOUT, false, NULL, myUserName );
 	if ( !schedd ) {
 		error_str = "Failed to connect to schedd!";
 		goto contact_schedd_failure;

--- a/src/condor_includes/condor_qmgr.h
+++ b/src/condor_includes/condor_qmgr.h
@@ -25,6 +25,7 @@
 #include "proc.h"
 #include "../condor_utils/CondorError.h"
 #include "condor_classad.h"
+#include "dc_schedd.h"
 
 // this header declares functions for external clients of the schedd, but it is also included by the schedd itself
 // this can cause nasty link errors if the schedd tries to pull in parts of the external api, so
@@ -76,20 +77,17 @@ int InitializeConnection(const char *, const char *);
 int InitializeReadOnlyConnection(const char * );
 
 /** Initiate connection to schedd job queue and begin transaction.
-	@param qmgr_location can be the name or sinful string of a schedd or
-	       NULL to connect to the local schedd
+    @param schedd is the schedd to connect to
     @param timeout specifies the maximum time (in seconds) to wait for TCP
 	       connection establishment
     @param read_only can be set to true to skip the potentially slow
 	       authenticate step for connections which don't modify the queue
     @param effective_owner if not NULL, will call QmgmtSetEffectiveOwner()
-	@param schedd_version_str Version of schedd if known (o.w. NULL).
 	@return opaque Qmgr_connection structure
-*/		 
-Qmgr_connection *ConnectQ(const char *qmgr_location, int timeout=0, 
+*/
+Qmgr_connection *ConnectQ(DCSchedd& schedd, int timeout=0,
 				bool read_only=false, CondorError* errstack=NULL,
-				const char *effective_owner=NULL,
-				char const *schedd_version_str=NULL);
+				const char *effective_owner=NULL);
 
 /** Close the connection to the schedd job queue, and optionally commit
 	the transaction.

--- a/src/condor_job_router/submit_job.cpp
+++ b/src/condor_job_router/submit_job.cpp
@@ -169,7 +169,7 @@ ClaimJobResult claim_job(int cluster, int proc, std::string * error_details, con
 static Qmgr_connection *open_q_as_owner(char const *effective_owner,DCSchedd &schedd,FailObj &failobj)
 {
 	CondorError errstack;
-	Qmgr_connection * qmgr = ConnectQ(schedd.addr(), 0 /*timeout==default*/, false /*read-only*/, & errstack, effective_owner, schedd.version());
+	Qmgr_connection * qmgr = ConnectQ(schedd, 0 /*timeout==default*/, false /*read-only*/, & errstack, effective_owner);
 	if( ! qmgr ) {
 		failobj.fail("Unable to connect\n%s\n", errstack.getFullText(true).c_str());
 		return NULL;

--- a/src/condor_prio/prio.cpp
+++ b/src/condor_prio/prio.cpp
@@ -155,11 +155,10 @@ main( int argc, char *argv[] )
 	}
 
 	// Open job queue
-	DaemonName = schedd.addr();
-	q = ConnectQ(DaemonName.c_str());
+	q = ConnectQ(schedd);
 	if( !q ) {
 		fprintf( stderr, "Failed to connect to queue manager %s\n", 
-				 DaemonName.c_str() );
+		         schedd.addr() );
 		exit(1);
 	}
 	for(i = 0; i < nArgs; i++)

--- a/src/condor_schedd.V6/qmgr_job_updater.cpp
+++ b/src/condor_schedd.V6/qmgr_job_updater.cpp
@@ -33,8 +33,8 @@
 #include "dc_schedd.h"
 
 
-QmgrJobUpdater::QmgrJobUpdater( ClassAd* job, const char* schedd_address,
-	const char *schedd_version ) : common_job_queue_attrs(0),
+QmgrJobUpdater::QmgrJobUpdater( ClassAd* job, const char* schedd_address )
+	: common_job_queue_attrs(0),
 	hold_job_queue_attrs(0),
 	evict_job_queue_attrs(0),
 	remove_job_queue_attrs(0),
@@ -44,14 +44,12 @@ QmgrJobUpdater::QmgrJobUpdater( ClassAd* job, const char* schedd_address,
 	x509_job_queue_attrs(0),
 	m_pull_attrs(0),
 	job_ad(job), // we do *NOT* want to make our own copy of this ad
-	schedd_addr(schedd_address?strdup(schedd_address):0),
-	schedd_ver(schedd_version?strdup(schedd_version):0),
+	m_schedd_obj(schedd_address),
 	cluster(-1), proc(-1),
 	q_update_tid(-1) 
 {
-	if( ! is_valid_sinful(schedd_address) ) {
-		EXCEPT( "schedd_addr not specified with valid address (%s)",
-				schedd_address );
+	if( ! m_schedd_obj.locate() ) {
+		EXCEPT("Invalid schedd address (%s)", schedd_address);
 	}
 	if( !job_ad->LookupInteger(ATTR_CLUSTER_ID, cluster)) {
 		EXCEPT("Job ad doesn't contain a %s attribute.", ATTR_CLUSTER_ID);
@@ -81,8 +79,6 @@ QmgrJobUpdater::~QmgrJobUpdater()
 		daemonCore->Cancel_Timer( q_update_tid );
 		q_update_tid = -1;
 	}
-	if( schedd_addr ) { free(schedd_addr); }
-	if (schedd_ver)   {free(schedd_ver); }
 	if( common_job_queue_attrs ) { delete common_job_queue_attrs; }
 	if( hold_job_queue_attrs ) { delete hold_job_queue_attrs; }
 	if( evict_job_queue_attrs ) { delete evict_job_queue_attrs; }
@@ -313,7 +309,7 @@ QmgrJobUpdater::updateAttr( const char *name, const char *expr, bool updateMaste
 	if (log) {
 		flags = SHOULDLOG;
 	}
-	if( ConnectQ(schedd_addr,SHADOW_QMGMT_TIMEOUT,false,NULL,m_owner.c_str(),schedd_ver) ) {
+	if( ConnectQ(m_schedd_obj,SHADOW_QMGMT_TIMEOUT,false,NULL,m_owner.c_str()) ) {
 		if( SetAttribute(cluster,p,name,expr,flags) < 0 ) {
 			err_msg = "SetAttribute() failed";
 			result = FALSE;
@@ -409,7 +405,7 @@ QmgrJobUpdater::updateJob( update_t type, SetAttributeFlags_t commit_flags )
 			 job_queue_attrs->contains_anycase(name)) ) {
 
 			if( ! is_connected ) {
-				if( ! ConnectQ(schedd_addr, SHADOW_QMGMT_TIMEOUT, false, NULL, m_owner.c_str(),schedd_ver) ) {
+				if( ! ConnectQ(m_schedd_obj, SHADOW_QMGMT_TIMEOUT, false, NULL, m_owner.c_str()) ) {
 					return false;
 				}
 				is_connected = true;
@@ -423,7 +419,7 @@ QmgrJobUpdater::updateJob( update_t type, SetAttributeFlags_t commit_flags )
 	m_pull_attrs->rewind();
 	while ( (name = m_pull_attrs->next()) ) {
 		if ( !is_connected ) {
-			if ( !ConnectQ( schedd_addr, SHADOW_QMGMT_TIMEOUT, true, NULL, NULL, schedd_ver ) ) {
+			if ( !ConnectQ( m_schedd_obj, SHADOW_QMGMT_TIMEOUT, true ) ) {
 				return false;
 			}
 			is_connected = true;
@@ -469,7 +465,7 @@ QmgrJobUpdater::retrieveJobUpdates( void )
 	ProcIdToStr(cluster, proc, id_str);
 	job_ids.insert(id_str);
 
-	if ( !ConnectQ( schedd_addr, SHADOW_QMGMT_TIMEOUT, false ) ) {
+	if ( !ConnectQ( m_schedd_obj, SHADOW_QMGMT_TIMEOUT, false ) ) {
 		return false;
 	}
 	if ( GetDirtyAttributes( cluster, proc, &updates ) < 0 ) {
@@ -482,8 +478,7 @@ QmgrJobUpdater::retrieveJobUpdates( void )
 	dPrintAd( D_JOB, updates );
 	MergeClassAds( job_ad, &updates, true );
 
-	DCSchedd schedd( schedd_addr );
-	if ( schedd.clearDirtyAttrs( &job_ids, &errstack ) == NULL ) {
+	if ( m_schedd_obj.clearDirtyAttrs( &job_ids, &errstack ) == NULL ) {
 		dprintf( D_ALWAYS, "clearDirtyAttrs() failed: %s\n", errstack.getFullText().c_str() );
 		return false;
 	}

--- a/src/condor_schedd.V6/qmgr_job_updater.h
+++ b/src/condor_schedd.V6/qmgr_job_updater.h
@@ -47,8 +47,8 @@ typedef enum {
 class QmgrJobUpdater : public Service
 {
 public:
-	QmgrJobUpdater( ClassAd* job_a, const char*schedd_address, char const *schedd_version);
-	QmgrJobUpdater( ) :  common_job_queue_attrs(0),  hold_job_queue_attrs(0), evict_job_queue_attrs(0), remove_job_queue_attrs(0), requeue_job_queue_attrs(0), terminate_job_queue_attrs(0), checkpoint_job_queue_attrs(0), x509_job_queue_attrs(0), m_pull_attrs(0), job_ad(0), schedd_addr(0), schedd_ver(0), cluster(-1), proc(-1), q_update_tid(-1) {}
+	QmgrJobUpdater( ClassAd* job_a, const char*schedd_address );
+	QmgrJobUpdater( ) :  common_job_queue_attrs(0),  hold_job_queue_attrs(0), evict_job_queue_attrs(0), remove_job_queue_attrs(0), requeue_job_queue_attrs(0), terminate_job_queue_attrs(0), checkpoint_job_queue_attrs(0), x509_job_queue_attrs(0), m_pull_attrs(0), job_ad(0), cluster(-1), proc(-1), q_update_tid(-1) {}
 	virtual ~QmgrJobUpdater();
 
 	virtual void startUpdateTimer( void );
@@ -141,8 +141,7 @@ private:
 	StringList* m_pull_attrs;
 
 	ClassAd* job_ad;
-	char* schedd_addr;
-	char* schedd_ver;
+	DCSchedd m_schedd_obj;
 	std::string m_owner;
 
 	int cluster;
@@ -155,7 +154,7 @@ private:
 class NullQmgrJobUpdater : public QmgrJobUpdater
 {
 public:
-	NullQmgrJobUpdater( ClassAd* , const char* , char const *) : QmgrJobUpdater() {}
+	NullQmgrJobUpdater( ClassAd* , const char* ) : QmgrJobUpdater() {}
 	virtual ~NullQmgrJobUpdater() {}
 
 	virtual void startUpdateTimer( void ) {return;}

--- a/src/condor_schedd.V6/qmgr_lib_support.cpp
+++ b/src/condor_schedd.V6/qmgr_lib_support.cpp
@@ -34,7 +34,7 @@ ReliSock *qmgmt_sock = NULL;
 static Qmgr_connection connection;
 
 Qmgr_connection *
-ConnectQ(const char *qmgr_location, int timeout, bool read_only, CondorError* errstack, const char *effective_owner, const char* /*schedd_version_str*/ )
+ConnectQ(DCSchedd& schedd, int timeout, bool read_only, CondorError* errstack, const char *effective_owner)
 {
 	int		rval, ok;
 	int cmd = read_only ? QMGMT_READ_CMD : QMGMT_WRITE_CMD;
@@ -54,17 +54,11 @@ ConnectQ(const char *qmgr_location, int timeout, bool read_only, CondorError* er
 	}
 
     // no connection active as of now; create a new one
-	Daemon d( DT_SCHEDD, qmgr_location );
-	if( ! d.locate() ) {
+	if( ! schedd.locate() ) {
 		ok = FALSE;
-		if( qmgr_location ) {
-			dprintf( D_ALWAYS, "Can't find address of queue manager %s\n", 
-					 qmgr_location );
-		} else {
-			dprintf( D_ALWAYS, "Can't find address of local queue manager\n" );
-		}
+		dprintf( D_ALWAYS, "Can't find address of queue manager\n" );
 	} else { 
-		qmgmt_sock = (ReliSock*) d.startCommand( cmd,
+		qmgmt_sock = (ReliSock*) schedd.startCommand( cmd,
 												 Stream::reli_sock,
 												 timeout,
 												 errstack_select);

--- a/src/condor_shadow.V6.1/baseshadow.cpp
+++ b/src/condor_shadow.V6.1/baseshadow.cpp
@@ -213,9 +213,9 @@ BaseShadow::baseInit( ClassAd *job_ad, const char* schedd_addr, const char *xfer
 		// Unless we got a command line arg asking us not to
 	if (sendUpdatesToSchedd) {
 		// the usual case
-		job_updater = new QmgrJobUpdater( jobAd, scheddAddr, CondorVersion() );
+		job_updater = new QmgrJobUpdater( jobAd, scheddAddr );
 	} else {
-		job_updater = new NullQmgrJobUpdater( jobAd, scheddAddr, CondorVersion() );
+		job_updater = new NullQmgrJobUpdater( jobAd, scheddAddr );
 	}
 
 		// init user log; hold on failure

--- a/src/condor_starter.V6.1/jic_local_schedd.cpp
+++ b/src/condor_starter.V6.1/jic_local_schedd.cpp
@@ -269,7 +269,7 @@ JICLocalSchedd::getLocalJobAd( void )
 	if( ! JICLocalFile::getLocalJobAd() ) {
 		return false;
 	}
-	job_updater = new QmgrJobUpdater( job_ad, schedd_addr, CondorVersion() );
+	job_updater = new QmgrJobUpdater( job_ad, schedd_addr );
 	return true;
 }
 

--- a/src/condor_tools/qedit.cpp
+++ b/src/condor_tools/qedit.cpp
@@ -522,7 +522,7 @@ main(int argc, const char *argv[])
 	}
 
 	// Open job queue
-	Qmgr_connection *q = ConnectQ( schedd.addr(), 0, false, NULL, NULL, schedd.version() );
+	Qmgr_connection *q = ConnectQ( schedd );
 	if( !q ) {
 		fprintf( stderr, "Failed to connect to queue manager %s\n",
 				 schedd.addr() );

--- a/src/condor_tools/ssh_to_job.cpp
+++ b/src/condor_tools/ssh_to_job.cpp
@@ -439,7 +439,7 @@ bool SSHToJob::execute_ssh()
 	//
 
 	if( m_could_be_ec2_job ) {
-		Qmgr_connection * q = ConnectQ( schedd.addr(), 0, true );
+		Qmgr_connection * q = ConnectQ( schedd, 0, true );
 		if( ! q ) {
 			logError( "Can't connect to schedd\n" );
 			return false;

--- a/src/condor_utils/condor_q.cpp
+++ b/src/condor_utils/condor_q.cpp
@@ -226,7 +226,7 @@ fetchQueue (ClassAdList &list, StringList &attrs, ClassAd *ad, CondorError* errs
 	Qmgr_connection *qmgr;
 	ExprTree		*tree;
 	int     		result;
-	char    		scheddString [32];
+	std::string scheddString;
 	const char 		*constraint;
 
 	int useFastPath = 0;
@@ -242,7 +242,8 @@ fetchQueue (ClassAdList &list, StringList &attrs, ClassAd *ad, CondorError* errs
 	if (ad == 0)
 	{
 		// local case
-		if( !(qmgr = ConnectQ( 0, connect_timeout, true, errstack)) ) {
+		DCSchedd schedd(nullptr);
+		if( !(qmgr = ConnectQ( schedd, connect_timeout, true, errstack)) ) {
 			errstack->push("TEST", 0, "FOO");
 			return Q_SCHEDD_COMMUNICATION_ERROR;
 		}
@@ -251,10 +252,11 @@ fetchQueue (ClassAdList &list, StringList &attrs, ClassAd *ad, CondorError* errs
 	else
 	{
 		// remote case to handle condor_globalq
-		if (!ad->LookupString (ATTR_SCHEDD_IP_ADDR, scheddString, sizeof(scheddString)))
+		if (!ad->LookupString (ATTR_SCHEDD_IP_ADDR, scheddString))
 			return Q_NO_SCHEDD_IP_ADDR;
 
-		if( !(qmgr = ConnectQ( scheddString, connect_timeout, true, errstack)) )
+		DCSchedd schedd(scheddString.c_str());
+		if( !(qmgr = ConnectQ( schedd, connect_timeout, true, errstack)) )
 			return Q_SCHEDD_COMMUNICATION_ERROR;
 
 	}
@@ -288,7 +290,8 @@ fetchQueueFromHost (ClassAdList &list, StringList &attrs, const char *host, char
 	 optimal.  :^).
 	*/
 	init();  // needed to get default connect_timeout
-	if( !(qmgr = ConnectQ( host, connect_timeout, true, errstack)) )
+	DCSchedd schedd(host);
+	if( !(qmgr = ConnectQ( schedd, connect_timeout, true, errstack)) )
 		return Q_SCHEDD_COMMUNICATION_ERROR;
 
 	int useFastPath = 0;
@@ -361,7 +364,8 @@ CondorQ::fetchQueueFromHostAndProcess ( const char *host,
 	 optimal.  :^).
 	*/
 	init();  // needed to get default connect_timeout
-	if( !(qmgr = ConnectQ( host, connect_timeout, true, errstack)) ) {
+	DCSchedd schedd(host);
+	if( !(qmgr = ConnectQ( schedd, connect_timeout, true, errstack)) ) {
 		free( constraint );
 		return Q_SCHEDD_COMMUNICATION_ERROR;
 	}

--- a/src/condor_utils/submit_protocol.cpp
+++ b/src/condor_utils/submit_protocol.cpp
@@ -89,7 +89,7 @@ ActualScheddQ::~ActualScheddQ()
 
 bool ActualScheddQ::Connect(DCSchedd & MySchedd, CondorError & errstack) {
 	if (qmgr) return true;
-	qmgr = ConnectQ(MySchedd.addr(), 0 /* default */, false /* default */, &errstack, NULL, MySchedd.version());
+	qmgr = ConnectQ(MySchedd, 0 /* default */, false /* default */, &errstack);
 	allows_late = has_late = false;
 	if (qmgr) {
 		CondorVersionInfo cvi(MySchedd.version());

--- a/src/python-bindings/schedd.cpp
+++ b/src/python-bindings/schedd.cpp
@@ -2636,7 +2636,8 @@ ConnectionSentry::ConnectionSentry(Schedd &schedd, bool transaction, SetAttribut
         bool result;
         {
         condor::ModuleLock ml;
-        result = ConnectQ(schedd.m_addr.c_str(), 0, false, NULL, NULL, schedd.m_version.c_str()) == 0;
+        DCSchedd schedd_obj(schedd.m_addr.c_str());
+        result = ConnectQ(schedd_obj) == 0;
         }
         if (result)
         {


### PR DESCRIPTION
Remove the unused version argument. Change the name/sinful string
argument to a DCSchedd object, which most callers already had available.
Also fix a static buffer for condor_q -global.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
