### PR TITLE
HTCONDOR-996 job submit method recording branch

### DIFF
--- a/docs/apis/python-bindings/api/htcondor.rst
+++ b/docs/apis/python-bindings/api/htcondor.rst
@@ -85,6 +85,8 @@ Submitting Jobs
    .. automethod:: getQArgs
    .. automethod:: setQArgs
    .. automethod:: from_dag
+   .. automethod:: setSubmitMethod
+   .. automethod:: getSubmitMethod
 
 .. autoclass:: QueueItemsIterator
 

--- a/docs/classad-attributes/job-classad-attributes.rst
+++ b/docs/classad-attributes/job-classad-attributes.rst
@@ -1042,6 +1042,27 @@ all attributes.
     | 7     | Suspended           |
     +-------+---------------------+
 
+:classad-attribute: `JobSubmitMethod`
+    Integer which indicates how a **Job** was submitted to HTCondor.
+ 
+    +-----------+------------------------+
+    | Value     | Method of Submission   |
+    +===========+========================+
+    | Undefined | Unknown                |
+    +-----------+------------------------+
+    | 0         | *condor_submit*        |
+    +-----------+------------------------+
+    | 1         | DAGMan                 |
+    +-----------+------------------------+
+    | 2         | Python Bindings        |
+    +-----------+------------------------+
+    | 3         |*htcondor job submit*   |
+    +-----------+------------------------+
+    | 4         |*htcondor jobset submit*|
+    +-----------+------------------------+
+    | 5         |*htcondor dag submit*   |
+    +-----------+------------------------+
+
 
 :index:`JobUniverse<single: JobUniverse; ClassAd job attribute>`
 :index:`job ClassAd attribute<single: job ClassAd attribute; JobUniverse>`

--- a/docs/classad-attributes/job-classad-attributes.rst
+++ b/docs/classad-attributes/job-classad-attributes.rst
@@ -1042,8 +1042,9 @@ all attributes.
     | 7     | Suspended           |
     +-------+---------------------+
 
-:classad-attribute: `JobSubmitMethod`
-    Integer which indicates how a **Job** was submitted to HTCondor.
+:classad-attribute:`JobSubmitMethod`
+    Integer which indicates how a job was submitted to HTCondor. Users can
+    set a custom value for job via Python Bindings API.
  
     +-----------+------------------------+
     | Value     | Method of Submission   |
@@ -1052,17 +1053,17 @@ all attributes.
     +-----------+------------------------+
     | 0         | *condor_submit*        |
     +-----------+------------------------+
-    | 1         | DAGMan                 |
+    | 1         | DAGMan-Direct          |
     +-----------+------------------------+
     | 2         | Python Bindings        |
     +-----------+------------------------+
     | 3         |*htcondor job submit*   |
     +-----------+------------------------+
-    | 4         |*htcondor jobset submit*|
+    | 4         |*htcondor dag submit*   |
     +-----------+------------------------+
-    | 5         |*htcondor dag submit*   |
+    | 5         |*htcondor jobset submit*|
     +-----------+------------------------+
-    | 6         | User Set/Custom        |
+    | 100+      | Portal/User-set        |
     +-----------+------------------------+
 
 

--- a/docs/classad-attributes/job-classad-attributes.rst
+++ b/docs/classad-attributes/job-classad-attributes.rst
@@ -1062,6 +1062,8 @@ all attributes.
     +-----------+------------------------+
     | 5         |*htcondor dag submit*   |
     +-----------+------------------------+
+    | 6         | User Set/Custom        |
+    +-----------+------------------------+
 
 
 :index:`JobUniverse<single: JobUniverse; ClassAd job attribute>`

