### PR TITLE
HTCONDOR-923 Parent directory fix for 9.5.1

### DIFF
--- a/docs/version-history/development-release-series-91.rst
+++ b/docs/version-history/development-release-series-91.rst
@@ -19,7 +19,12 @@ New Features:
 
 Bugs Fixed:
 
-- None.
+- HTCondor now properly creates directories when transferring a directory
+  tree out of SPOOL while preserving relative paths.  This bug would manifest
+  after a self-checkpointing job created a file in a new subdirectory of a
+  directory in its checkpoint: when the job was rescheduled and had to
+  download its checkpoint, it would go on hold.
+  :jira:`923`
 
 Version 9.5.0
 -------------


### PR DESCRIPTION
This ports HTCONDOR-923 from master to the 9.5.1 branch.  This pull does _not_ include the test from the master branch, because that depends on HTCONDOR-815, which seemed like a lot of extra code.

The first commit on this branch is a cherry-pick of the corresponding commit from 9.6.0; the second is the same release note as used for 9.6.0, but located in the correct place. 

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
