### PR TITLE
HTCONDOR-899 Additional procd debug line

### DIFF
--- a/src/condor_procd/proc_family_monitor.cpp
+++ b/src/condor_procd/proc_family_monitor.cpp
@@ -206,8 +206,8 @@ ProcFamilyMonitor::register_subfamily(pid_t root_pid,
 	ret = m_member_table.lookup(root_pid, member);
 	if ((ret == -1) || (member->get_proc_family() == m_everybody_else)) {
 		dprintf(D_ALWAYS,
-		        "register_subfamily failure: pid %u not in process tree\n",
-		        root_pid);
+		        "register_subfamily failure: (%d) pid %u not in process tree\n",
+		        ret, root_pid);
 		return PROC_FAMILY_ERROR_PROCESS_NOT_FAMILY;
 	}
 


### PR DESCRIPTION
We see a rare failure in the tests where the starter forks
to run a job, and in the child process, before it execs
the job, it registers itself as a subfamily to the procd.
The procd returns an error, rarely, claiming the pid of
the forked starter (which the starter has logged) either
doesn't exist, or isn't in the process tree of its parent.

This diff tells us which of those particular cases is
actually happening, so we can debug it further

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
