### PR TITLE
 HTCONDOR-1162-Do not allow RemoteUserCpu to go backwards. 

### DIFF
--- a/src/condor_shadow.V6.1/remoteresource.cpp
+++ b/src/condor_shadow.V6.1/remoteresource.cpp
@@ -1387,10 +1387,13 @@ RemoteResource::updateFromStarter( ClassAd* update_ad )
 			double prevTotalUsage = 0.0;
 			jobAd->LookupFloat(ATTR_JOB_CUMULATIVE_REMOTE_SYS_CPU, prevTotalUsage);
 			jobAd->Assign(ATTR_JOB_CUMULATIVE_REMOTE_SYS_CPU, prevTotalUsage + (real_value - prevUsage));
+
+			// Also, do not reset remote cpu unless there was an increase, to guard
+			// against the case starter sending a zero value (perhaps right when the
+			// job terminates).
+			remote_rusage.ru_stime.tv_sec = (time_t)real_value;
+			jobAd->Assign(ATTR_JOB_REMOTE_SYS_CPU, real_value);
 		}
-		
-		remote_rusage.ru_stime.tv_sec = (time_t) real_value;
-		jobAd->Assign(ATTR_JOB_REMOTE_SYS_CPU, real_value);
 	}
 
 	if( update_ad->LookupFloat(ATTR_JOB_REMOTE_USER_CPU, real_value) ) {
@@ -1404,10 +1407,14 @@ RemoteResource::updateFromStarter( ClassAd* update_ad )
 			double prevTotalUsage = 0.0;
 			jobAd->LookupFloat(ATTR_JOB_CUMULATIVE_REMOTE_USER_CPU, prevTotalUsage);
 			jobAd->Assign(ATTR_JOB_CUMULATIVE_REMOTE_USER_CPU, prevTotalUsage + (real_value - prevUsage));
+
+			// Also, do not reset remote cpu unless there was an increase, to guard
+			// against the case starter sending a zero value (perhaps right when the
+			// job terminates).
+			remote_rusage.ru_utime.tv_sec = (time_t)real_value;
+			jobAd->Assign(ATTR_JOB_REMOTE_USER_CPU, real_value);
+
 		}
-		
-		remote_rusage.ru_utime.tv_sec = (time_t) real_value;
-		jobAd->Assign(ATTR_JOB_REMOTE_USER_CPU, real_value);
 	}
 
 	if( update_ad->LookupInteger(ATTR_IMAGE_SIZE, long_value) ) {


### PR DESCRIPTION
Hopefully this patch will fix observed behavior where
RemoteUserCpu and RemoteSysCpu will sometimes end up with zero
values in the history file, while CumulativeRemoteUserCpu is > 0.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
