### PR TITLE
HTCONDOR-944: Don't require hidepid <= 1 mount option for /proc

### DIFF
--- a/docs/version-history/development-release-series-91.rst
+++ b/docs/version-history/development-release-series-91.rst
@@ -19,7 +19,10 @@ New Features:
 
 Bugs Fixed:
 
-- None.
+- HTCondor no longer assumes that PID 1 is always visible.  Instead,
+  it checks to see if ``/proc`` was mounted with the ``hidepid`` option
+  of ``1`` or less, and only checks for PID 1 if it was.
+  :jira:`944`
 
 Version 9.5.3
 -------------

--- a/src/condor_procapi/procapi.cpp
+++ b/src/condor_procapi/procapi.cpp
@@ -1925,7 +1925,7 @@ build_pid_list( std::vector<pid_t> & newPidList ) {
 		std::ifstream file("/proc/self/mountinfo");
 		if( file.good() ) {
 			while(! file.eof()) {
-				std::getline(file, line);
+				getline(file, line);
 				if(! file.good()) { break; }
 
 				std::string token;
@@ -1961,13 +1961,17 @@ build_pid_list( std::vector<pid_t> & newPidList ) {
 							size_t pos = option.find("hidepid");
 							if( pos == 0 ) {
 								found_hidepid = true;
-								std::string value = option.substr(7 + 1);
-								int v = std::stoi(value);
-								if( v <= 1 ) {
-									dprintf( D_ALWAYS, "Found per-superblock option hidepid <= 1 for /proc, enabling check for PID 1.\n" );
-									hidepid = false;
-									break;
+								try {
+									std::string value = option.substr(7 + 1);
+									int v = std::stoi(value);
+									if( v <= 1 ) {
+										dprintf( D_ALWAYS, "Found per-superblock option hidepid <= 1 for /proc, enabling check for PID 1.\n" );
+										hidepid = false;
+										break;
+									}
 								}
+								catch( std::out_of_range & e ) { break; }
+								catch( std::invalid_argument & e ) { break; }
 							}
 						}
 					}

--- a/src/condor_procapi/procapi.cpp
+++ b/src/condor_procapi/procapi.cpp
@@ -1918,7 +1918,7 @@ build_pid_list( std::vector<pid_t> & newPidList ) {
 	//
 	// See condor_utils/filesystem_remap.cpp for details.
 	//
-	static bool hidepid = false;
+	static bool hidepid = true;
 	static bool checked_proc_mountinfo = false;
 	if(! checked_proc_mountinfo) {
 		std::string line;
@@ -1958,9 +1958,9 @@ build_pid_list( std::vector<pid_t> & newPidList ) {
 							if( pos == 0 ) {
 								std::string value = option.substr(7 + 1);
 								int v = std::stoi(value);
-								if( v > 1 ) {
-									dprintf( D_ALWAYS, "Found per-superblock option hidepid > 1 for /proc, will not check for PID 1.\n" );
-									hidepid = true;
+								if( v <= 1 ) {
+									dprintf( D_ALWAYS, "Found per-superblock option hidepid <= 1 for /proc, enabling check for PID 1.\n" );
+									hidepid = false;
 									break;
 								}
 							}

--- a/src/condor_procapi/procapi.cpp
+++ b/src/condor_procapi/procapi.cpp
@@ -1983,8 +1983,9 @@ build_pid_list( std::vector<pid_t> & newPidList ) {
 						dprintf( D_ALWAYS, "/proc was mounted without hidepid, assuming default of 0.\n" );
 						hidepid = false;
 					}
-				// We found `proc`, we can quit reading now.
-				break;
+
+					// We found `proc`, we can quit reading now.
+					break;
 				}
 			}
 

--- a/src/condor_procapi/procapi.cpp
+++ b/src/condor_procapi/procapi.cpp
@@ -1948,7 +1948,11 @@ build_pid_list( std::vector<pid_t> & newPidList ) {
 				getline(is, token, ' '); // per-superblock options
 				std::string ps_options = token;
 
+				bool found_proc = false;
+				bool found_hidepid = false;
 				if( mount_point == "/proc" ) {
+					found_proc = true;
+
 					std::string option;
 					std::istringstream psos(ps_options);
 					while(! psos.eof()) {
@@ -1956,6 +1960,7 @@ build_pid_list( std::vector<pid_t> & newPidList ) {
 						if(! psos.fail()) {
 							size_t pos = option.find("hidepid");
 							if( pos == 0 ) {
+								found_hidepid = true;
 								std::string value = option.substr(7 + 1);
 								int v = std::stoi(value);
 								if( v <= 1 ) {
@@ -1966,6 +1971,14 @@ build_pid_list( std::vector<pid_t> & newPidList ) {
 							}
 						}
 					}
+
+				// The default mount option for hidepid is 0; indeed, if you
+				// explicitly specify hidepid=0 in the mount command, it
+				// won't appear in /proc/self/mountinfo.
+				if( found_proc && ! found_hidepid ) {
+					dprintf( D_ALWAYS, "/proc was mounted without hidepid, assuming default of 0.\n" );
+					hidepid = false;
+				}
 
 				break;
 				}


### PR DESCRIPTION
If you mount `/proc` with the mount option `hidepid=2`, and aren't running as root, then PID 1 will not appear in `/proc`.  This causes the procd to freak out, because we use the absence of PID 1 to help verify that we got a complete read of `/proc`.  This pattch changes procapi to check for PID 1 only if `/proc` were mounted without `hidepid=2`.  There's a small complication that because `hidepid=0` is the default, it's not explicitly listed in `/proc/self/mountinfo`.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
