### PR TITLE
HTCONDOR-1075: Subsystem trusted with root privileges

### DIFF
--- a/docs/apis/python-bindings/tutorials/Interacting-With-Daemons.ipynb
+++ b/docs/apis/python-bindings/tutorials/Interacting-With-Daemons.ipynb
@@ -221,7 +221,7 @@
     }
    ],
    "source": [
-    "htcondor.set_subsystem('SCHEDD', True)         # changes the running process to identify as a schedd and sets subsytem to be trusted with root privileges.\n",
+    "htcondor.set_subsystem('SCHEDD')         # changes the running process to identify as a schedd and sets subsytem to be trusted with root privileges.\n",
     "print(htcondor.param['TEST_FOO'])        # since we now identify as a schedd, should use the special setting of 'bar'"
    ]
   },
@@ -391,7 +391,7 @@
     }
    ],
    "source": [
-    "htcondor.set_subsystem(\"TOOL\", False)\n",
+    "htcondor.set_subsystem(\"TOOL\")\n",
     "htcondor.param['TOOL_DEBUG'] = 'D_FULLDEBUG'\n",
     "htcondor.param['TOOL_LOG'] = '/tmp/log'\n",
     "htcondor.enable_log()    # Send logs to the log file (/tmp/foo)\n",

--- a/src/condor_credd/condor_credmon_oauth/condor_credmon_oauth
+++ b/src/condor_credd/condor_credmon_oauth/condor_credmon_oauth
@@ -47,7 +47,7 @@ def signal_handler(logger, send_queue, signum, frame):
 
 def main():
 
-    htcondor.set_subsystem("CREDMON_OAUTH", True, htcondor.SubsystemType.Daemon)
+    htcondor.set_subsystem("CREDMON_OAUTH", htcondor.SubsystemType.Daemon)
     (options, args) = parser.parse_args()
 
     cred_dir = get_cred_dir(cred_dir = options.cred_dir)

--- a/src/condor_credd/condor_credmon_oauth/condor_credmon_vault
+++ b/src/condor_credd/condor_credmon_oauth/condor_credmon_vault
@@ -46,7 +46,7 @@ def signal_handler(logger, send_queue, signum, frame):
 
 def main():
 
-    htcondor.set_subsystem("CREDMON_OAUTH", True, htcondor.SubsystemType.Daemon)
+    htcondor.set_subsystem("CREDMON_OAUTH", htcondor.SubsystemType.Daemon)
     (options, args) = parser.parse_args()
 
     cred_dir = get_cred_dir(cred_dir = options.cred_dir)

--- a/src/condor_scripts/condor_adstash
+++ b/src/condor_scripts/condor_adstash
@@ -157,7 +157,7 @@ def main():
 
     # register with the condor_master unless running standalone
     if not args.standalone:
-        htcondor.set_subsystem(args.process_name, False, htcondor.SubsystemType.Daemon)
+        htcondor.set_subsystem(args.process_name, htcondor.SubsystemType.Daemon)
         try:
             logging.info("Sending DC_SET_READY message to condor_master")
             htcondor.set_ready_state("Ready")

--- a/src/condor_utils/subsystem_info.cpp
+++ b/src/condor_utils/subsystem_info.cpp
@@ -41,6 +41,11 @@ void set_mySubSystem( const char *subsystem_name, bool _trust,
 {
 	delete mySubSystem;
 	mySubSystem = new SubsystemInfo( subsystem_name, _trust, _type );
+	/* If Subsystem type passed is AUTO, then we can't be certain whether or not the subsystem
+	 * is assumed to be trusted with root privileges for various checks. So, after initialization
+	 * we check if the subsystem class is DAEMON. If so, then set trust to true. -Cole Bollig
+	*/
+	if ( _type == SUBSYSTEM_TYPE_AUTO && mySubSystem->isDaemon() ) { mySubSystem->setIsTrusted(true); }
 }
 
 //

--- a/src/condor_utils/subsystem_info.h
+++ b/src/condor_utils/subsystem_info.h
@@ -46,7 +46,7 @@ typedef enum {
 	SUBSYSTEM_TYPE_MIN = 1,	// Min valid subsystem type, don't start at zero
 
 	// Daemon types
-	SUBSYSTEM_TYPE_MASTER,
+	SUBSYSTEM_TYPE_MASTER = SUBSYSTEM_TYPE_MIN,
 	SUBSYSTEM_TYPE_COLLECTOR,
 	SUBSYSTEM_TYPE_NEGOTIATOR,
 	SUBSYSTEM_TYPE_SCHEDD,
@@ -179,6 +179,7 @@ class SubsystemInfo
 
 	// Subsystem trusted privileges
 	bool isTrusted( void ) { return m_trusted; };
+	void setIsTrusted ( bool is_trusted ) { m_trusted = is_trusted; }
 
   private:
 	const char					*m_Name;

--- a/src/python-bindings/dc_tool.cpp
+++ b/src/python-bindings/dc_tool.cpp
@@ -280,9 +280,12 @@ enable_log()
 
 
 void
-set_subsystem(std::string subsystem, bool trust, SubsystemType type=SUBSYSTEM_TYPE_AUTO)
+set_subsystem(std::string subsystem, SubsystemType type=SUBSYSTEM_TYPE_AUTO)
 {
-    set_mySubSystem(subsystem.c_str(), trust, type);
+    //Boolean array that corresponds to SubsystemType enum for whether that subsystem is assumed to be trusted with root privileges or not
+    bool trustedSubsys[] = {false, true, true, true, true, true, true, true, false, false, true, true, false, false, false, false};
+    //Corresponding enum:   Inval,Mastr,Clctr,Negtr,Sched,Shado,Stard,Strtr,  GHAP,DAGMan,SHPrt,Daemn, Tool ,Submit,  Job , Auto 
+    set_mySubSystem(subsystem.c_str(), trustedSubsys[type], type);
 }
 
 
@@ -492,11 +495,10 @@ export_dc_tool()
         The subsystem is primarily used for the parsing of the HTCondor configuration file.
 
         :param str name: The subsystem name.
-        :param bool trust: Boolean to represent whether subsystem can be trusted with 'root' privileges.
         :param daemon_type: The HTCondor daemon type. The default value of Auto infers the type from the name parameter.
         :type daemon_type: :class:`SubsystemType`
         )C0ND0R",
-        (boost::python::arg("subsystem"), boost::python::arg("trust"), boost::python::arg("type")=SUBSYSTEM_TYPE_AUTO))
+        (boost::python::arg("subsystem"), boost::python::arg("type")=SUBSYSTEM_TYPE_AUTO))
         ;
 
     def("enable_debug", enable_debug,


### PR DESCRIPTION
-Reverted external python changes to not break old scripts
-Python dc_tools now internally sets trust based off of passed
 subsystem type
-Added setIsTrusted(bool) function to directly set a subsystems
 trust. Used for the case of AUTO types of subsystems. We don't
 know if subsys can be trusted unless the class is daemon which
 is set during initialization of the subsystem.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
