### PR TITLE
HTCONDOR-1091: More vault integration improvements

### DIFF
--- a/src/condor_credd/condor_credmon_oauth/condor_vault_storer
+++ b/src/condor_credd/condor_credmon_oauth/condor_vault_storer
@@ -110,6 +110,11 @@ for REQUEST; do
         fi
     fi
     STOREOPTS=()
+    if [ -n "$SEC_CREDENTIAL_STORECRED_OPTS" ]; then
+        for OPT in $SEC_CREDENTIAL_STORECRED_OPTS; do
+            STOREOPTS+=($OPT)
+        done
+    fi
     for PART in "${PARTS[@]:1}"; do
         VAL="${PART#*=}"
         case "$PART" in

--- a/src/condor_credd/condor_credmon_oauth/condor_vault_storer
+++ b/src/condor_credd/condor_credmon_oauth/condor_vault_storer
@@ -174,10 +174,14 @@ but make sure no other job is using them."
         mv $TMPFILE $BTOKEN
     fi
 
-    if ! [[ "$CRED" =~ ^s\..* ]]; then
-        # No new vault token was generated
-        continue
-    fi 
+    CREDLINES="$(echo "$CRED"|wc -l)"
+    case $CREDLINES in
+        1)  # No new vault token was generated
+            continue;;
+        2)  # First line is new vault token, second line is bearer URL
+            ;;
+        *)  fatal "Unexpected number of stdout lines from htgettoken: $CREDLINES";;
+    esac
 
     # A new long-duration vault token was received, followed by bearer URL
     # Exchange vault token for a shorter duration vault token on disk


### PR DESCRIPTION
This makes 3 more improvements in the HTCondor/vault integration:
1. Don't require encryption for connections to all daemons, only to schedd and credd
2. Add a SEC_CREDENTIAL_STORECRED_OPTS variable to condor_vault_storer to enable sending additional options to every condor_store_cred command.
3. Recognize the new format of vault tokens, beginning with `hvs.` in addition to the old format beginning with `s.`.