--- a/src/condor_dagman/dagman_submit.cpp
+++ b/src/condor_dagman/dagman_submit.cpp
@@ -588,7 +588,7 @@ direct_condor_submit(const Dagman &dm, Job* node,
 		debug_printf(DEBUG_NORMAL, "Submitting node %s from file %s using direct job submission\n", node->GetJobName(), node->GetCmdFile());
 		submitHash = new SubmitHash();
 		// Start by populating the hash with some parameters
-		submitHash->init(submit_method::DAGMAN);
+		submitHash->init(DAGMAN);
 		submitHash->setDisableFileChecks(true);
 		submitHash->setScheddVersion(CondorVersion());
 		// if (myproxy_password) submitHash.setMyProxyPassword(myproxy_password);

--- a/src/condor_dagman/dagman_submit.cpp
+++ b/src/condor_dagman/dagman_submit.cpp
@@ -588,7 +588,7 @@ direct_condor_submit(const Dagman &dm, Job* node,
 		debug_printf(DEBUG_NORMAL, "Submitting node %s from file %s using direct job submission\n", node->GetJobName(), node->GetCmdFile());
 		submitHash = new SubmitHash();
 		// Start by populating the hash with some parameters
-		submitHash->init(DAGMAN);
+		submitHash->init(JSM_DAGMAN);
 		submitHash->setDisableFileChecks(true);
 		submitHash->setScheddVersion(CondorVersion());
 		// if (myproxy_password) submitHash.setMyProxyPassword(myproxy_password);

--- a/src/condor_dagman/dagman_submit.cpp
+++ b/src/condor_dagman/dagman_submit.cpp
@@ -588,7 +588,7 @@ direct_condor_submit(const Dagman &dm, Job* node,
 		debug_printf(DEBUG_NORMAL, "Submitting node %s from file %s using direct job submission\n", node->GetJobName(), node->GetCmdFile());
 		submitHash = new SubmitHash();
 		// Start by populating the hash with some parameters
-		submitHash->init();
+		submitHash->init(submit_method::DAGMAN);
 		submitHash->setDisableFileChecks(true);
 		submitHash->setScheddVersion(CondorVersion());
 		// if (myproxy_password) submitHash.setMyProxyPassword(myproxy_password);

--- a/src/condor_includes/condor_attributes.h
+++ b/src/condor_includes/condor_attributes.h
@@ -431,6 +431,7 @@
 #define ATTR_LAST_JOB_STATUS  "LastJobStatus"
 #define ATTR_JOB_TOE "ToE"  // termination of execution ad
 #define ATTR_JOB_STATUS_ON_RELEASE  "JobStatusOnRelease"
+#define ATTR_JOB_SUBMIT_METHOD "JobSubmitMethod"
 #define ATTR_JOB_TRANSFERRING_OUTPUT  "JobTransferringOutput"
 #define ATTR_JOB_TRANSFERRING_OUTPUT_TIME  "JobTransferringOutputTime"
 #define ATTR_JOB_UNIVERSE  "JobUniverse"

--- a/src/condor_includes/proc.h
+++ b/src/condor_includes/proc.h
@@ -147,6 +147,20 @@ typedef struct JOB_ID_KEY {
 inline bool operator==( const JOB_ID_KEY a, const JOB_ID_KEY b) { return a.cluster == b.cluster && a.proc == b.proc; }
 size_t hashFunction(const JOB_ID_KEY &);
 
+// used to indicate how a job was submitted to htcondor
+enum class submit_method{
+	UNDEFINED = -1,
+	CONDOR_SUBMIT,
+	DAGMAN,
+	PYTHON_BINDINGS,
+	HTC_JOB_SUBMIT,
+	HTC_JOBSET_SUBMIT,
+	HTC_DAG_SUBMIT,
+	USER_SET,
+};
+
+const char* getSubmitMethodString(submit_method method);
+
 #define ICKPT -1
 
 #define NEW_PROC 1

--- a/src/condor_includes/proc.h
+++ b/src/condor_includes/proc.h
@@ -147,19 +147,18 @@ typedef struct JOB_ID_KEY {
 inline bool operator==( const JOB_ID_KEY a, const JOB_ID_KEY b) { return a.cluster == b.cluster && a.proc == b.proc; }
 size_t hashFunction(const JOB_ID_KEY &);
 
-// used to indicate how a job was submitted to htcondor
-enum class submit_method{
-	UNDEFINED = -1,
-	CONDOR_SUBMIT,
-	DAGMAN,
-	PYTHON_BINDINGS,
-	HTC_JOB_SUBMIT,
-	HTC_JOBSET_SUBMIT,
-	HTC_DAG_SUBMIT,
-	USER_SET,
-};
+// Macros used to indicate how a job was submitted to htcondor
+#define JOB_SUBMIT_METHOD_MIN 0
+#define CONDOR_SUBMIT 0
+#define DAGMAN 1
+#define PYTHON_BINDINGS 2
+#define HTC_JOB_SUBMIT 3
+#define HTC_DAG_SUBMIT 4
+#define HTC_JOBSET_SUBMIT 5
+#define USER_SET 100
+#define JOB_SUBMIT_METHOD_MAX 100
 
-const char* getSubmitMethodString(submit_method method);
+const char* getSubmitMethodString(int method);
 
 #define ICKPT -1
 

--- a/src/condor_includes/proc.h
+++ b/src/condor_includes/proc.h
@@ -149,13 +149,13 @@ size_t hashFunction(const JOB_ID_KEY &);
 
 // Macros used to indicate how a job was submitted to htcondor
 #define JOB_SUBMIT_METHOD_MIN 0
-#define CONDOR_SUBMIT 0
-#define DAGMAN 1
-#define PYTHON_BINDINGS 2
-#define HTC_JOB_SUBMIT 3
-#define HTC_DAG_SUBMIT 4
-#define HTC_JOBSET_SUBMIT 5
-#define USER_SET 100
+#define JSM_CONDOR_SUBMIT 0
+#define JSM_DAGMAN 1
+#define JSM_PYTHON_BINDINGS 2
+#define JSM_HTC_JOB_SUBMIT 3
+#define JSM_HTC_DAG_SUBMIT 4
+#define JSM_HTC_JOBSET_SUBMIT 5
+#define JSM_USER_SET 100
 #define JOB_SUBMIT_METHOD_MAX 100
 
 const char* getSubmitMethodString(int method);

--- a/src/condor_q.V6/queue.cpp
+++ b/src/condor_q.V6/queue.cpp
@@ -2580,7 +2580,7 @@ usage (const char *myName, int other)
 			std::string display = getSubmitMethodString(met);
 			//If number yeilds final enum key then output and break out of loop
 			if(display.compare("Portal/User-Set") == 0){
-				printf("\t%3d+ %s\n", USER_SET, display.c_str());
+				printf("\t%3d+ %s\n", JSM_USER_SET, display.c_str());
 				break;
 			}
 			printf("\t%3d  %s\n", met, display.c_str());

--- a/src/condor_q.V6/queue.cpp
+++ b/src/condor_q.V6/queue.cpp
@@ -2575,9 +2575,15 @@ usage (const char *myName, int other)
 	}
 	if (other & usage_SubmitMethod) {
 		printf("    %s codes:\n", ATTR_JOB_SUBMIT_METHOD);
-		printf("\t%3s %s\n", "UND", getSubmitMethodString(submit_method::UNDEFINED));
-		for (int met = 0; met <= static_cast<int>(submit_method::USER_SET); ++met) {
-			printf("\t%3d %s\n", met, getSubmitMethodString(static_cast<submit_method>(met)));
+		printf("\t%3s  %s\n", "UND", "Undefined");
+		for (int met = JOB_SUBMIT_METHOD_MIN; met <= JOB_SUBMIT_METHOD_MAX; ++met) {
+			std::string display = getSubmitMethodString(met);
+			//If number yeilds final enum key then output and break out of loop
+			if(display.compare("Portal/User-Set") == 0){
+				printf("\t%3d+ %s\n", USER_SET, display.c_str());
+				break;
+			}
+			printf("\t%3d  %s\n", met, display.c_str());
 		}
 		printf("\n");
 	}

--- a/src/condor_q.V6/queue.cpp
+++ b/src/condor_q.V6/queue.cpp
@@ -76,7 +76,7 @@ static  bool streaming_print_job(void*, ClassAd*);
 typedef bool (* buffer_line_processor)(void*, ClassAd *);
 
 static 	void usage (const char *, int other=0);
-enum { usage_Universe=1, usage_JobStatus=2, usage_AllOther=0xFF };
+enum { usage_Universe=1, usage_JobStatus=2, usage_SubmitMethod=4, usage_AllOther=0xFF };
 static bool render_job_status_char(std::string & result, ClassAd*ad, Formatter &);
 
 // functions to fetch job ads and print them out
@@ -1378,6 +1378,8 @@ processCommandLineArguments (int argc, const char *argv[])
 					other |= usage_Universe;
 				} else if (is_arg_prefix(argv[i], "state", 2) || is_arg_prefix(argv[i], "State", 2) || is_arg_prefix(argv[i], "status", 2)) {
 					other |= usage_JobStatus;
+				} else if (is_arg_prefix(argv[i], "submit", 2) || is_arg_prefix(argv[i], "Submit", 2)) {
+					other |= usage_SubmitMethod;
 				} else if (is_arg_prefix(argv[i], "all", 2)) {
 					other |= usage_AllOther;
 				}
@@ -2568,6 +2570,14 @@ usage (const char *myName, int other)
 		printf("    %s codes:\n", ATTR_JOB_STATUS);
 		for (int st = JOB_STATUS_MIN; st <= JOB_STATUS_MAX; ++st) {
 			printf("\t%2d %c %s\n", st, encode_status(st), getJobStatusString(st));
+		}
+		printf("\n");
+	}
+	if (other & usage_SubmitMethod) {
+		printf("    %s codes:\n", ATTR_JOB_SUBMIT_METHOD);
+		printf("\t%3s %s\n", "UND", getSubmitMethodString(submit_method::UNDEFINED));
+		for (int met = 0; met <= static_cast<int>(submit_method::USER_SET); ++met) {
+			printf("\t%3d %s\n", met, getSubmitMethodString(static_cast<submit_method>(met)));
 		}
 		printf("\n");
 	}

--- a/src/condor_submit.V6/submit.cpp
+++ b/src/condor_submit.V6/submit.cpp
@@ -539,7 +539,7 @@ main( int argc, const char *argv[] )
 	}
 
 	init_params();
-	submit_hash.init(submit_method::CONDOR_SUBMIT);
+	submit_hash.init(CONDOR_SUBMIT);
 
 	default_to_factory = param_boolean("SUBMIT_FACTORY_JOBS_BY_DEFAULT", default_to_factory);
 

--- a/src/condor_submit.V6/submit.cpp
+++ b/src/condor_submit.V6/submit.cpp
@@ -539,7 +539,7 @@ main( int argc, const char *argv[] )
 	}
 
 	init_params();
-	submit_hash.init(CONDOR_SUBMIT);
+	submit_hash.init(JSM_CONDOR_SUBMIT);
 
 	default_to_factory = param_boolean("SUBMIT_FACTORY_JOBS_BY_DEFAULT", default_to_factory);
 

--- a/src/condor_submit.V6/submit.cpp
+++ b/src/condor_submit.V6/submit.cpp
@@ -539,7 +539,7 @@ main( int argc, const char *argv[] )
 	}
 
 	init_params();
-	submit_hash.init();
+	submit_hash.init(submit_method::CONDOR_SUBMIT);
 
 	default_to_factory = param_boolean("SUBMIT_FACTORY_JOBS_BY_DEFAULT", default_to_factory);
 

