### PR TITLE
HTCONDOR-1035 fix missing HoldReason/HoldReasonCode

### DIFF
--- a/docs/version-history/development-release-series-91.rst
+++ b/docs/version-history/development-release-series-91.rst
@@ -17,7 +17,11 @@ New Features:
 
 Bugs Fixed:
 
-- None.
+- Fixed bug introduced in HTCondor v9.7.0 where job may go on hold without
+  setting a ``HoldReason`` and/or ``HoldReasonCode`` and ``HoldReasonSubCode``
+  attributes in the job classad.  In particular, this could happen when file transfer
+  using a file transfer plugin failed.
+  :jira:`1035`
 
 Version 9.7.0
 -------------

--- a/src/condor_utils/file_transfer.cpp
+++ b/src/condor_utils/file_transfer.cpp
@@ -5890,7 +5890,7 @@ FileTransfer::InvokeFileTransferPlugin(CondorError &e, const char* source, const
 		std::string transferUrl;
 		if (!plugin_stats->LookupString("TransferError", errorMessage)) {
 			errorMessage = "File transfer plugin " + plugin +
-				" exited unexpectedly without producing an error message\n";
+				" exited unexpectedly without producing an error message ";
 		}
 		plugin_stats->LookupString("TransferUrl", transferUrl);
 		e.pushf("FILETRANSFER", 1, "non-zero exit (%i) from %s. Error: %s (%s)",
@@ -6045,14 +6045,14 @@ FileTransfer::InvokeMultipleFileTransferPlugin( CondorError &e,
 			this_file_stats_ad.LookupString( "TransferUrl", transfer_url );
 			if ( !this_file_stats_ad.LookupBool( "TransferSuccess", transfer_success ) ) {
 				error_message = "File transfer plugin " + plugin_path +
-					" exited without producing a TransferSuccess result\n";
+					" exited without producing a TransferSuccess result ";
 				e.pushf( "FILETRANSFER", 1, "non-zero exit (%i) from %s. Error: %s (%s)",
 					exit_status, plugin_path.c_str(), error_message.c_str(), transfer_url.c_str() );
 			}
 			else if ( !transfer_success ) {
 				if (!this_file_stats_ad.LookupString("TransferError", error_message)) {
 					error_message = "File transfer plugin " + plugin_path +
-						" exited unexpectedly without producing an error message\n";
+						" exited unexpectedly without producing an error message ";
 				}
 				e.pushf( "FILETRANSFER", 1, "non-zero exit (%i) from %s. Error: %s (%s)",
 					exit_status, plugin_path.c_str(), error_message.c_str(), UrlSafePrint(transfer_url) );


### PR DESCRIPTION
https://opensciencegrid.atlassian.net/browse/HTCONDOR-1035

Fix bug where jobs may go on hold without a HoldReason and/or HoldReasonCode.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
