### PR TITLE
HTCONDOR-749: Get BUILD-ID into version string on Debian and Ubuntu

### DIFF
--- a/build/packaging/new-debian/rules
+++ b/build/packaging/new-debian/rules
@@ -3,6 +3,7 @@
 srcpkg = $(shell LC_ALL=C dpkg-parsechangelog | grep '^Source:' | cut -d ' ' -f 2,2)
 debver = $(shell LC_ALL=C dpkg-parsechangelog | grep '^Version:' | cut -d ' ' -f 2,2 )
 upstreamver = $(shell echo $(debver) | cut -d '-' -f 1,1 )
+buildid = $(shell cat ../../BUILD-ID)
 
 # this figures out the last merge point from 'master' into the Debian branch and
 # then described this commit relative to the last release tag (V...)
@@ -26,9 +27,8 @@ override_dh_auto_configure:
 		-DPROPER:BOOL=ON \
 		-DUW_BUILD:BOOL=OFF \
 		-D_DEBUG:BOOL=TRUE \
-		-DBUILDID:STRING="Debian-$(debver)"\
+		-DBUILDID:STRING="$(buildid)"\
 		-DPACKAGEID:STRING="$(debver)"\
-		-DFORCE_PRE_RELEASE:STRING="Debian-$(debver)"\
 		-DCMAKE_SKIP_RPATH:BOOL=ON \
 		-DHAVE_EXT_GSOAP:BOOL=OFF \
 		-DWITH_GSOAP:BOOL=OFF \

--- a/build/packaging/new-debian/rules.focal
+++ b/build/packaging/new-debian/rules.focal
@@ -3,6 +3,7 @@
 srcpkg = $(shell LC_ALL=C dpkg-parsechangelog | grep '^Source:' | cut -d ' ' -f 2,2)
 debver = $(shell LC_ALL=C dpkg-parsechangelog | grep '^Version:' | cut -d ' ' -f 2,2 )
 upstreamver = $(shell echo $(debver) | cut -d '-' -f 1,1 )
+buildid = $(shell cat ../../BUILD-ID)
 
 # this figures out the last merge point from 'master' into the Debian branch and
 # then described this commit relative to the last release tag (V...)
@@ -28,9 +29,8 @@ override_dh_auto_configure:
 		-DUW_BUILD:BOOL=OFF \
 		-DNO_PHONE_HOME:BOOL=ON \
 		-D_DEBUG:BOOL=TRUE \
-		-DBUILDID:STRING="Debian-$(debver)"\
+		-DBUILDID:STRING="$(buildid)"\
 		-DPACKAGEID:STRING="$(debver)"\
-		-DFORCE_PRE_RELEASE:STRING="Debian-$(debver)"\
 		-DCMAKE_SKIP_RPATH:BOOL=ON \
 		-DHAVE_EXT_GSOAP:BOOL=OFF \
 		-DWITH_GSOAP:BOOL=OFF \


### PR DESCRIPTION
https://opensciencegrid.atlassian.net/browse/HTCONDOR-749

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
