### PR TITLE
(HTCONDOR-950)  Don't segfault in htcondor.Submit constructor.

### DIFF
--- a/docs/version-history/stable-release-series-90.rst
+++ b/docs/version-history/stable-release-series-90.rst
@@ -53,18 +53,22 @@ Bugs Fixed:
   This restores the behavior in versions 9.0.1 and prior.
   :jira:`904`
 
+- Fixed a bug in the FileTransfer mechanism where URL transfers caused
+  subsequent failures to report incorrect error messages.
+  :jira:`915`
+
 - Fixed a bug in the *condor_dagman* parser which caused ``SUBMIT-DESCRIPTION``
   statements to return an error even after parsing correctly.
   :jira:`928`
-  
+
 - Fix problem where **condor_ssh_to_job** may fail to connect to a job
   running under an HTCondor tarball installation (glidein) built from an RPM
   based platform.
   :jira:`942`
 
-- Fixed a bug in the FileTransfer mechanism where URL transfers caused 
-  subsequent failures to report incorrect error messages.
-  :jira:`915`
+- The Python bindings no longer segfault when the ``htcondor.Submit``
+  constructor is passed a dictionary with an entry whose value is ``None``.
+  :jira:`950`
 
 .. _lts-version-history-909:
 

--- a/src/condor_tests/CMakeLists.txt
+++ b/src/condor_tests/CMakeLists.txt
@@ -214,6 +214,8 @@ endif ()
 
 			condor_pl_test(test_manifest "Test manifest functionality" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 
+			condor_pl_test(test_htcondor_submit_constructor "Test htcondor.Submit()", "quick;ctest"	CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
+
 			# These tests require Python 3.6 or later.
 			if (PYTHON3_VERSION_MINOR GREATER_EQUAL 6)
 				condor_pl_test(test_custom_machine_resource "Test that a custom machine resource is assigned, limited, and monitored correctly" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py;src/condor_tests/libcmr.py")

--- a/src/condor_tests/test_htcondor_submit_constructor.py
+++ b/src/condor_tests/test_htcondor_submit_constructor.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env pytest
+
+import logging
+import htcondor
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+class TestHTCondorSubmitConstructor:
+    def test_passing_none(self):
+        # This used to segfault.
+        s = htcondor.Submit({"attribute": None})

--- a/src/python-bindings/schedd.cpp
+++ b/src/python-bindings/schedd.cpp
@@ -3110,7 +3110,7 @@ public:
             boost::python::tuple tup = boost::python::extract<boost::python::tuple>(obj);
             std::string attr = boost::python::extract<std::string>(tup[0]);
 
-            boost::python::object value(tup[0]);
+            // boost::python::object value(tup[1]);
             std::string value_str = convertToSubmitValue(tup[1]);
 
             m_hash.set_submit_param(plus_to_my(attr), value_str.c_str());
@@ -3729,7 +3729,12 @@ private:
             boost::python::extract<ExprTreeHolder*> extract_expr(value);
             if (extract_expr.check()) {
                 ExprTreeHolder *holder = extract_expr();
-                attr = holder->toString();
+                // If value is _Py_NoneStruct, holder will be NULL.
+                if( holder != NULL ) {
+                    attr = holder->toString();
+                } else {
+                    return "undefined";
+                }
             } else {
                 boost::python::extract<ClassAdWrapper*> extract_classad(value);
                 if (extract_classad.check()) {


### PR DESCRIPTION
If the value is `_Py_NoneStruct`, when we (succesfully) convert it to an `ExprTreeHolder *`, that pointer is `NULL`.  In that case, since all we want is the string to put in the submit file, return `"undefined"` instead.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
