### PR TITLE
constexpr sort for command strings (C++20)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ project(CONDOR LANGUAGES C CXX)
 cmake_minimum_required(VERSION 3.8)
 
 # Exactly c++ 11 for all platforms
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(PREFER_CPP11 ON) # Still have some ifdefs on this

--- a/src/condor_utils/command_strings.cpp
+++ b/src/condor_utils/command_strings.cpp
@@ -22,6 +22,7 @@
 #include "command_strings.h"
 #include "condor_perms.h"
 #include <map>
+#include <algorithm>
 
 #define USE_GENERATED_CMD_TABLES
 #ifdef USE_GENERATED_CMD_TABLES
@@ -385,15 +386,21 @@ const T * BinaryLookupFromIndex (const int aIndex[], const T aTable[], int cElms
 	}
 }
 
+static constexpr auto getSortedTable_DCTranslation() {
+	auto arrTable = std::to_array(DCTranslation);
+	std::sort(arrTable.begin(), arrTable.end(),
+		[](const BTranslation& e1, const BTranslation& e2) { return strcmp(e1.name, e2.name) < 0; });
+	return arrTable;
+}
 
-const char * getCommandString(int id)
-{
-	const BTranslation * ptr = BinaryLookup(
-			DCTranslation,
-			DCTranslation_count,
-			id);
-	if (ptr) return ptr->name;
-	return NULL;
+static constexpr auto DCTranslation_sorted = getSortedTable_DCTranslation();
+
+static_assert(DCTranslation_sorted[8].id == CA_CMD);
+
+const char * getCommandString(int id) {
+    auto iter = std::lower_bound(DCTranslation_sorted.begin(), DCTranslation_sorted.end(), id,
+		[](const BTranslation& e, int _id) { return e.id < _id; });
+	return (iter != DCTranslation_sorted.end()) ? iter->name : NULL;
 }
 
 int getCommandNum(const char * name)


### PR DESCRIPTION
In command_strings.cpp, edit getCommandString function to use a compile-time sorted array to improve lookup time.
Test condor_view_classad_types fails and test cmd_ssh_to_job_van times out at the moment.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
