### PR TITLE
HTCONDOR-1028: Allow Jira tickets over 1000

### DIFF
--- a/docs/extensions/jira.py
+++ b/docs/extensions/jira.py
@@ -22,11 +22,11 @@ def make_link_node(rawtext, app, type, slug, options):
 def ticket_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     try:
         ticket_id = int(text)
-        if ticket_id > 1000:
+        if ticket_id > 10000:
             raise ValueError
     except ValueError:
         msg = inliner.reporter.error(
-            'HTCondor ticket number must be a number less than or equal to 1000; '
+            'HTCondor ticket number must be a number less than or equal to 10000; '
             '"%s" is invalid.' % text, line=lineno)
         prb = inliner.problematic(rawtext, rawtext, msg)
         return [prb], [msg]


### PR DESCRIPTION
This used to double check between GitTrac and Jira ticket numbers.
I was tempted to remove the check altogether. However, it would
guard against and unfortunate key bounce. The change is going into
stable, so adding a digit to the number is a minimal change.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
