### PR TITLE
HTCONDOR-969 Directory quiet dprintf

### DIFF
--- a/src/condor_utils/directory.cpp
+++ b/src/condor_utils/directory.cpp
@@ -764,10 +764,14 @@ Directory::Rewind()
 				// this directory.  If that works, we should save this
 				// as our desired priv_state for future actions...
 			if( ! want_priv_change ) {
-				dprintf( D_ALWAYS, "Can't open directory \"%s\" as %s, "
-						 "errno: %d (%s)\n", curr_dir, 
-						 priv_to_string(get_priv()), errno, 
-						 strerror(errno) );
+				if( errno == ENOENT ) {
+					dprintf(D_FULLDEBUG, "Directory::Rewind(): path \"%s\" does not exist (yet)\n", curr_dir);
+				} else {
+					dprintf( D_ALWAYS, "Can't open directory \"%s\" as %s, "
+					         "errno: %d (%s)\n", curr_dir,
+					         priv_to_string(get_priv()), errno,
+					         strerror(errno) );
+				}
 				return_and_resetpriv(false);
 			}
 
@@ -776,7 +780,7 @@ Directory::Rewind()
 			priv_state old_priv = setOwnerPriv( curr_dir, err );
 			if( old_priv == PRIV_UNKNOWN ) {
 				if (err == SINoFile)
-					dprintf(D_FULLDEBUG, "Directory::Rewind(): path \"%s\" does not exist (yet) \n", curr_dir);
+					dprintf(D_FULLDEBUG, "Directory::Rewind(): path \"%s\" does not exist (yet)\n", curr_dir);
 				else 
 					dprintf( D_ALWAYS, "Directory::Rewind(): "
 							 "failed to find owner of \"%s\"\n", curr_dir );


### PR DESCRIPTION
Make Directory::Rewind() quieter about the directory not existing when
not running as root (to match its behavior when running as root).

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
