### PR TITLE
HTCONDOR-945: DAGMan parser shouldn't lookup DAGMAN_USE_CONDOR_SUBMIT knob on every iteration

### DIFF
--- a/src/condor_dagman/parse.cpp
+++ b/src/condor_dagman/parse.cpp
@@ -45,6 +45,7 @@ static const char * ILLEGAL_CHARS = "+";
 
 static std::vector<char*> _spliceScope;
 static bool _useDagDir = false;
+static bool _useDirectSubmit = true;
 
 // _thisDagNum will be incremented for each DAG specified on the
 // condor_submit_dag command line.
@@ -179,6 +180,7 @@ bool parse(Dag *dag, const char *filename, bool useDagDir,
 	}
 
 	_useDagDir = useDagDir;
+	_useDirectSubmit = param_boolean("DAGMAN_USE_DIRECT_SUBMIT", true);
 	_schedd = schedd;
 
 		//
@@ -274,7 +276,7 @@ bool parse(Dag *dag, const char *filename, bool useDagDir,
 						   "submitfile" );
 			if (parsed_line_successfully && inline_submit) {
 				// go into inline subfile parsing mode
-				if (!param_boolean("DAGMAN_USE_DIRECT_SUBMIT", true)) {
+				if (!_useDirectSubmit) {
 					debug_printf(DEBUG_NORMAL, "ERROR: To use an inline job "
 					  "description for node %s, DAGMAN_USE_DIRECT_SUBMIT must "
 					  "be set to True. Aborting.\n", nodename.c_str());
@@ -334,7 +336,7 @@ bool parse(Dag *dag, const char *filename, bool useDagDir,
 					"submitfile");
 			if (parsed_line_successfully && inline_submit) {
 				// go into inline subfile parsing mode
-				if (!param_boolean("DAGMAN_USE_DIRECT_SUBMIT", true)) {
+				if (!_useDirectSubmit) {
 					debug_printf(DEBUG_NORMAL, "ERROR: To use an inline job "
 					  "description for node %s, DAGMAN_USE_DIRECT_SUBMIT must "
 					  "be set to True. Aborting.\n", nodename.c_str());
@@ -411,7 +413,7 @@ bool parse(Dag *dag, const char *filename, bool useDagDir,
 			bool is_submit_description = desc && *desc == '{';
 			if (is_submit_description) {
 				// Start parsing submit description
-				if (!param_boolean("DAGMAN_USE_DIRECT_SUBMIT", true)) {
+				if (!_useDirectSubmit) {
 					debug_printf(DEBUG_NORMAL, "ERROR: To use an inline job "
 					  "description for node %s, DAGMAN_USE_DIRECT_SUBMIT must "
 					  "be set to True. Aborting.\n", descName.c_str());


### PR DESCRIPTION
This ticket is a small optimization to [HTCONDOR-619](https://opensciencegrid.atlassian.net/browse/HTCONDOR-619), in which we changed DAGMan to submit jobs directly to the condor_schedd instead of forking a condor_submit process. The optimization comes in the parser code, where we read the value of the `DAMGAN_USE_DIRECT_SUBMIT` configuration knob once and store it in a global variable, instead of looking it up every time we need it.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
