### PR TITLE
HTCONDOR-1185 - up default for SCHEDD_ASSUME_NEGOTIATOR_GONE

### DIFF
--- a/docs/admin-manual/configuration-macros.rst
+++ b/docs/admin-manual/configuration-macros.rst
@@ -5165,7 +5165,9 @@ These macros control the *condor_schedd*.
     local *condor_startd*. This allows for a machine that is acting as
     both a submit and execute node to run jobs locally if it cannot
     communicate with the central manager. The default value, if not
-    specified, is 1200 (20 minutes).
+    specified, is 2,000,000 seconds (effectively never).  If this
+    feature is desired, we recommend setting it to some small multiple
+    of the negotiation cycle, say, 1200 seconds, or 20 minutes.
 
 .. _GRACEFULLY_REMOVE_JOBS:
 

--- a/docs/version-history/development-release-series-91.rst
+++ b/docs/version-history/development-release-series-91.rst
@@ -25,6 +25,12 @@ New Features:
   level authorization.
   :jira:`1164`
 
+- The default value for ``SCHEDD_ASSUME_NEGOTIATOR_GONE`` has been changed 
+  from 20 minutes to a practically infinite value.  This is to prevent
+  surprises when the schedd starts running vanilla universe jobs even when
+  the admin has intentionally stopped the negotiator.
+  :jira:`1185`
+
 Bugs Fixed:
 
 - None.

--- a/src/condor_schedd.V6/schedd.cpp
+++ b/src/condor_schedd.V6/schedd.cpp
@@ -16160,9 +16160,9 @@ Scheduler::claimLocalStartd()
 
 		// Check when we last had a negotiation cycle; if recent, return.
 	int claimlocal_interval = param_integer("SCHEDD_ASSUME_NEGOTIATOR_GONE",
-				20 * 60);
+			2000000000);
 	if ( time(NULL) - NegotiationRequestTime < claimlocal_interval ) {
-			// we have negotiated recently, no need to calim the local startd
+			// we have negotiated recently, no need to claim the local startd
 		return false;
 	}
 

--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -3135,6 +3135,12 @@ type=bool
 tags=schedd
 description=Set to false to have Schedd refuse late materialization submits
 
+[SCHEDD_ASSUME_NEGOTIATOR_GONE]
+default=2000000000
+type=int
+tags=schedd
+description=
+
 [SCHEDD_NON_DURABLE_LATE_MATERIALIZE]
 default=true
 type=bool


### PR DESCRIPTION
https://opensciencegrid.atlassian.net/browse/HTCONDOR-1185

set default for SCHEDD_ASSUME_NEGOTIATOR_GONE to 2,000,000,000, effectively disabling it by default


# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
