### PR TITLE
HTCONDOR-1228  Fix RESERVED_DISK.

### DIFF
--- a/docs/version-history/development-release-series-91.rst
+++ b/docs/version-history/development-release-series-91.rst
@@ -105,6 +105,11 @@ New Features:
 
 Bugs Fixed:
 
+- Fixed bug where specifying more than 2TB of ``RESERVED_DISK`` would
+  cause HTCondor to instead pretend that available disk space was larger,
+  rather than smaller.
+  `jira`:1228
+
 - Fixed two bugs which could occur when resuming from a checkpoint with
   ``preserve_relative_paths`` set.  Both involved the checkpoint transfer
   list including a file at a relative path which was itself listed in the

--- a/src/condor_sysapi/free_fs_blocks.cpp
+++ b/src/condor_sysapi/free_fs_blocks.cpp
@@ -131,21 +131,10 @@ reserve_for_afs_cache()
   How much disk space we need to reserve for the regular file system.
   Answer is in kilobytes.
 */
-int
+long long
 sysapi_reserve_for_fs()
 {
-	/* XXX make cleaner */
-	int	answer = -1;
-
-	if( answer < 0 ) {
-		answer = _sysapi_reserve_disk;
-		if( answer < 0 ) {
-			answer = 0;
-		}
-	}
-
-	answer = _sysapi_reserve_disk;
-	return answer;
+	return _sysapi_reserve_disk;
 }
 
 

--- a/src/condor_sysapi/sysapi.h
+++ b/src/condor_sysapi/sysapi.h
@@ -41,7 +41,7 @@ int sysapi_phys_memory(void);
 int sysapi_phys_memory_raw_no_param(void);
 
 /* How to get the free disk blocks from a full pathname, answer in KB */
-int sysapi_reserve_for_fs();
+long long sysapi_reserve_for_fs();
 long long sysapi_disk_space_raw(const char *filename);
 long long sysapi_disk_space(const char *filename);
 

--- a/src/condor_tests/CMakeLists.txt
+++ b/src/condor_tests/CMakeLists.txt
@@ -256,6 +256,8 @@ endif()
 				condor_pl_test(test_htcondor_955 "Test output_destination with standard stream names" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 				condor_pl_test(test_xfer_stats_overflow_regression "Test TransferInputStats nested attributes don't overflow" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 				condor_pl_test(test_condor_manifest "Test MANIFEST implementation via condor_manifest tool" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
+				# Sadly, Python doesn't implement a way to get disk space on Windows.
+				condor_pl_test(test_reserve_disk "Test RESERVED_DISK underflow" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 			endif()
 		endif()
 	endif()

--- a/src/condor_tests/test_reserve_disk.py
+++ b/src/condor_tests/test_reserve_disk.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env pytest
+
+import os
+import logging
+import htcondor
+
+from ornithology import (
+    action,
+    config,
+    Condor,
+)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+@action
+def reported_disk_space(test_dir):
+    with Condor(test_dir / "condor", { "RESERVED_DISK": "3145728" }) as condor:
+        result = condor.status(
+            ad_type=htcondor.AdTypes.Startd,
+            projection=["TotalDisk"],
+        )
+        return result[0]["TotalDisk"]
+
+@action
+def actual_disk_space(test_dir):
+    stats = os.statvfs(test_dir.as_posix())
+    return int(stats.f_bfree/1024.0 * stats.f_bsize)
+
+class TestReserveDisk:
+    def test_reserve_disk(self, actual_disk_space, reported_disk_space):
+        assert(reported_disk_space < actual_disk_space)


### PR DESCRIPTION
For some reason, RESERVED_DISK was still being stored in an `int`, which rolls over and makes the available disk larger rather than smaller if it's too large.

This PR does not fix the problem that we're still using a signed integer for a size.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
