### PR TITLE
HTCONDOR-1242 singularity-path

### DIFF
--- a/src/condor_starter.V6.1/singularity.cpp
+++ b/src/condor_starter.V6.1/singularity.cpp
@@ -366,9 +366,16 @@ Singularity::setup(ClassAd &machineAd,
 
 	// For some reason, singularity really wants /usr/sbin near the beginning of the PATH
 	// when running /usr/sbin/mksquashfs when running docker: images
-	std::string oldPath;
-	job_env.GetEnv("PATH", oldPath);
-	job_env.SetEnv("PATH", std::string("/usr/sbin:" + oldPath));
+	//
+	// Update:  If PATH wasn't set, singularity will set it from the
+	// image.  In this case, we are injecting a new PATH which prevents
+	// the image path from being set, which breaks all kinds of things.
+	// comment this out for now until we find a better solution.
+	// This means that to run docker images, the user will have to have
+	// /usr/sbin in their path
+	//std::string oldPath;
+	//job_env.GetEnv("PATH", oldPath);
+	//job_env.SetEnv("PATH", std::string("/usr/sbin:" + oldPath));
 
 	// If reading an image from a docker hub, store it in the scratch dir
 	// when we get AP sandboxes, that would be a better place to store these


### PR DESCRIPTION
PATH

This breaks the case where the job isn't setting any PATH, and
expects the PATH to be set from the image.

This is a short term fix, but we need to get this out until
we can come up with a better fix to the problem that running
docker: images in singularity requires access to /usr/sbin/mksquashfs

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
