### PR TITLE
HTCONDOR-899 Fix rare race condition in test_custom_machine_resources

### DIFF
--- a/src/condor_tests/test_custom_machine_resource.py
+++ b/src/condor_tests/test_custom_machine_resource.py
@@ -164,7 +164,10 @@ def condor(test_dir, slot_config, discovery_script, monitor_script):
         # Ornithology will run condor_who to verify that all the daemons are running,
         # but occasionally, not all 16 slots will have made it to the collector
 
+        loop_count = 0
         while 16 != len(condor.status(ad_type=htcondor.AdTypes.Startd, projection=["SlotID"])):
+            loop_count = loop_count + 1
+            assert(loop_count < 20)
             time.sleep(1)
         yield condor
 

--- a/src/condor_tests/test_custom_machine_resource.py
+++ b/src/condor_tests/test_custom_machine_resource.py
@@ -18,6 +18,7 @@
 
 import pytest
 import logging
+import time
 
 import htcondor
 
@@ -164,7 +165,7 @@ def condor(test_dir, slot_config, discovery_script, monitor_script):
         # but occasionally, not all 16 slots will have made it to the collector
 
         while 16 != len(condor.status(ad_type=htcondor.AdTypes.Startd, projection=["SlotID"])):
-            os.sleep(1)
+            time.sleep(1)
         yield condor
 
 

--- a/src/condor_tests/test_custom_machine_resource.py
+++ b/src/condor_tests/test_custom_machine_resource.py
@@ -160,6 +160,11 @@ def condor(test_dir, slot_config, discovery_script, monitor_script):
         local_dir=test_dir / "condor",
         config={**slot_config, "TEST_DIR": test_dir.as_posix()},
     ) as condor:
+        # Ornithology will run condor_who to verify that all the daemons are running,
+        # but occasionally, not all 16 slots will have made it to the collector
+
+        while 16 != len(condor.status(ad_type=htcondor.AdTypes.Startd, projection=["SlotID"])):
+            os.sleep(1)
         yield condor
 
 

--- a/src/condor_tests/test_custom_machine_resource_instances.py
+++ b/src/condor_tests/test_custom_machine_resource_instances.py
@@ -147,7 +147,10 @@ def condor(test_dir, slot_config):
         # but occasionally, not all slots will have made it to the collector
 
         num_slots = int(slot_config["NUM_SLOTS"])
+        loop_count = 0
         while num_slots != len(condor.status(ad_type=htcondor.AdTypes.Startd, projection=["SlotID"])):
+            loop_count = loop_count + 1
+            assert(loop_count < 20)
             time.sleep(1)
         yield condor
 

--- a/src/condor_tests/test_custom_machine_resource_instances.py
+++ b/src/condor_tests/test_custom_machine_resource_instances.py
@@ -11,7 +11,9 @@
 # want to test the pieces individually, you'll have to change the code.
 #
 
+import pytest 
 import logging
+import time
 
 import htcondor
 
@@ -140,6 +142,13 @@ def condor(test_dir, slot_config):
         local_dir=test_dir / "condor",
         config={**slot_config, "TEST_DIR": test_dir.as_posix()},
     ) as condor:
+
+        # Ornithology will run condor_who to verify that all the daemons are running,
+        # but occasionally, not all slots will have made it to the collector
+
+        num_slots = int(slot_config["NUM_SLOTS"])
+        while num_slots != len(condor.status(ad_type=htcondor.AdTypes.Startd, projection=["SlotID"])):
+            time.sleep(1)
         yield condor
 
 


### PR DESCRIPTION
This test configures a startd with 16 static slots.  While ornithology
correctly waits until all daemons are "ready", via running condor_who,
condor_who doesn't know how many slots should show up in the collector,
and sometimes thinks condor is ready when some, but not all of the slots
are in the collector -- here is evidence from the failing test:
Note that the query came in between slot updates:

