### PR TITLE
HTCONDOR-1101 fix merged stdout/err test on windows

### DIFF
--- a/src/condor_tests/job_filexfer_merged-stdout_van.run
+++ b/src/condor_tests/job_filexfer_merged-stdout_van.run
@@ -30,6 +30,10 @@ use Check::SimpleJob;
 
 $testname = "job_filexfer_merged-stdout_van";
 
+# Merged stdout/err is broken on Windows (the two data streams overwite
+# each other). See HTCONDOR-1119.
+$check_stdout = ! CondorUtils::is_windows();
+
 # truly const variables in perl
 sub IDLE{1};
 sub HELD{5};
@@ -70,12 +74,17 @@ $success = sub
 	# (from stdout):Called with:...
 	# (from stderr):Hello
 	# (from stdout):Working Directory is ...
-	if(!open(FH, '<', "$stdout")){ print "Failed to open job stdout\n"; exit(1)};
-	chomp(my @lines = <FH>);
-	if ($lines[0] !~ /Called with:/ || $lines[1] !~ /Hello/ || $lines[2] !~ /Working Directory/ ) {
-		print "Job stdout/err doesn't have expected contents\n";
-		exit(1);
-	};
+	if ($check_stdout) {
+		CondorTest::debug("Checking merged stdout/err output\n", 1);
+		if(!open(FH, '<', "$stdout")){ print "Failed to open job stdout\n"; exit(1)};
+		chomp(my @lines = <FH>);
+		if ($lines[0] !~ /Called with:/ || $lines[1] !~ /Hello/ || $lines[2] !~ /Working Directory/ ) {
+			print "Job stdout/err doesn't have expected contents\n";
+			exit(1);
+		}
+	} else {
+		CondorTest::debug("Not checking merged stdout/err output\n" ,1);
+	}
 };
 
 $abort = sub {


### PR DESCRIPTION
A job's stdout/err is not being merged properly on Windows. Disable that
portion of the test until the problem is fixed.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
