### PR TITLE
HTCONDOR-860: Round RequestMemory up to 2 GB/core on Expanse instead of 3 GB/core

### DIFF
--- a/src/condor_scripts/annex/expanse.sh
+++ b/src/condor_scripts/annex/expanse.sh
@@ -327,12 +327,12 @@ SINGULARITY = ${PILOT_DIR}/singularity.sh
 ${CONDOR_CPUS_LINE}
 ${CONDOR_MEMORY_LINE}
 
-# Create dynamic slots 3 GB at a time.  This number was chosen because it's
-# the amount of RAM requested per core on the OS Pool, but we actually bother
+# Create dynamic slots 2 GB at a time.  This number was chosen because it's
+# the amount of RAM handed out per core on Expanse, but we actually bother
 # to set it because we start seeing weird scaling issues with more than 64
 # or so slots.  Since we can't fix that problem right now, avoid it.
 MUST_MODIFY_REQUEST_EXPRS = TRUE
-MODIFY_REQUEST_EXPR_REQUESTMEMORY = max({ 3072, quantize(RequestMemory, {128}) })
+MODIFY_REQUEST_EXPR_REQUESTMEMORY = max({ 2048, quantize(RequestMemory, {128}) })
 
 " > local/config.d/00-basic-pilot
 


### PR DESCRIPTION
1 Expanse SU gives you 1 core and 2 GB so you're leaving cores on the table if you request 3 GB.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
