### PR TITLE
Fix GPU discovery on powerpc HTCONDOR-967

### DIFF
--- a/docs/version-history/development-release-series-91.rst
+++ b/docs/version-history/development-release-series-91.rst
@@ -50,7 +50,8 @@ New Features:
 
 Bugs Fixed:
 
-- None.
+- Fix for *condor_gpu_discovery* crash when run on Linux for Power (ppc64le) architecture.
+  :jira:`967`
 
 Version 9.7.0
 -------------

--- a/src/gpu/cuda_device_enumeration.h
+++ b/src/gpu/cuda_device_enumeration.h
@@ -93,7 +93,7 @@ GPUFP cuda_t                    cudaRuntimeGetVersion;
 GPUFP dev_basic_props           getBasicProps;
 GPUFP cuda_DevicePropBuf_int    cudaGetDevicePropertiesOfIndeterminateStructure;
 
-typedef void * cudev;
+typedef int * cudev;
 typedef cudaError_t (CUDACALL* cuda_dev_int_t)(cudev *, int);
 typedef cudaError_t (CUDACALL* cuda_name_t)(char *, int, cudev);
 typedef CUresult (CUDACALL * cuda_uuid_t)(unsigned char uuid[16], cudev);


### PR DESCRIPTION
https://opensciencegrid.atlassian.net/browse/HTCONDOR-967

In the [cuda_device_enumeration.h file (line 96)](https://github.com/htcondor/htcondor/blob/4de3b217c5583b28092176b300dc55110fb74215/src/gpu/cuda_device_enumeration.h#L96) we declare `typedef void * cudef;`  this does not force 4 byte alignment, which is needed on power-pc for these APIs.   It is suggested that we change this to an `int *` or in some other way force alignment of these pointers.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
