### PR TITLE
HTCONDOR-1117: Request Lustre access on Expanse

### DIFF
--- a/src/condor_scripts/annex/expanse.sh
+++ b/src/condor_scripts/annex/expanse.sh
@@ -413,6 +413,8 @@ echo "
 ${SBATCH_RESOURCES_LINES}
 #SBATCH -t ${MINUTES}
 ${SBATCH_ALLOCATION_LINE}
+# Expanse specific:
+#SBATCH --constraint=\"lustre\"
 
 ${MULTI_PILOT_BIN} ${PILOT_BIN} ${PILOT_DIR}
 " >> ${PILOT_DIR}/expanse.slurm


### PR DESCRIPTION
According to the Expanse User Guide, this additional sbatch argument is needed to get access to Lustre.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
