### PR TITLE
HTCONDOR-1093 - V9_10-HTCONDOR-1093-cmd_q_protocols

### DIFF
--- a/src/condor_starter.V6.1/os_proc.cpp
+++ b/src/condor_starter.V6.1/os_proc.cpp
@@ -1036,7 +1036,17 @@ OsProc::ShutdownGraceful()
 	if ( findRmKillSig(JobAd) != -1 ) {
 		daemonCore->Send_Signal(JobPid, rm_kill_sig);
 	} else {
-		daemonCore->Send_Signal(JobPid, soft_kill_sig);
+		bool sent = daemonCore->Send_Signal(JobPid, soft_kill_sig);
+		if (!sent) {
+			dprintf(D_ALWAYS, "Send (softkill) signal failed, retrying...\n");
+			sleep(1);
+			sent = daemonCore->Send_Signal(JobPid, soft_kill_sig);
+			if (!sent) {
+				dprintf(D_ALWAYS, "Send (softkill) signal failed twice, hardkill will fire after timeout\n");
+			} else {
+				dprintf(D_ALWAYS, "Send (softkill) signal worked the second time\n");
+			}
+		}
 	}
 	return false;	// return false says shutdown is pending	
 }


### PR DESCRIPTION
This fixes a problem we occasionaly see in the test suite
where the cmd_q_protocols test fails because it removes a job
immediately after it starts.  On Windows, this requires the
job to have run long enough to install the handlers, thus
creating a race.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
