### PR TITLE
HTCONDOR-899 Make cmd_q_protocols test more robust

### DIFF
--- a/src/condor_tests/cmd_q_protocols.run
+++ b/src/condor_tests/cmd_q_protocols.run
@@ -66,7 +66,7 @@ my $firstappend_condor_config = '
 	WANT_SUSPEND = FALSE
 	NEGOTIATOR_INTERVAL = 1
 	ALL_DEBUG = D_FULLDEBUG D_NETWORK
-	NUM_CPUS = 1
+	NUM_CPUS = 2
 	CONDOR_Q_USE_V3_PROTOCOL = true
 	# Turning this on breaks this test, which means it is way less
 	# robust than it at first may appear.
@@ -210,7 +210,7 @@ my $runresult = SimpleJob::RunCheck(
 my $secondappend_condor_config = '
 	WANT_SUSPEND = FALSE
 	ALL_DEBUG = D_FULLDEBUG
-	NUM_CPUS = 1
+	NUM_CPUS = 2
 	CONDOR_Q_USE_V3_PROTOCOL = false
 	# Turning this on breaks this test, which means it is way less
 	# robust than it at first may appear.
@@ -288,7 +288,7 @@ $runresult = SimpleJob::RunCheck(
 my $thirdappend_condor_config = '
 	WANT_SUSPEND = FALSE
 	ALL_DEBUG = D_FULLDEBUG
-	NUM_CPUS = 1
+	NUM_CPUS = 2
 	CONDOR_Q_USE_V3_PROTOCOL = true
 ';
 


### PR DESCRIPTION
This test submits a job, then immediately removes it.  In rare cases
the remove while the slot is being claimed.  In this case, the
unclaiming doesn't work, and the slot is stuck in claimed/idle for 10
minutes.  The test then submits a subsequent job which can't match
and the test times out.

To fix this problem, we'll just add a second slot in the test
condor.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
