### PR TITLE
HTCONDOR-287 Fix replay prorection bug in old python submit binding

### DIFF
--- a/src/python-bindings/schedd.cpp
+++ b/src/python-bindings/schedd.cpp
@@ -1880,7 +1880,7 @@ struct Schedd {
 
         if (param_boolean("SUBMIT_SEND_RESCHEDULE",true))
         {
-            reschedule();
+            sentry.reschedule();
         }
         return cluster;
     }


### PR DESCRIPTION
When submitting a job, the python bindings need to delay sending the
RESCHEDULE command until after the qmgmt connection is closed. The
previous fix for this missed the deprecated submit() form that takes a
job ClassAd.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