--- a/src/condor_tests/CMakeLists.txt
+++ b/src/condor_tests/CMakeLists.txt
@@ -234,6 +234,8 @@ endif ()
 
 			condor_pl_test(test_htcondor_submit_constructor "Test htcondor.Submit()" "quick;ctest"	CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 
+			condor_pl_test(test_job_submit_method_recording "Test recording of JobSubmitMethod job attribute" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
+
 			# These tests require Python 3.6 or later.
 			if (PYTHON3_VERSION_MINOR GREATER_EQUAL 6)
 				condor_pl_test(test_custom_machine_resource "Test that a custom machine resource is assigned, limited, and monitored correctly" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py;src/condor_tests/libcmr.py")

--- a/src/condor_tests/test_job_submit_method_recording.py
+++ b/src/condor_tests/test_job_submit_method_recording.py
@@ -13,6 +13,11 @@ import os
 from time import sleep
 
 
+#Function to wait until schedd has no jobs
+def wait(schedd):
+     while any(schedd.query(constraint='true',projection=["JobSubmitMethod"])) == True:
+          sleep(0.1)
+
 #Fixture to write simple .sub file for general use
 @action
 def write_sub_file(test_dir,path_to_sleep):
@@ -42,9 +47,9 @@ PARENT A CHILD B
 def run_condor_submit(default_condor,write_sub_file):
      #Submit job
      p = default_condor.run_command(["condor_submit", write_sub_file])
-     sleep(10)
      #Get the job ad for completed job
      schedd = default_condor.get_local_schedd()
+     wait(schedd)
      job_ad = schedd.history(
           constraint=None,
           projection=["JobSubmitMethod"],
@@ -58,9 +63,9 @@ def run_condor_submit(default_condor,write_sub_file):
 def run_dagman_submission(default_condor,write_dag_file):
      #Submit job 
      p = default_condor.run_command(["condor_submit_dag",write_dag_file])
-     sleep(20)
      #Get the job ad for completed job
      schedd = default_condor.get_local_schedd()
+     wait(schedd)
      job_ad = schedd.history(
           constraint=None,
           projection=["JobSubmitMethod"],
@@ -102,9 +107,9 @@ print(job.getSubmitMethod())
 @action
 def run_htcondor_job_submit(default_condor,write_sub_file):
      p = default_condor.run_command(["htcondor","job","submit",write_sub_file])
-     sleep(10)
      #Get the job ad for completed job
      schedd = default_condor.get_local_schedd()
+     wait(schedd)
      job_ad = schedd.history(
           constraint=None,
           projection=["JobSubmitMethod"],
@@ -133,9 +138,9 @@ job {{
      jobset_file.close()
 
      p = default_condor.run_command(["htcondor","jobset","submit",test_dir / "job.set"])
-     sleep(10)
      #Get the job ad for completed job
      schedd = default_condor.get_local_schedd()
+     wait(schedd)
      job_ad = schedd.history(
           constraint=f"JobSetName == \"JobSubmitMethodTest\"",
           projection=["JobSubmitMethod"],
@@ -158,12 +163,12 @@ def run_htcondor_dag_submit(default_condor,write_dag_file,test_dir):
           p = default_condor.run_command(["mv",test_dir / name, test_dir / "dag_test1"])
      #run second dag submission test 
      p = default_condor.run_command(["htcondor","dag","submit", write_dag_file])
-     sleep(20)
      #move secodn test files into dag_test2 directory
      for name in files_to_move:
-          p = default_condor.run_command(["mv",test_dir / name, test_dir / "dag_test1"])
+          p = default_condor.run_command(["mv",test_dir / name, test_dir / "dag_test2"])
      #Get the job ad for completed job
      schedd = default_condor.get_local_schedd()
+     wait(schedd)
      job_ad = schedd.history(
           constraint=None,
           projection=["JobSubmitMethod"],

--- a/src/condor_tests/test_job_submit_method_recording.py
+++ b/src/condor_tests/test_job_submit_method_recording.py
@@ -271,15 +271,17 @@ class TestJobSubmitMethod:
      #Test python bindings job submission yields 2 for normal submission and 6 for when a user sets the value to 6
      def test_python_bindings_submit_method_value(self,run_python_bindings):
           passed = False
-          if run_python_bindings.stdout == '2':
+          if run_python_bindings.stdout == '2':#Check normal
                passed = True
-          elif run_python_bindings.stdout == "69":
+          elif run_python_bindings.stdout == "-3":#Check user-set(1)
                passed = True
-          elif run_python_bindings.stdout == "100":
+          elif run_python_bindings.stdout == "69":#Check user-set(3)
                passed = True
-          elif run_python_bindings.stdout == "666":
+          elif run_python_bindings.stdout == "100":#Check user-set(4)
                passed = True
-          elif "htcondor.HTCondorValueError: Submit Method value must be" in run_python_bindings.stderr:
+          elif run_python_bindings.stdout == "666":#Check user-set(5)
+               passed = True
+          elif "htcondor.HTCondorValueError: Submit Method value must be" in run_python_bindings.stderr:#Check user-set(2)
                if "or greater. Or allow_reserved_values must be set to True." in run_python_bindings.stderr:
                     passed = True
           assert passed

--- a/src/condor_tests/test_job_submit_method_recording.py
+++ b/src/condor_tests/test_job_submit_method_recording.py
@@ -62,7 +62,7 @@ job = htcondor.Submit({{
      "executable":"{0}"
 }})
 
-job._setSubmitMethod(-1,True)
+job.setSubmitMethod(-1,True)
 schedd = htcondor.Schedd()
 submit_result = schedd.submit(job)
 """.format(path_to_sleep))
@@ -119,9 +119,10 @@ subTestNum = 0
 @action(params={
 "normal":'',
 "user_set(1)":"job.setSubmitMethod(-3)",
-"user_set(2)":"job.setSubmitMethod(53)",
-"user_set(3)":"job.setSubmitMethod(100)",
-"user_set(4)":"job.setSubmitMethod(666)",
+"user_set(2)":"job.setSubmitMethod(69)",
+"user_set(3)":"job.setSubmitMethod(69,True)",
+"user_set(4)":"job.setSubmitMethod(100)",
+"user_set(5)":"job.setSubmitMethod(666)",
 })#Parameter tests: Standard, User-set(-3), User-set(53), User-set(100), and User-set(666)
 def run_python_bindings(default_condor,test_dir,path_to_sleep,request):
      global subTestNum
@@ -272,10 +273,15 @@ class TestJobSubmitMethod:
           passed = False
           if run_python_bindings.stdout == '2':
                passed = True
+          elif run_python_bindings.stdout == "69":
+               passed = True
           elif run_python_bindings.stdout == "100":
                passed = True
           elif run_python_bindings.stdout == "666":
                passed = True
+          elif "htcondor.HTCondorValueError: Submit Method value must be" in run_python_bindings.stderr:
+               if "or greater. Or allow_reserved_values must be set to True." in run_python_bindings.stderr:
+                    passed = True
           assert passed
 
      #Test 'htcondor job submit' yields 3

--- a/src/condor_tests/test_job_submit_method_recording.py
+++ b/src/condor_tests/test_job_submit_method_recording.py
@@ -11,12 +11,16 @@
 from ornithology import *
 import os
 from time import sleep
+from time import time
 
 
 #Function to wait until schedd has no jobs
 def wait(schedd):
+     t_end = time() + 180 #Give a 2 minute maximum for waiting
      while any(schedd.query(constraint='true',projection=["JobSubmitMethod"])) == True:
           sleep(0.1)
+          if time() >= t_end:
+               break
 
 #Fixture to write simple .sub file for general use
 @action

--- a/src/condor_tests/test_job_submit_method_recording.py
+++ b/src/condor_tests/test_job_submit_method_recording.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env pytest
+
+#Job Ad attribute: JobSubmitMethod assignment testing
+#
+#Each sub-test submits job(s) and waits till all are hopefully finished.
+#Then it collects the recent job ads from schedd history and returns
+#them for evaluation.
+#
+#Written by: Cole Bollig @ March 2022
+
+from ornithology import *
+import os
+from time import sleep
+
+
+#Fixture to write simple .sub file for general use
+@action
+def write_sub_file(test_dir,path_to_sleep):
+     submit_file = open( test_dir / "simple_submit.sub","w")
+     submit_file.write("""executable={0}
+arguments=1
+should_transfer_files=Yes
+queue
+""".format(path_to_sleep))
+     submit_file.close()
+     return test_dir / "simple_submit.sub"
+
+#Fixture to write simple .dag file using write_sub_file fixture for general dag use
+@action
+def write_dag_file(test_dir,write_sub_file):
+     dag_file = open( test_dir / "simple.dag", "w")
+     dag_file.write("""JOB A {0}
+JOB B {0}
+
+PARENT A CHILD B
+""".format(write_sub_file))
+     dag_file.close()
+     return test_dir / "simple.dag"
+
+#Fixture to run condor_submit and check the JobSubmitMethod attr
+@action
+def run_condor_submit(default_condor,write_sub_file):
+     #Submit job
+     p = default_condor.run_command(["condor_submit", write_sub_file])
+     sleep(10)
+     #Get the job ad for completed job
+     schedd = default_condor.get_local_schedd()
+     job_ad = schedd.history(
+          constraint=None,
+          projection=["JobSubmitMethod"],
+          match=1,
+     )
+     
+     return job_ad
+
+#Fixture to run condor_submit_dag and check the JobSubmitMethod attr
+@action
+def run_dagman_submission(default_condor,write_dag_file):
+     #Submit job 
+     p = default_condor.run_command(["condor_submit_dag",write_dag_file])
+     sleep(20)
+     #Get the job ad for completed job
+     schedd = default_condor.get_local_schedd()
+     job_ad = schedd.history(
+          constraint=None,
+          projection=["JobSubmitMethod"],
+          match=3,
+     )
+     
+     return job_ad
+
+subTestNum = 0
+#Fixture to run python bindings with and without user set value and check the JobSubmitMethod attr
+@action(params={"normal":'',"user_set":"job.setSubmitMethod(6)"})#Add line to have setting JobSubmitMethod to value 6 in python files
+def run_python_bindings(default_condor,test_dir,path_to_sleep,request):
+     global subTestNum
+     filename = "test{}.py".format(subTestNum)
+     python_file = open(test_dir / filename, "w")
+     subTestNum += 1
+     python_file.write(
+     """import htcondor
+import classad
+
+job = htcondor.Submit({{
+     "executable":"{0}"
+}})
+
+{1}
+schedd = htcondor.Schedd()
+submit_result = schedd.submit(job)
+print(job.getSubmitMethod())
+""".format(path_to_sleep,request.param))
+     python_file.close()
+     #^^^Make python file for submission^^^
+
+     #Submit file to run job
+     p = default_condor.run_command(["python3",test_dir / filename])
+
+     return p
+
+#Fixture to run 'htcondor job submit' and check the JobSubmitMethod attr
+@action
+def run_htcondor_job_submit(default_condor,write_sub_file):
+     p = default_condor.run_command(["htcondor","job","submit",write_sub_file])
+     sleep(10)
+     #Get the job ad for completed job
+     schedd = default_condor.get_local_schedd()
+     job_ad = schedd.history(
+          constraint=None,
+          projection=["JobSubmitMethod"],
+          match=1,
+     )
+     
+     return job_ad
+
+#Fixture to run 'htcondor jobset submit' and check the JobSubmitMethod attr
+@action
+def run_htcondor_jobset_submit(default_condor,test_dir,path_to_sleep):
+     jobset_file = open(test_dir / "job.set", "w")
+     jobset_file.write(
+     """name = JobSubmitMethodTest
+
+iterator = table var {{
+     Job1
+     Job2
+}}
+
+job {{
+     executable = {}
+     queue
+}}
+""".format(path_to_sleep))
+     jobset_file.close()
+
+     p = default_condor.run_command(["htcondor","jobset","submit",test_dir / "job.set"])
+     sleep(10)
+     #Get the job ad for completed job
+     schedd = default_condor.get_local_schedd()
+     job_ad = schedd.history(
+          constraint=f"JobSetName == \"JobSubmitMethodTest\"",
+          projection=["JobSubmitMethod"],
+          match=2,
+     )
+     
+     return job_ad
+
+#Fixture to run 'htcondor dag submit' and check the JobSubmitMethod attr
+@action
+def run_htcondor_dag_submit(default_condor,write_dag_file,test_dir):
+     #List of files needed to be moved
+     files_to_move = ["simple.dag.condor.sub","simple.dag.dagman.log","simple.dag.dagman.out","simple.dag.lib.err","simple.dag.lib.out","simple.dag.metrics","simple.dag.nodes.log"]
+     #make directories for each dag submission test to avoid errors
+     p = default_condor.run_command(["pwd"])
+     p = default_condor.run_command(["mkdir",test_dir / "dag_test1"])
+     p = default_condor.run_command(["mkdir",test_dir / "dag_test2"])
+     #move first test files into dag_test1 directory
+     for name in files_to_move:
+          p = default_condor.run_command(["mv",test_dir / name, test_dir / "dag_test1"])
+     #run second dag submission test 
+     p = default_condor.run_command(["htcondor","dag","submit", write_dag_file])
+     sleep(20)
+     #move secodn test files into dag_test2 directory
+     for name in files_to_move:
+          p = default_condor.run_command(["mv",test_dir / name, test_dir / "dag_test1"])
+     #Get the job ad for completed job
+     schedd = default_condor.get_local_schedd()
+     job_ad = schedd.history(
+          constraint=None,
+          projection=["JobSubmitMethod"],
+          match=3,
+     )
+     
+     return job_ad
+
+
+#JobSubmitMethod Tests
+class TestJobSubmitMethod:
+
+     #Test condor_submit yields 0
+     def test_condor_submit_method_value(self,run_condor_submit):
+          i = 0
+          passed = False
+          #Check that returned job ads have a submission value of 0
+          for ad in run_condor_submit:
+               i += 1
+               #If job ad submit method is not 0 then fail test
+               if ad["JobSubmitMethod"] == 0:
+                    passed = True
+          if i != 1:
+               passed = False
+          #If made it this far then the test passed
+          assert passed
+
+     #Test condor_submit yields 0 for dag and 1 for dag submitted jobs
+     def test_dagman_submit_job_value(self,run_dagman_submission):
+          countDAG = 0
+          countJobs = 0
+          passed = False
+          #Check that returned job ads 
+          for ad in run_dagman_submission:
+               if ad["JobSubmitMethod"] == 0:
+                    countDAG += 1
+               if ad["JobSubmitMethod"] == 1:
+                    countJobs += 1
+          if countDAG == 1 and countJobs == 2:
+               passed = True
+
+          #If made it this far then the test passed
+          assert passed
+
+     #Test python bindings job submission yields 2 for normal submission and 6 for when a user sets the value to 6
+     def test_python_bindings_submit_method_value(self,run_python_bindings):
+          passed = False
+          if run_python_bindings.stdout == '2':
+               passed = True
+          elif run_python_bindings.stdout == '6':
+               passed = True
+          assert passed
+
+     #Test 'htcondor job submit' yields 3
+     def test_htcondor_job_submit_method_value(self,run_htcondor_job_submit):
+          i = 0
+          passed = False
+          #Check that returned job ads have a submission value of 3
+          for ad in run_htcondor_job_submit:
+               i += 1
+               #If job ad submit method is not 3 then fail test
+               if ad["JobSubmitMethod"] == 3:
+                    passed = True
+          if i != 1:
+               passed = False
+          #If made it this far then the test passed
+          assert passed
+
+     #Test 'htcondor jobset submit yields 4
+     def test_htcondor_jobset_submit_method_value(self,run_htcondor_jobset_submit):
+          i = 0
+          passed = False
+          #Check that returned job ads have a submission value of 4
+          for ad in run_htcondor_jobset_submit:
+               i += 1
+               #If job ad submit method is not 4 then fail test
+               if ad["JobSubmitMethod"] == 4:
+                    passed = True
+          if i != 2:
+               passed = False
+          #If made it this far then the test passed
+          assert passed
+
+     #Test 'htcondor dag submit yields 5
+     def test_htcondor_dag_submit_method_value(self,run_htcondor_dag_submit):
+          countDAG = 0
+          countJobs = 0
+          passed = False
+          #Check that returned job ads 
+          for ad in run_htcondor_dag_submit:
+               if ad["JobSubmitMethod"] == 5:
+                    countDAG += 1
+               if ad["JobSubmitMethod"] == 1:
+                    countJobs += 1
+          if countDAG == 1 and countJobs == 2:
+               passed = True
+
+          #If made it this far then the test passed
+          assert passed
+
+
+

--- a/src/condor_tools/htcondor_cli/dagman.py
+++ b/src/condor_tools/htcondor_cli/dagman.py
@@ -17,6 +17,7 @@ from htcondor_cli import TMP_DIR
 
 schedd = htcondor.Schedd()
 
+CONST_SUBMIT_METHOD = 4
 
 class Submit(Verb):
     """
@@ -44,7 +45,7 @@ class Submit(Verb):
         # Submit the DAG to the local schedd
         submit_description = htcondor.Submit.from_dag(dag_filename)
 	#Set s_method to HTC_DAG_SUBMIT
-        submit_description.setSubmitMethod(5)
+        submit_description._setSubmitMethod(CONST_SUBMIT_METHOD,True)
 
         with schedd.transaction() as txn:
             try:

--- a/src/condor_tools/htcondor_cli/dagman.py
+++ b/src/condor_tools/htcondor_cli/dagman.py
@@ -43,6 +43,8 @@ class Submit(Verb):
 
         # Submit the DAG to the local schedd
         submit_description = htcondor.Submit.from_dag(dag_filename)
+	#Set s_method to HTC_DAG_SUBMIT
+        submit_description.setSubmitMethod(5)
 
         with schedd.transaction() as txn:
             try:

--- a/src/condor_tools/htcondor_cli/dagman.py
+++ b/src/condor_tools/htcondor_cli/dagman.py
@@ -14,10 +14,9 @@ from htcondor_cli.verb import Verb
 from htcondor_cli import JobStatus
 from htcondor_cli import TMP_DIR
 
-
 schedd = htcondor.Schedd()
 
-CONST_SUBMIT_METHOD = 4
+JSM_HTC_DAG_SUBMIT = 4
 
 class Submit(Verb):
     """
@@ -45,7 +44,7 @@ class Submit(Verb):
         # Submit the DAG to the local schedd
         submit_description = htcondor.Submit.from_dag(dag_filename)
 	#Set s_method to HTC_DAG_SUBMIT
-        submit_description._setSubmitMethod(CONST_SUBMIT_METHOD,True)
+        submit_description.setSubmitMethod(JSM_HTC_DAG_SUBMIT,True)
 
         with schedd.transaction() as txn:
             try:

--- a/src/condor_tools/htcondor_cli/job.py
+++ b/src/condor_tools/htcondor_cli/job.py
@@ -66,6 +66,8 @@ class Submit(Verb):
             with submit_file.open() as f:
                 submit_data = f.read()
             submit_description = htcondor.Submit(submit_data)
+	    #Set s_method to HTC_JOB_SUBMIT
+            submit_description.setSubmitMethod(3)
 
             annex_name = options["annex_name"]
             if annex_name is not None:

--- a/src/condor_tools/htcondor_cli/job.py
+++ b/src/condor_tools/htcondor_cli/job.py
@@ -7,6 +7,7 @@ import tempfile
 import time
 import getpass
 
+
 from datetime import datetime
 from pathlib import Path
 
@@ -18,6 +19,7 @@ from htcondor_cli.dagman import DAGMan
 from htcondor_cli import JobStatus
 from htcondor_cli import TMP_DIR
 
+CONST_SUBMIT_METHOD = 3
 
 class Submit(Verb):
     """
@@ -67,7 +69,7 @@ class Submit(Verb):
                 submit_data = f.read()
             submit_description = htcondor.Submit(submit_data)
 	    #Set s_method to HTC_JOB_SUBMIT
-            submit_description.setSubmitMethod(3)
+            submit_description._setSubmitMethod(CONST_SUBMIT_METHOD,True)
 
             annex_name = options["annex_name"]
             if annex_name is not None:

--- a/src/condor_tools/htcondor_cli/job.py
+++ b/src/condor_tools/htcondor_cli/job.py
@@ -19,7 +19,7 @@ from htcondor_cli.dagman import DAGMan
 from htcondor_cli import JobStatus
 from htcondor_cli import TMP_DIR
 
-CONST_SUBMIT_METHOD = 3
+JSM_HTC_JOB_SUBMIT = 3
 
 class Submit(Verb):
     """
@@ -69,7 +69,7 @@ class Submit(Verb):
                 submit_data = f.read()
             submit_description = htcondor.Submit(submit_data)
 	    #Set s_method to HTC_JOB_SUBMIT
-            submit_description._setSubmitMethod(CONST_SUBMIT_METHOD,True)
+            submit_description.setSubmitMethod(JSM_HTC_JOB_SUBMIT,True)
 
             annex_name = options["annex_name"]
             if annex_name is not None:

--- a/src/condor_tools/htcondor_cli/job_set.py
+++ b/src/condor_tools/htcondor_cli/job_set.py
@@ -12,6 +12,8 @@ from htcondor_cli.noun import Noun
 from htcondor_cli.verb import Verb
 
 
+CONST_SUBMIT_METHOD = 5
+
 class Submit(Verb):
     """
     Submits a job set when given a job set file
@@ -212,13 +214,13 @@ class Submit(Verb):
                         lineno += inlineno
                         submit_obj = htcondor.Submit(inline_data)
 			#Set s_method to HTC_JOBSET_SUBMIT
-                        submit_obj.setSubmitMethod(4)
+                        submit_obj._setSubmitMethod(CONST_SUBMIT_METHOD,True)
                     else:
                         try:
                             with open(job_source, "rt") as f_sub:
                                 submit_obj = htcondor.Submit(f_sub.read())
 				#Set s_method to HTC_JOBSET_SUBMIT
-                                submit_obj.setSubmitMethod(4)
+                                submit_obj._setSubmitMethod(CONST_SUBMIT_METHOD,True)
                         except IOError as e:
                             raise IOError(f"Error opening submit description file {job_source} in {job_set_file} at line {lineno}:\n{str(e)}")
 

--- a/src/condor_tools/htcondor_cli/job_set.py
+++ b/src/condor_tools/htcondor_cli/job_set.py
@@ -11,8 +11,7 @@ import classad
 from htcondor_cli.noun import Noun
 from htcondor_cli.verb import Verb
 
-
-CONST_SUBMIT_METHOD = 5
+JSM_HTC_JOBSET_SUBMIT = 5
 
 class Submit(Verb):
     """
@@ -214,13 +213,13 @@ class Submit(Verb):
                         lineno += inlineno
                         submit_obj = htcondor.Submit(inline_data)
 			#Set s_method to HTC_JOBSET_SUBMIT
-                        submit_obj._setSubmitMethod(CONST_SUBMIT_METHOD,True)
+                        submit_obj.setSubmitMethod(JSM_HTC_JOBSET_SUBMIT,True)
                     else:
                         try:
                             with open(job_source, "rt") as f_sub:
                                 submit_obj = htcondor.Submit(f_sub.read())
 				#Set s_method to HTC_JOBSET_SUBMIT
-                                submit_obj._setSubmitMethod(CONST_SUBMIT_METHOD,True)
+                                submit_obj.setSubmitMethod(JSM_HTC_JOBSET_SUBMIT,True)
                         except IOError as e:
                             raise IOError(f"Error opening submit description file {job_source} in {job_set_file} at line {lineno}:\n{str(e)}")
 

--- a/src/condor_tools/htcondor_cli/job_set.py
+++ b/src/condor_tools/htcondor_cli/job_set.py
@@ -212,13 +212,13 @@ class Submit(Verb):
                         lineno += inlineno
                         submit_obj = htcondor.Submit(inline_data)
 			#Set s_method to HTC_JOBSET_SUBMIT
-                        submit_description.setSubmitMethod(4)
+                        submit_obj.setSubmitMethod(4)
                     else:
                         try:
                             with open(job_source, "rt") as f_sub:
                                 submit_obj = htcondor.Submit(f_sub.read())
 				#Set s_method to HTC_JOBSET_SUBMIT
-                                submit_description.setSubmitMethod(4)
+                                submit_obj.setSubmitMethod(4)
                         except IOError as e:
                             raise IOError(f"Error opening submit description file {job_source} in {job_set_file} at line {lineno}:\n{str(e)}")
 

--- a/src/condor_tools/htcondor_cli/job_set.py
+++ b/src/condor_tools/htcondor_cli/job_set.py
@@ -211,10 +211,14 @@ class Submit(Verb):
                             raise ValueError(f"""Unclosed bracket in {job_set_file} starting at line {lineno}.""")
                         lineno += inlineno
                         submit_obj = htcondor.Submit(inline_data)
+			#Set s_method to HTC_JOBSET_SUBMIT
+                        submit_description.setSubmitMethod(4)
                     else:
                         try:
                             with open(job_source, "rt") as f_sub:
                                 submit_obj = htcondor.Submit(f_sub.read())
+				#Set s_method to HTC_JOBSET_SUBMIT
+                                submit_description.setSubmitMethod(4)
                         except IOError as e:
                             raise IOError(f"Error opening submit description file {job_source} in {job_set_file} at line {lineno}:\n{str(e)}")
 

--- a/src/condor_utils/proc.cpp
+++ b/src/condor_utils/proc.cpp
@@ -97,20 +97,31 @@ getJobStatusNum( const char* name )
 	return -1;
 }
 
+//Array of strings for names of Job Submit Methods
+static const char* JobSubmitMethodNames[] = {
+	"condor_submit",
+	"DAGMan-Direct",
+	"Python Bindings",
+	"htcondor job submit",
+	"htcondor jobset submit",
+	"htcondor dag submit",
+	//Any new methods should go above this comment in order of the table
+	"Portal/User-Set",//<-This should always be last
+};
+
 //This method reads a given submit_method enum and returns a string for help display
 const char* 
-getSubmitMethodString(submit_method method)
+getSubmitMethodString(int method)
 {
-	switch(method)
-	{
-		case submit_method::CONDOR_SUBMIT:      return "condor_submit";
-		case submit_method::DAGMAN:             return "DAGMan";
-		case submit_method::PYTHON_BINDINGS:    return "Python Bindings";
-		case submit_method::HTC_JOB_SUBMIT:     return "htcondor job submit";
-		case submit_method::HTC_JOBSET_SUBMIT:  return "htcondor jobset submit";
-		case submit_method::HTC_DAG_SUBMIT:     return "htcondor dag submit";
-		case submit_method::USER_SET:           return "User Set";
-		default:                 return "Unkown";
+	int array_size = *(&JobSubmitMethodNames+1)-JobSubmitMethodNames;
+	//Check to see if value is greater than the array index of second to last element
+	//or greater than or equal to 100 (final possible listing)
+	//If so then we will just return the cap (Portal/User-set at 100)
+	if(method > (array_size - 2) || method >= JOB_SUBMIT_METHOD_MAX){
+		return JobSubmitMethodNames[array_size-1];
+	}
+	else{
+		return JobSubmitMethodNames[method];
 	}
 }
 

--- a/src/condor_utils/proc.cpp
+++ b/src/condor_utils/proc.cpp
@@ -103,8 +103,8 @@ static const char* JobSubmitMethodNames[] = {
 	"DAGMan-Direct",
 	"Python Bindings",
 	"htcondor job submit",
-	"htcondor jobset submit",
 	"htcondor dag submit",
+	"htcondor jobset submit",
 	//Any new methods should go above this comment in order of the table
 	"Portal/User-Set",//<-This should always be last
 };
@@ -113,11 +113,14 @@ static const char* JobSubmitMethodNames[] = {
 const char* 
 getSubmitMethodString(int method)
 {
-	int array_size = *(&JobSubmitMethodNames+1)-JobSubmitMethodNames;
+	if( method < JOB_SUBMIT_METHOD_MIN)
+		return "UNDEFINED";
+
+	int array_size = COUNTOF(JobSubmitMethodNames);
 	//Check to see if value is greater than the array index of second to last element
 	//or greater than or equal to 100 (final possible listing)
 	//If so then we will just return the cap (Portal/User-set at 100)
-	if(method > (array_size - 2) || method >= JOB_SUBMIT_METHOD_MAX){
+	if(method > (array_size - 2)){
 		return JobSubmitMethodNames[array_size-1];
 	}
 	else{

--- a/src/condor_utils/proc.cpp
+++ b/src/condor_utils/proc.cpp
@@ -97,4 +97,21 @@ getJobStatusNum( const char* name )
 	return -1;
 }
 
+//This method reads a given submit_method enum and returns a string for help display
+const char* 
+getSubmitMethodString(submit_method method)
+{
+	switch(method)
+	{
+		case submit_method::CONDOR_SUBMIT:      return "condor_submit";
+		case submit_method::DAGMAN:             return "DAGMan";
+		case submit_method::PYTHON_BINDINGS:    return "Python Bindings";
+		case submit_method::HTC_JOB_SUBMIT:     return "htcondor job submit";
+		case submit_method::HTC_JOBSET_SUBMIT:  return "htcondor jobset submit";
+		case submit_method::HTC_DAG_SUBMIT:     return "htcondor dag submit";
+		case submit_method::USER_SET:           return "User Set";
+		default:                 return "Unkown";
+	}
+}
+
 

--- a/src/condor_utils/submit_utils.cpp
+++ b/src/condor_utils/submit_utils.cpp
@@ -518,6 +518,8 @@ SubmitHash::SubmitHash()
 	SubmitMacroSet.initialize(CONFIG_OPT_WANT_META | CONFIG_OPT_KEEP_DEFAULTS | CONFIG_OPT_SUBMIT_SYNTAX);
 	setup_macro_defaults();
 
+	s_method = submit_method::UNDEFINED;//Initialize JobSubmitMethod to undefined
+
 	mctx.init("SUBMIT", 3);
 }
 
@@ -1157,6 +1159,24 @@ void SubmitHash::init()
 	SubmitMacroSet.sources.push_back("<Default>");
 	SubmitMacroSet.sources.push_back("<Argument>");
 	SubmitMacroSet.sources.push_back("<Live>");
+
+	// in case this hasn't happened already.
+	init_submit_default_macros();
+
+	JobIwd.clear();
+	mctx.cwd = NULL;
+}
+
+//init() overload for assigning JobSubmitMethod to init passed value as enum
+void SubmitHash::init(submit_method value)
+{
+	clear();
+	SubmitMacroSet.sources.push_back("<Detected>");
+	SubmitMacroSet.sources.push_back("<Default>");
+	SubmitMacroSet.sources.push_back("<Argument>");
+	SubmitMacroSet.sources.push_back("<Live>");
+
+	s_method = value;//Enum variable being set to passed value for JobSubmitMethod
 
 	// in case this hasn't happened already.
 	init_submit_default_macros();
@@ -8242,6 +8262,12 @@ int SubmitHash::init_base_ad(time_t submit_time_in, const char * username)
 	// all jobs should end up with the same qdate, so we only query time once.
 	baseJob.Assign(ATTR_Q_DATE, submit_time);
 	baseJob.Assign(ATTR_COMPLETION_DATE, 0);
+	
+	// set all jobs submission method if s_method is defined
+	if ( s_method != submit_method::UNDEFINED)
+	{
+		baseJob.Assign(ATTR_JOB_SUBMIT_METHOD, static_cast<int>(s_method));
+	}
 
 	// as of 8.9.5 we no longer think it is a good idea for submit to set the Owner attribute
 	// for jobs, even for local jobs, but just in case, set this knob to true to enable the

--- a/src/condor_utils/submit_utils.cpp
+++ b/src/condor_utils/submit_utils.cpp
@@ -1150,7 +1150,7 @@ const char * init_submit_default_macros()
 	return ret;
 }
 
-void SubmitHash::init()
+void SubmitHash::init(int value)
 {
 	clear();
 	SubmitMacroSet.sources.push_back("<Detected>");
@@ -1161,13 +1161,10 @@ void SubmitHash::init()
 	// in case this hasn't happened already.
 	init_submit_default_macros();
 
+	s_method = value;
+
 	JobIwd.clear();
 	mctx.cwd = NULL;
-}
-
-void SubmitHash::init(int value){
-	s_method = value;
-	init();
 }
 
 

--- a/src/condor_utils/submit_utils.cpp
+++ b/src/condor_utils/submit_utils.cpp
@@ -518,8 +518,6 @@ SubmitHash::SubmitHash()
 	SubmitMacroSet.initialize(CONFIG_OPT_WANT_META | CONFIG_OPT_KEEP_DEFAULTS | CONFIG_OPT_SUBMIT_SYNTAX);
 	setup_macro_defaults();
 
-	s_method = submit_method::UNDEFINED;//Initialize JobSubmitMethod to undefined
-
 	mctx.init("SUBMIT", 3);
 }
 
@@ -1167,23 +1165,11 @@ void SubmitHash::init()
 	mctx.cwd = NULL;
 }
 
-//init() overload for assigning JobSubmitMethod to init passed value as enum
-void SubmitHash::init(submit_method value)
-{
-	clear();
-	SubmitMacroSet.sources.push_back("<Detected>");
-	SubmitMacroSet.sources.push_back("<Default>");
-	SubmitMacroSet.sources.push_back("<Argument>");
-	SubmitMacroSet.sources.push_back("<Live>");
-
-	s_method = value;//Enum variable being set to passed value for JobSubmitMethod
-
-	// in case this hasn't happened already.
-	init_submit_default_macros();
-
-	JobIwd.clear();
-	mctx.cwd = NULL;
+void SubmitHash::init(int value){
+	s_method = value;
+	init();
 }
+
 
 void SubmitHash::clear()
 {
@@ -8264,9 +8250,9 @@ int SubmitHash::init_base_ad(time_t submit_time_in, const char * username)
 	baseJob.Assign(ATTR_COMPLETION_DATE, 0);
 	
 	// set all jobs submission method if s_method is defined
-	if ( s_method != submit_method::UNDEFINED)
+	if ( s_method >= JOB_SUBMIT_METHOD_MIN)
 	{
-		baseJob.Assign(ATTR_JOB_SUBMIT_METHOD, static_cast<int>(s_method));
+		baseJob.Assign(ATTR_JOB_SUBMIT_METHOD, s_method);
 	}
 
 	// as of 8.9.5 we no longer think it is a good idea for submit to set the Owner attribute
@@ -9602,5 +9588,4 @@ const char* SubmitHash::make_digest(std::string & out, int cluster_id, StringLis
 
 	return out.c_str();
 }
-
 

--- a/src/condor_utils/submit_utils.h
+++ b/src/condor_utils/submit_utils.h
@@ -490,6 +490,7 @@ enum class submit_method{
 	HTC_JOB_SUBMIT,
 	HTC_JOBSET_SUBMIT,
 	HTC_DAG_SUBMIT,
+	USER_SET,
 };
 
 typedef int (*FNSUBMITPARSE)(void* pv, MACRO_SOURCE& source, MACRO_SET& set, char * line, std::string & errmsg);
@@ -654,7 +655,8 @@ public:
 	bool AssignJobVal(const char * attr, long val) { return AssignJobVal(attr, (long long)val); }
 	//bool AssignJobVal(const char * attr, time_t val)  { return AssignJobVal(attr, (long long)val); }
 
-	void setSubmitMethod(int value){ s_method = static_cast<submit_method>(value); }//Set job submit method to enum equal to passed value
+	//Set job submit method to enum equal to passed value if value is in range
+	void setSubmitMethod(int value){ s_method = (value < -1 || value > 6) ? submit_method::UNDEFINED : static_cast<submit_method>(value); }
 	int getSubmitMethod(){ return static_cast<int>(s_method); }//Return job submit method value given s_method enum
 
 	MACRO_ITEM* lookup_exact(const char * name) { return find_macro_item(name, NULL, SubmitMacroSet); }

--- a/src/condor_utils/submit_utils.h
+++ b/src/condor_utils/submit_utils.h
@@ -491,8 +491,7 @@ public:
 	SubmitHash();
 	~SubmitHash();
 
-	void init();
-	void init(int value);
+	void init(int value=-1);
 	void clear(); // clear, but do not deallocate
 	void setScheddVersion(const char * version) { ScheddVersion = version; }
 	void setMyProxyPassword(const char * pass) { MyProxyPassword = pass; }
@@ -876,7 +875,7 @@ private:
 
 	ContainerImageType image_type_from_string(const std::string &image) const;
 
-	int s_method = -1; //-1 represents undefined job submit method
+	int s_method; //-1 represents undefined job submit method
 };
 
 struct SubmitStepFromQArgs {

--- a/src/condor_utils/submit_utils.h
+++ b/src/condor_utils/submit_utils.h
@@ -492,7 +492,7 @@ public:
 	~SubmitHash();
 
 	void init();
-	void init(submit_method value);
+	void init(int value);
 	void clear(); // clear, but do not deallocate
 	void setScheddVersion(const char * version) { ScheddVersion = version; }
 	void setMyProxyPassword(const char * pass) { MyProxyPassword = pass; }
@@ -645,8 +645,8 @@ public:
 	//bool AssignJobVal(const char * attr, time_t val)  { return AssignJobVal(attr, (long long)val); }
 
 	//Set job submit method to enum equal to passed value if value is in range
-	void setSubmitMethod(int value){ s_method = (value < -1 || value > 6) ? submit_method::UNDEFINED : static_cast<submit_method>(value); }
-	int getSubmitMethod(){ return static_cast<int>(s_method); }//Return job submit method value given s_method enum
+	void setSubmitMethod(int value) { s_method = value; }
+	int getSubmitMethod(){ return s_method; }//Return job submit method value given s_method enum
 
 	MACRO_ITEM* lookup_exact(const char * name) { return find_macro_item(name, NULL, SubmitMacroSet); }
 	CondorError* error_stack() const { return SubmitMacroSet.errors; }
@@ -876,7 +876,7 @@ private:
 
 	ContainerImageType image_type_from_string(const std::string &image) const;
 
-	submit_method s_method;
+	int s_method = -1; //-1 represents undefined job submit method
 };
 
 struct SubmitStepFromQArgs {

--- a/src/condor_utils/submit_utils.h
+++ b/src/condor_utils/submit_utils.h
@@ -481,6 +481,17 @@ enum _submit_file_role {
 	SFR_OUTPUT,
 };
 
+// used to indicate how a job was submitted to htcondor
+enum class submit_method{
+	UNDEFINED = -1,
+	CONDOR_SUBMIT,
+	DAGMAN,
+	PYTHON_BINDINGS,
+	HTC_JOB_SUBMIT,
+	HTC_JOBSET_SUBMIT,
+	HTC_DAG_SUBMIT,
+};
+
 typedef int (*FNSUBMITPARSE)(void* pv, MACRO_SOURCE& source, MACRO_SET& set, char * line, std::string & errmsg);
 
 class DeltaClassAd;
@@ -491,6 +502,7 @@ public:
 	~SubmitHash();
 
 	void init();
+	void init(submit_method value);
 	void clear(); // clear, but do not deallocate
 	void setScheddVersion(const char * version) { ScheddVersion = version; }
 	void setMyProxyPassword(const char * pass) { MyProxyPassword = pass; }
@@ -641,6 +653,9 @@ public:
 	bool AssignJobVal(const char * attr, int val) { return AssignJobVal(attr, (long long)val); }
 	bool AssignJobVal(const char * attr, long val) { return AssignJobVal(attr, (long long)val); }
 	//bool AssignJobVal(const char * attr, time_t val)  { return AssignJobVal(attr, (long long)val); }
+
+	void setSubmitMethod(int value){ s_method = static_cast<submit_method>(value); }//Set job submit method to enum equal to passed value
+	int getSubmitMethod(){ return static_cast<int>(s_method); }//Return job submit method value given s_method enum
 
 	MACRO_ITEM* lookup_exact(const char * name) { return find_macro_item(name, NULL, SubmitMacroSet); }
 	CondorError* error_stack() const { return SubmitMacroSet.errors; }
@@ -869,6 +884,8 @@ private:
 	int process_container_input_files(StringList & input_files, long long * accumulate_size_kb); // call after building the input files list to find .vmx and .vmdk files in that list
 
 	ContainerImageType image_type_from_string(const std::string &image) const;
+
+	submit_method s_method;
 };
 
 struct SubmitStepFromQArgs {

--- a/src/condor_utils/submit_utils.h
+++ b/src/condor_utils/submit_utils.h
@@ -481,17 +481,6 @@ enum _submit_file_role {
 	SFR_OUTPUT,
 };
 
-// used to indicate how a job was submitted to htcondor
-enum class submit_method{
-	UNDEFINED = -1,
-	CONDOR_SUBMIT,
-	DAGMAN,
-	PYTHON_BINDINGS,
-	HTC_JOB_SUBMIT,
-	HTC_JOBSET_SUBMIT,
-	HTC_DAG_SUBMIT,
-	USER_SET,
-};
 
 typedef int (*FNSUBMITPARSE)(void* pv, MACRO_SOURCE& source, MACRO_SET& set, char * line, std::string & errmsg);
 

--- a/src/python-bindings/schedd.cpp
+++ b/src/python-bindings/schedd.cpp
@@ -3855,7 +3855,8 @@ public:
 
 	void //Undocumented for internal use so users dont mess up number assignments
 	setSubmitMethod(int method_value, bool allow_reserved_values = false){
-		if ( method_value < JSM_USER_SET && !allow_reserved_values) {
+		//If value is in range of reserves and allow_reserved_values isn't true then throw an exception
+		if ( method_value >= 0 && method_value < JSM_USER_SET && !allow_reserved_values) {
 			std::string error_message = "Submit Method value must be " +std::to_string(JSM_USER_SET)+" or greater. Or allow_reserved_values must be set to True.";
 			THROW_EX(HTCondorValueError,error_message.c_str());
 		}
@@ -4730,10 +4731,11 @@ void export_schedd()
             R"C0ND0R(
             Sets the **Job Ad** attribute ``JobSubmitMethod`` to passed over number. ``method_value``
             is recommended to be set to a value of ``100`` or greater to avoid confusion
-            to pre-set values. If wanted, any number can be set by passing ``True`` to
-            ``allow_reserved_values``. This allows any number to be set including negatives that
-            will result in ``JobSubmitMethod`` to not be defined in the **Job Ad**. 
-            **Note~** Setting of ``JobSubmitMethod`` must occur before job is submitted to Schedd.
+            to pre-set values. Negative numbers will result in ``JobSubmitMethod`` to not be defined 
+            in the **Job Ad**. If wanted, any number can be set by passing ``True`` to
+            ``allow_reserved_values``. This allows any positive number to be set to ``JobSubmitMethod``.
+            This includes all reserved numbers. **Note~** Setting of ``JobSubmitMethod`` must occur
+            before job is submitted to Schedd.
 
             :param int method_value: Value set to ``JobSubmitMethod``.
             :param bool allow_reserved_values: Boolean that allows any number to be set to

--- a/src/python-bindings/schedd.cpp
+++ b/src/python-bindings/schedd.cpp
@@ -4723,17 +4723,19 @@ void export_schedd()
             boost::python::args("self", "args"))
 	.def("setSubmitMethod", &Submit::setSubmitMethod,
 	    R"CONDOR(
-	    Sets the attribute ``JobSubmitMethod`` based on passed over number. See table for
-	    values. Number must be in the range of the table or ``JobSubmitMethod`` will be 
-	    ``UNDEFINED``. This number is set behind the scenes and should not have to be set,
-	    but if wanted, you can set ``JobSubmitMethod`` to `User Set`=6 to declare custom submit method.
+	    Sets the attribute ``JobSubmitMethod`` based on passed over number. See table or use 
+	    *condor_q -help Submit* for values. Number must be in the range of the table or 
+	    ``JobSubmitMethod`` will be ``UNDEFINED``. This number is set behind the scenes and
+	    should not have to be set, but if wanted, you can set ``JobSubmitMethod`` to 
+	    `User Set`=6 to declare custom submit method. Note: Setting of ``JobSubmitMethod``
+	    must occur before job is submitted.
 	   
 	   :param int value: Value of ``JobSubmitMethod``.
 	   )CONDOR",
 	   boost::python::arg("self"), boost::python::arg("value")=-1)
 	.def("getSubmitMethod", &Submit::getSubmitMethod,
 	    R"CONDOR(
-	    :return: ``JobSubmitMethod`` attributes value. See table for values.
+	    :return: ``JobSubmitMethod`` attribute value. See table or use *condor_q -help Submit* for values.
 	    :rtype: int
 	    )CONDOR",
 	    boost::python::arg("self"))

--- a/src/python-bindings/schedd.cpp
+++ b/src/python-bindings/schedd.cpp
@@ -928,7 +928,7 @@ struct SubmitJobsIterator {
 		, m_spool(spool)
 	{
 			// copy the input submit hash into our new hash.
-			m_hash.init();
+			m_hash.init(submit_method::PYTHON_BINDINGS);
 			copy_hash(h);
 			m_hash.setDisableFileChecks(true);
 			m_hash.init_base_ad(qdate, owner.c_str());
@@ -942,7 +942,7 @@ struct SubmitJobsIterator {
 		, m_spool(spool)
 	{
 		// copy the input submit hash into our new hash.
-		m_hash.init();
+		m_hash.init(submit_method::PYTHON_BINDINGS);
 		copy_hash(h);
 		m_hash.setDisableFileChecks(true);
 		m_hash.init_base_ad(qdate, owner.c_str());
@@ -2919,7 +2919,7 @@ public:
 		 m_ms_inline("", 0, EmptyMacroSrc)
        , m_queue_may_append_to_cluster(false)
     {
-        m_hash.init();
+        m_hash.init(submit_method::PYTHON_BINDINGS);
     }
 
 
@@ -2928,7 +2928,7 @@ public:
          m_ms_inline("", 0, EmptyMacroSrc)
        , m_queue_may_append_to_cluster(false)
     {
-        m_hash.init();
+        m_hash.init(submit_method::PYTHON_BINDINGS);
         update(input);
     }
 
@@ -2967,7 +2967,7 @@ public:
        , m_ms_inline("", 0, EmptyMacroSrc) 
        , m_queue_may_append_to_cluster(false)
 	{
-		m_hash.init();
+		m_hash.init(submit_method::PYTHON_BINDINGS);
 		if ( ! lines.empty()) {
 			m_hash.insert_source("<PythonString>", m_src_pystring);
 			MacroStreamMemoryFile ms(lines.c_str(), lines.size(), m_src_pystring);
@@ -3853,6 +3853,14 @@ public:
 		}
 	}
 
+	//Set function for job submit method
+	void 
+	setSubmitMethod(int value){ m_hash.setSubmitMethod(value); }
+
+	//Get function for job submit method
+	int
+	getSubmitMethod(){ return m_hash.getSubmitMethod(); }
+
 private:
 
     std::string
@@ -4713,6 +4721,22 @@ void export_schedd()
             :param str args: The arguments to pass to the ``QUEUE`` statement.
             )C0ND0R",
             boost::python::args("self", "args"))
+	.def("setSubmitMethod", &Submit::setSubmitMethod,
+	    R"CONDOR(
+	    Sets the attribute ``JobSubmitMethod`` based on passed over number. See table for
+	    values. Number must be in the range of the table or ``JobSubmitMethod`` will be 
+	    ``UNDEFINED``. This number is set behind the scenes and should not have to be set,
+	    but if wanted, you can set ``JobSubmitMethod`` to `User Set`=6 to declare custom submit method.
+	   
+	   :param int value: Value of ``JobSubmitMethod``.
+	   )CONDOR",
+	   boost::python::arg("self"), boost::python::arg("value")=-1)
+	.def("getSubmitMethod", &Submit::getSubmitMethod,
+	    R"CONDOR(
+	    :return: ``JobSubmitMethod`` attributes value. See table for values.
+	    :rtype: int
+	    )CONDOR",
+	    boost::python::arg("self"))
         .def("__delitem__", &Submit::deleteItem)
         .def("__getitem__", &Submit::getItem)
         .def("__setitem__", &Submit::setItem)

--- a/src/python-bindings/schedd.cpp
+++ b/src/python-bindings/schedd.cpp
@@ -928,7 +928,7 @@ struct SubmitJobsIterator {
 		, m_spool(spool)
 	{
 			// copy the input submit hash into our new hash.
-			m_hash.init(PYTHON_BINDINGS);
+			m_hash.init(JSM_PYTHON_BINDINGS);
 			copy_hash(h);
 			m_hash.setDisableFileChecks(true);
 			m_hash.init_base_ad(qdate, owner.c_str());
@@ -942,7 +942,7 @@ struct SubmitJobsIterator {
 		, m_spool(spool)
 	{
 		// copy the input submit hash into our new hash.
-		m_hash.init(PYTHON_BINDINGS);
+		m_hash.init(JSM_PYTHON_BINDINGS);
 		copy_hash(h);
 		m_hash.setDisableFileChecks(true);
 		m_hash.init_base_ad(qdate, owner.c_str());
@@ -2919,7 +2919,7 @@ public:
 		 m_ms_inline("", 0, EmptyMacroSrc)
        , m_queue_may_append_to_cluster(false)
     {
-        m_hash.init(PYTHON_BINDINGS);
+        m_hash.init(JSM_PYTHON_BINDINGS);
     }
 
 
@@ -2928,7 +2928,7 @@ public:
          m_ms_inline("", 0, EmptyMacroSrc)
        , m_queue_may_append_to_cluster(false)
     {
-        m_hash.init(PYTHON_BINDINGS);
+        m_hash.init(JSM_PYTHON_BINDINGS);
         update(input);
     }
 
@@ -2967,7 +2967,7 @@ public:
        , m_ms_inline("", 0, EmptyMacroSrc) 
        , m_queue_may_append_to_cluster(false)
 	{
-		m_hash.init(PYTHON_BINDINGS);
+		m_hash.init(JSM_PYTHON_BINDINGS);
 		if ( ! lines.empty()) {
 			m_hash.insert_source("<PythonString>", m_src_pystring);
 			MacroStreamMemoryFile ms(lines.c_str(), lines.size(), m_src_pystring);
@@ -3853,18 +3853,13 @@ public:
 		}
 	}
 
-	//Set function for job submit method
-	void //Documented for users to use
-	setSubmitMethod(int value = -1) { _setSubmitMethod(value,false); }
-
 	void //Undocumented for internal use so users dont mess up number assignments
-	_setSubmitMethod(int value = -1, bool internal = false){
-		//Check if is an internal setting or user setting 
-		if( !internal )//If user and passed value is smaller than 100 set value to 100
-			if( value < USER_SET )
-				value = USER_SET;
-
-		m_hash.setSubmitMethod(value); 
+	setSubmitMethod(int method_value, bool allow_reserved_values = false){
+		if ( method_value < JSM_USER_SET && !allow_reserved_values) {
+			std::string error_message = "Submit Method value must be " +std::to_string(JSM_USER_SET)+" or greater. Or allow_reserved_values must be set to True.";
+			THROW_EX(HTCondorValueError,error_message.c_str());
+		}
+		m_hash.setSubmitMethod(method_value); 
 	}
 
 	//Get function for job submit method
@@ -4733,16 +4728,18 @@ void export_schedd()
             boost::python::args("self", "args"))
         .def("setSubmitMethod", &Submit::setSubmitMethod,
             R"C0ND0R(
-            Sets the Job Ad attribute ``JobSubmitMethod`` to passed over number. Set
-            number must be greater than or equal to ``100``. If no number is passed then
-            ``JobSubmitMethod`` will be undefined. **Note~** Setting of ``JobSubmitMethod``
-            must occur before job is submitted to Schedd.
+            Sets the **Job Ad** attribute ``JobSubmitMethod`` to passed over number. ``method_value``
+            is recommended to be set to a value of ``100`` or greater to avoid confusion
+            to pre-set values. If wanted, any number can be set by passing ``True`` to
+            ``allow_reserved_values``. This allows any number to be set including negatives that
+            will result in ``JobSubmitMethod`` to not be defined in the **Job Ad**. 
+            **Note~** Setting of ``JobSubmitMethod`` must occur before job is submitted to Schedd.
 
-            :param int value: Value of ``JobSubmitMethod``.
+            :param int method_value: Value set to ``JobSubmitMethod``.
+            :param bool allow_reserved_values: Boolean that allows any number to be set to
+                 ``JobSubmitMethod``.
             )C0ND0R",
-            (boost::python::arg("self"), boost::python::arg("value")=-1))
-        .def("_setSubmitMethod", &Submit::_setSubmitMethod,
-            (boost::python::arg("self"), boost::python::arg("value")=-1, boost::python::arg("internal")=false))
+            (boost::python::arg("self"), boost::python::arg("method_value")=-1, boost::python::arg("allow_reserved_values")=false))
         .def("getSubmitMethod", &Submit::getSubmitMethod,
             R"C0ND0R(
             :return: ``JobSubmitMethod`` attribute value. See table or use *condor_q -help Submit* for values.

--- a/src/python-bindings/schedd.cpp
+++ b/src/python-bindings/schedd.cpp
@@ -4735,8 +4735,9 @@ void export_schedd()
             R"C0ND0R(
             Sets the Job Ad attribute ``JobSubmitMethod`` to passed over number. Set
             number must be greater than or equal to ``100``. If no number is passed then
-            ``JobSubmitMethod`` will be undefined. Note: Setting of ``JobSubmitMethod``
+            ``JobSubmitMethod`` will be undefined. **Note~** Setting of ``JobSubmitMethod``
             must occur before job is submitted to Schedd.
+
             :param int value: Value of ``JobSubmitMethod``.
             )C0ND0R",
             (boost::python::arg("self"), boost::python::arg("value")=-1))


### PR DESCRIPTION
     This is code to implement the JobSubmitMethod Job ad attribute. The new code: overrides the submit hash init(), sets the value at various parts in the code, allows for output display similar to Job status during condor_q --help, added an ornithology test, and documents the features.
Extra checks:
-[ ] Verify documentation looks right (job-classad-attributes.rst & schedd.cpp)
-[ ] Verify my test call is correct in the cmake file
Messed up branch naming. Is a new feature should be V9_8 not V9_0

############################################################################################

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
