### PR TITLE
Convert qsort instances to std::sort

### DIFF
--- a/src/condor_schedd.V6/dedicated_scheduler.h
+++ b/src/condor_schedd.V6/dedicated_scheduler.h
@@ -140,7 +140,7 @@ class ResList : public CAList {
 
 	int num_matches;
 	
-	static int machineSortByRank(const void *lhs, const void *rhs);
+	static bool machineSortByRank(const struct rankSortRec &lhs, const struct rankSortRec &rhs);
 
 	void selectGroup( CAList *group, const char   *groupName);
 };
@@ -512,11 +512,11 @@ class DedicatedScheduler : public Service {
 time_t findAvailTime( match_rec* mrec );
 
 // Comparison function for sorting job cluster ids by JOB_PRIO and QDate
-int clusterSortByPrioAndDate( const void* ptr1, const void* ptr2 );
+bool clusterSortByPrioAndDate(int, int);
 
 // Comparison function for sorting machines by rank, cluster_id
-int
-RankSorter( const void *ptr1, const void* ptr2 );
+bool
+RankSorter(const PreemptCandidateNode &, const PreemptCandidateNode &);
 
 // Print out
 void displayResource( ClassAd* ad, const char* str, int debug_level );

--- a/src/condor_startd.V6/ResMgr.h
+++ b/src/condor_startd.V6/ResMgr.h
@@ -65,7 +65,7 @@
 typedef float (Resource::*ResourceFloatMember)();
 typedef void (Resource::*ResourceMaskMember)(amask_t);
 typedef void (Resource::*VoidResourceMember)();
-typedef int (*ComparisonFunc)(const void *, const void *);
+typedef bool (*ComparisonFunc)(const Resource *, const Resource *);
 
 namespace htcondor {
 class DataReuseDirectory;
@@ -456,14 +456,14 @@ private:
 // Comparison function for sorting resources:
 
 // natural order is slotid / slot_sub_id
-int naturalSlotOrderCmp(const void*, const void*);
+bool naturalSlotOrderCmp(const Resource *, const Resource *);
 
 // Sort on State, with Owner state resources coming first, etc.
-int ownerStateCmp( const void*, const void* );
+bool ownerStateCmp(const Resource *, const Resource *);
 
 // Sort on State, with Claimed state resources coming first.  Break
 // ties with the value of the Rank expression for Claimed resources.
-int claimedRankCmp( const void*, const void* );
+bool claimedRankCmp(const Resource *, const Resource *);
 
 /*
   Sort resource so their in the right order to give out a new COD
@@ -475,7 +475,7 @@ int claimedRankCmp( const void*, const void* );
   3) in case of a tie, the Claimed resource with the lowest value of
      machine Rank for its claim
 */
-int newCODClaimCmp( const void*, const void* );
+bool newCODClaimCmp(const Resource *, const Resource *);
 
 bool OtherSlotEval(const char * /*name*/,
 	const classad::ArgumentList &arg_list,

--- a/src/condor_unit_tests/OTEST_StringList.cpp
+++ b/src/condor_unit_tests/OTEST_StringList.cpp
@@ -4200,7 +4200,7 @@ static bool test_string_compare_equal_same_beg() {
 	StringList sl("a;b;c", ";");
 	char* list = sl.print_to_string();
 	char** strs = string_compare_helper(&sl, 0);
-	int retVal = string_compare(strs, strs);
+	int retVal = string_compare(*strs, *strs);
 	emit_input_header();
 	emit_param("StringList", list);
 	emit_param("STRING", *strs);
@@ -4225,7 +4225,7 @@ static bool test_string_compare_equal_same_mid() {
 	StringList sl("a;b;c", ";");
 	char* list = sl.print_to_string();
 	char** strs = string_compare_helper(&sl, 1);
-	int retVal = string_compare(strs, strs);
+	int retVal = string_compare(*strs, *strs);
 	emit_input_header();
 	emit_param("StringList", list);
 	emit_param("STRING", *strs);
@@ -4250,7 +4250,7 @@ static bool test_string_compare_equal_same_end() {
 	StringList sl("a;b;c", ";");
 	char* list = sl.print_to_string();
 	char** strs = string_compare_helper(&sl, 2);
-	int retVal = string_compare(strs, strs);
+	int retVal = string_compare(*strs, *strs);
 	emit_input_header();
 	emit_param("StringList", list);
 	emit_param("STRING", *strs);
@@ -4278,7 +4278,7 @@ static bool test_string_compare_equal_different_list() {
 	char* list2 = sl2.print_to_string();
 	char** strs1 = string_compare_helper(&sl1,1);
 	char** strs2 = string_compare_helper(&sl2,1);
-	int retVal = string_compare(strs1, strs2);
+	int retVal = string_compare(*strs1, *strs2);
 	emit_input_header();
 	emit_param("StringList", list1);
 	emit_param("StringList", list2);
@@ -4308,7 +4308,7 @@ static bool test_string_compare_copy() {
 	char* list2  = sl2.print_to_string();
 	char** strs1 = string_compare_helper(&sl1,0);
 	char** strs2 = string_compare_helper(&sl2,0);
-	int retVal = string_compare(strs1, strs2);
+	int retVal = string_compare(*strs1, *strs2);
 	emit_input_header();
 	emit_param("StringList", list1);
 	emit_param("StringList", list2);
@@ -4337,7 +4337,7 @@ static bool test_string_compare_not_equal_same() {
 	char* list = sl.print_to_string();
 	char** strs1 = string_compare_helper(&sl, 0);
 	char** strs2 = string_compare_helper(&sl, 1);
-	int retVal = string_compare(strs1, strs2);
+	int retVal = string_compare(*strs1, *strs2);
 	emit_input_header();
 	emit_param("StringList", list);
 	emit_param("STRING", *strs1);
@@ -4365,7 +4365,7 @@ static bool test_string_compare_not_equal_different() {
 	char* list2  = sl2.print_to_string();
 	char** strs1 = string_compare_helper(&sl1,1);
 	char** strs2 = string_compare_helper(&sl2,0);
-	int retVal = string_compare(strs1, strs2);
+	int retVal = string_compare(*strs1, *strs2);
 	emit_input_header();
 	emit_param("StringList", list1);
 	emit_param("StringList", list2);

--- a/src/condor_userlog/userlog.cpp
+++ b/src/condor_userlog/userlog.cpp
@@ -27,6 +27,8 @@
 #include "condor_sockaddr.h"
 #include "ipv6_hostname.h"
 
+#include <algorithm>
+
 /* 
 ** Job Record format: cluster.proc evict_time wall_time good_time cpu_usage
 ** Host Record format: host wall_hours, good_hours, cpu_hours
@@ -173,19 +175,15 @@ main(int argc, char *argv[])
 	return 0;
 }
 
-int
-statsort(const void *vi, const void *vj)
+bool
+statsort(const JobStatistics *i, const JobStatistics *j)
 {
-	const JobStatistics* const *i;
-	const JobStatistics* const *j;
-	i = (const JobStatistics* const *)vi;
-	j = (const JobStatistics* const *)vj;
 	int clustercomp;
-	clustercomp = (*i)->cluster - (*j)->cluster;
+	clustercomp = i->cluster - j->cluster;
 	if (clustercomp == 0) {
-		return (*i)->proc - (*j)->proc;
+		return i->proc - j->proc < 0;
 	}
-	return clustercomp;
+	return clustercomp < 0;
 }
 
 void
@@ -229,7 +227,7 @@ display_stats()
 		statarray[i] = js;
 	}
 
-	qsort(statarray, numJobStats, sizeof(JobStatistics *), statsort);
+	std::sort(statarray, statarray + numJobStats, statsort);
 
 	int allocations=0, kills=0;
 	int wall_time=0, good_time=0, cpu_usage=0;

--- a/src/condor_utils/historyFileFinder.cpp
+++ b/src/condor_utils/historyFileFinder.cpp
@@ -36,8 +36,10 @@
 
 #include "historyFileFinder.h"
 
+#include <algorithm>
+
 static bool isHistoryBackup(const char *fullFilename, time_t *backup_time);
-static int compareHistoryFilenames(const void *item1, const void *item2);
+static bool compareHistoryFilenames(const char *item1, const char *item2);
 
 static  char *BaseJobHistoryFileName = NULL;
 
@@ -125,7 +127,8 @@ const char **findHistoryFiles(const char *paramName, int *pnumHistoryFiles)
         if (numFiles > 2) {
             // Sort the backup files so that they are in the proper 
             // order. The current history file is already in the right place.
-            qsort(historyFiles, numFiles-1, sizeof(char*), compareHistoryFilenames);
+            std::sort(historyFiles, historyFiles + (numFiles - 1), compareHistoryFilenames);
+
         }
         
         free(historyDir);
@@ -176,13 +179,13 @@ static bool isHistoryBackup(const char *fullFilename, time_t *backup_time)
     return is_history_filename;
 }
 
-// Used by qsort in findHistoryFiles() to sort history files. 
-static int compareHistoryFilenames(const void *item1, const void *item2)
+// Used by std::sort in findHistoryFiles() to sort history files. 
+static bool compareHistoryFilenames(const char *item1, const char *item2)
 {
     time_t time1, time2;
 
-    isHistoryBackup(*(const char * const *) item1, &time1);
-    isHistoryBackup(*(const char * const *) item2, &time2);
-    return time1 - time2;
+    isHistoryBackup(item1, &time1);
+    isHistoryBackup(item2, &time2);
+    return time1 - time2 < 0;
 }
 

--- a/src/condor_utils/log_rotate.cpp
+++ b/src/condor_utils/log_rotate.cpp
@@ -26,6 +26,7 @@
 #ifndef WIN32
 #include <dirent.h>
 #endif
+#include <algorithm>
 
 /** is it a *.old file? */
 static int isOldString(const char *str);
@@ -88,7 +89,7 @@ long long quantizeTimestamp(time_t tt, long long secs)
 static
 int scandirectory(const char *dir, struct dirent ***namelist,
             int (*select)(const struct dirent *),
-        int (*compar)(const void*, const void*) ) {
+        bool (*compar)(const struct dirent*, const struct dirent*) ) {
 	DIR *d;
 	struct dirent *entry;
 	int i = 0;
@@ -120,17 +121,15 @@ int scandirectory(const char *dir, struct dirent ***namelist,
 	if (i == 0) 
 		return -1;
 	if (compar != NULL)
-    	qsort((void *)(*namelist), (size_t)i, sizeof(struct dirent *), compar);
+		std::sort(*namelist, *namelist + i, compar);
 
 	return i;
 }
 
 static
-int doalphasort(const void *a, const void *b) {
-        const struct dirent **d1 = (const struct dirent**)const_cast<void*>(a);
-        const struct dirent **d2 = (const struct dirent**)const_cast<void*>(b);
-        return(strcmp(const_cast<char*>((*d1)->d_name),
-		const_cast<char*>((*d2)->d_name)));
+bool doalphasort(const struct dirent *d1, const struct dirent *d2) {
+        return(strcmp(const_cast<char*>(d1->d_name),
+		const_cast<char*>(d2->d_name)) < 0);
 }
 
 #endif

--- a/src/condor_utils/string_list.cpp
+++ b/src/condor_utils/string_list.cpp
@@ -26,6 +26,8 @@
 #include "strcasestr.h"
 #include "condor_random_num.h"
 
+#include <algorithm>
+
 // initialize the List<char> from the VALID_*_FILES variable in the
 // config file; the files are separated by commas
 	//changed isSeparator to allow constructor to redefine
@@ -669,8 +671,8 @@ StringList::deleteCurrent() {
 }
 
 
-static int string_compare(const void *x, const void *y) {
-	return strcmp(*(char * const *) x, *(char * const *) y);
+static bool string_compare(const char *x, const char *y) {
+	return strcmp(x, y) < 0;
 }
 
 void
@@ -688,7 +690,7 @@ StringList::qsort() {
 		list[i] = strdup(str); // If only we had InsertAt on List...
 	}
 
-	::qsort(list, count, sizeof(char *), string_compare);
+	std::sort(list, list + count, string_compare);
 
 	for (i = 0, clearAll(); i < count; i++) {
 		m_strings.Append(list[i]);

--- a/src/gpu/condor_gpu_utilization.cpp
+++ b/src/gpu/condor_gpu_utilization.cpp
@@ -18,6 +18,7 @@
 #define NOIME
 #include <Windows.h>
 #endif /* defined(WIN32) */
+#include <algorithm>
 
 #include "pi_sleep.h"
 #include "pi_dynlink.h"
@@ -29,16 +30,8 @@
 unsigned debug = 0;
 time_t reportInterval = 10;
 
-int compareSamples( const void * vpA, const void * vpB ) {
-	const nvmlSample_t * a = (const nvmlSample_t *)vpA;
-	const nvmlSample_t * b = (const nvmlSample_t *)vpB;
-	if( a->timeStamp < b->timeStamp ) {
-		return -1;
-	} else if( a->timeStamp == b->timeStamp ) {
-		return 0;
-	} else {
-		return 1;
-	}
+bool compareSamples( const nvmlSample_t &a, const nvmlSample_t &b ) {
+	return a.timeStamp < b.timeStamp;
 }
 
 #ifndef WINDOWS
@@ -76,7 +69,7 @@ nvmlReturn_t getElapsedTimeForDevice( nvmlDevice_t d, unsigned long long * lastS
 	(* runningSampleCount) += sampleCount;
 
 	// Samples are usually but not always in order.
-	qsort( &samples[0], sampleCount, sizeof( nvmlSample_t ), compareSamples );
+	std::sort(samples.begin(), samples.end(), compareSamples);
 
 	// Convert the percentage to elapsed time, since that's what we
 	// actually care about (and the data representation is simpler).


### PR DESCRIPTION
Replace instances where qsort was used to sort an array-like to use std::sort.
At the moment 397 out of 407 tests seem to fail on Debian GNU/Linux but the same thing happens on the latest commit (ff95607).

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
