### PR TITLE
HTCONDOR-638 Fix crash when authentication is disabled

### DIFF
--- a/src/condor_io/condor_secman.cpp
+++ b/src/condor_io/condor_secman.cpp
@@ -3481,17 +3481,17 @@ SecMan::IsAuthenticationSufficient(DCpermission perm, const Sock &sock, CondorEr
 	}
 
 	std::string methods_allowed = getAuthenticationMethods(perm);
-	const char* method_used = sock.getAuthenticationMethodUsed();
-	bool allowed_method = getAuthBitmask(methods_allowed.c_str()) & sec_char_to_auth_method(method_used);
+	bool allowed_method = getAuthBitmask(methods_allowed.c_str()) & sec_char_to_auth_method(authentication_method);
 	if (!allowed_method &&
-		(!strcasecmp(method_used, AUTH_METHOD_FAMILY) ||
-		 !strcasecmp(method_used, AUTH_METHOD_MATCH))) {
+		(authentication_method == nullptr ||
+		 !strcasecmp(authentication_method, AUTH_METHOD_FAMILY) ||
+		 !strcasecmp(authentication_method, AUTH_METHOD_MATCH))) {
 		allowed_method = true;
 	}
 
 	if (!allowed_method) {
 		err.pushf("SECMAN", 80, "Used authentication method %s is not valid for permission level %s",
-			method_used, PermString(perm));
+		          authentication_method, PermString(perm));
 		return false;
 	}
 


### PR DESCRIPTION
When authentication is disabled (i.e. only peer IP address is used for
authorization), there's no authentication method to examine. We already
reject if authentication is required but wasn't performed.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
