### PR TITLE
HTCONDOR-1214: Fix up submit container doc: we do need 9618 open

### DIFF
--- a/build/docker/services/README.md
+++ b/build/docker/services/README.md
@@ -5,7 +5,7 @@ We provide the following containers for HTCondor services:
 - Minicondor (`htcondor/mini`)
 - Execute Node (`htcondor/execute`)
 - Central Manager (`htcondor/cm`)
-- Submit Node (`htcondor/submit`)
+- Submit Node (Access Point) (`htcondor/submit`)
 
 
 
@@ -219,8 +219,8 @@ To add additional configuration, see the [Providing Additional
 Configuration](#providing-additional-configuration) section below.
 
 
-Using the Submit Container
---------------------------
+Using the Submit (Access Point) Container
+-----------------------------------------
 
 ### Overview
 
@@ -229,7 +229,8 @@ scheduler daemon as described in [the machine roles section of the HTCondor
 manual](https://htcondor.readthedocs.io/en/latest/admin-manual/introduction-admin-manual.html#the-different-roles-a-machine-can-play)
 and can connect to an existing HTCondor pool via token authentication
 (recommended) or pool password.  Token authentication requires HTCondor 8.9.2+
-on both sides of the connection.  This container needs no inbound connectivity.
+on both sides of the connection.  This container requires inbound connectivity
+on port 9618.
 
 You must specify the address of the pool's central manager in the `CONDOR_HOST`
 environment variable or `CONDOR_SERVICE_HOST` environment variable.


### PR DESCRIPTION
Also mention the term "access point."  I'm not going to replace the old term
yet because I want to maintain consistency with the manual at
https://htcondor.readthedocs.io/en/latest/admin-manual/introduction-admin-manual.html#the-different-roles-a-machine-can-play
which still uses "submit."

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