01/05/22 21:48:49.011 (D_ALWAYS) StartdAd     : Inserting ** "< slot5@hostname , 172.17.0.8 >"
01/05/22 21:48:49.011 (D_ALWAYS) StartdPvtAd  : Inserting ** "< slot5@hostname , 172.17.0.8 >"
01/05/22 21:48:49.011 (D_ALWAYS) StartdAd     : Inserting ** "< slot6@hostname , 172.17.0.8 >"
01/05/22 21:48:49.011 (D_ALWAYS) StartdPvtAd  : Inserting ** "< slot6@hostname , 172.17.0.8 >"
01/05/22 21:48:49.012 (D_ALWAYS) StartdAd     : Inserting ** "< slot7@hostname , 172.17.0.8 >"
01/05/22 21:48:49.012 (D_ALWAYS) StartdPvtAd  : Inserting ** "< slot7@hostname , 172.17.0.8 >"
01/05/22 21:48:49.012 (D_ALWAYS) StartdAd     : Inserting ** "< slot8@hostname , 172.17.0.8 >"
01/05/22 21:48:49.012 (D_ALWAYS) StartdPvtAd  : Inserting ** "< slot8@hostname , 172.17.0.8 >"
01/05/22 21:48:49.012 (D_ALWAYS) StartdAd     : Inserting ** "< slot9@hostname , 172.17.0.8 >"
01/05/22 21:48:49.012 (D_ALWAYS) StartdPvtAd  : Inserting ** "< slot9@hostname , 172.17.0.8 >"
01/05/22 21:48:49.012 (D_ALWAYS) StartdAd     : Inserting ** "< slot10@hostname , 172.17.0.8 >"
01/05/22 21:48:49.012 (D_ALWAYS) StartdPvtAd  : Inserting ** "< slot10@hostname , 172.17.0.8 >"
01/05/22 21:48:49.012 (D_ALWAYS) StartdAd     : Inserting ** "< slot11@hostname , 172.17.0.8 >"
01/05/22 21:48:49.012 (D_ALWAYS) StartdPvtAd  : Inserting ** "< slot11@hostname , 172.17.0.8 >"
01/05/22 21:48:49.012 (D_ALWAYS) StartdAd     : Inserting ** "< slot12@hostname , 172.17.0.8 >"
01/05/22 21:48:49.012 (D_ALWAYS) StartdPvtAd  : Inserting ** "< slot12@hostname , 172.17.0.8 >"
01/05/22 21:48:49.012 (D_ALWAYS) StartdAd     : Inserting ** "< slot13@hostname , 172.17.0.8 >"
01/05/22 21:48:49.012 (D_ALWAYS) StartdPvtAd  : Inserting ** "< slot13@hostname , 172.17.0.8 >"
01/05/22 21:48:49.013 (D_ALWAYS) StartdAd     : Inserting ** "< slot14@hostname , 172.17.0.8 >"
01/05/22 21:48:49.013 (D_ALWAYS) StartdPvtAd  : Inserting ** "< slot14@hostname , 172.17.0.8 >"
01/05/22 21:48:49.013 (D_ALWAYS) StartdAd     : Inserting ** "< slot15@hostname , 172.17.0.8 >"
01/05/22 21:48:49.013 (D_ALWAYS) StartdPvtAd  : Inserting ** "< slot15@hostname , 172.17.0.8 >"
01/05/22 21:48:49.013 (D_ALWAYS) StartdAd     : Inserting ** "< slot16@hostname , 172.17.0.8 >"
01/05/22 21:48:49.013 (D_ALWAYS) StartdPvtAd  : Inserting ** "< slot16@hostname , 172.17.0.8 >"
01/05/22 21:48:49.239 (D_ALWAYS) Got QUERY_STARTD_ADS
01/05/22 21:48:49.240 (D_ALWAYS) QueryWorker: forked new worker with id 59756 ( max 4 active 1 pending 0 )
01/05/22 21:48:49.240 (D_ALWAYS) (Sending 12 ads in response to query)
01/05/22 21:48:49.240 (D_ALWAYS) Query info: matched=12; skipped=0; query_time=0.000337; send_time=0.000087; type=Machine; requirements={true}; locate=0; limit=0; from=TOOL; peer=<172.17.0.8:46737>; projection={SlotID AssignedSQUIDs}; filter_private_ads=0
01/05/22 21:48:50.044 (D_ALWAYS) StartdAd     : Inserting ** "< slot1@hostname , 172.17.0.8 >"
01/05/22 21:48:50.044 (D_ALWAYS) StartdPvtAd  : Inserting ** "< slot1@hostname , 172.17.0.8 >"
01/05/22 21:48:50.045 (D_ALWAYS) StartdAd     : Inserting ** "< slot2@hostname , 172.17.0.8 >"
01/05/22 21:48:50.045 (D_ALWAYS) StartdPvtAd  : Inserting ** "< slot2@hostname , 172.17.0.8 >"
01/05/22 21:48:50.045 (D_ALWAYS) StartdAd     : Inserting ** "< slot3@hostname , 172.17.0.8 >"
01/05/22 21:48:50.045 (D_ALWAYS) StartdPvtAd  : Inserting ** "< slot3@hostname , 172.17.0.8 >"
01/05/22 21:48:50.046 (D_ALWAYS) StartdAd     : Inserting ** "< slot4@hostname , 172.17.0.8 >"
01/05/22 21:48:50.046 (D_ALWAYS) StartdPvtAd  : Inserting ** "< slot4@hostname , 172.17.0.8 >"

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
