### PR TITLE
HTCONDOR-692 Add knob for collector hostname for SSL

### DIFF
--- a/docs/admin-manual/configuration-macros.rst
+++ b/docs/admin-manual/configuration-macros.rst
@@ -9066,6 +9066,15 @@ macros are described in the :doc:`/admin-manual/security` section.
     ``SSL_SKIP_HOST_CHECK`` :index:`SSL_SKIP_HOST_CHECK` for ways
     to disable this validation step.
 
+:macro-def:`USE_COLLECTOR_HOST_CNAME`
+    A boolean value that determines what hostname a client should
+    expect when validating the collector's certificate during SSL
+    authentication.
+    When set to ``True``, the hostname given to the client is used.
+    When set to ``False``, if the given hostname is a DNS CNAME, the
+    client resolves it to a DNS A record and uses that hostname.
+    The default value is ``True``.
+
 :macro-def:`DELEGATE_JOB_GSI_CREDENTIALS`
     A boolean value that defaults to ``True`` for HTCondor version
     6.7.19 and more recent versions. When ``True``, a job's X.509

--- a/docs/version-history/development-release-series-91.rst
+++ b/docs/version-history/development-release-series-91.rst
@@ -47,6 +47,8 @@ Bugs Fixed:
   to a fully-qualified canonical name when authenticating with SSL, matching
   the behavior of ``curl``.  Services using a DNS CNAME no longer need to
   implement workarounds in the host certificate to support the prior behavior.
+  The old behavior can be restored by setting new configuration
+  parameter ``USE_COLLECTOR_HOST_CNAME`` to ``False``.
   :jira:`692`
 
 Version 9.11.0

--- a/src/condor_daemon_client/daemon.cpp
+++ b/src/condor_daemon_client/daemon.cpp
@@ -1588,6 +1588,14 @@ Daemon::findCmDaemon( const char* cm_name )
 			return false;
 		}
 		sinful.setHost(saddr.to_ip_string().c_str());
+		// Older versions resolved a CNAME to the final A record FQDN and
+		// set that as the alias for the collector sinful here.
+		// This runs counter to how SSL host certificate validation is
+		// expected to work, and our setting of the alias for this Daemon
+		// object.
+		if(!param_boolean("USE_COLLECTOR_HOST_CNAME", true)) {
+			sinful.setAlias(fqdn.c_str());
+		}
 		dprintf( D_HOSTNAME, "Found CM IP address and port %s\n",
 				 sinful.getSinful() ? sinful.getSinful() : "NULL" );
 		New_full_hostname(strdup(fqdn.c_str()));

--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -157,6 +157,10 @@ tags=config
 description=Preferred DNS alias for this host
 customization=expert
 
+[USE_COLLECTOR_HOST_CNAME]
+default=true
+type=bool
+
 [HOSTNAME]
 default=
 type=string


### PR DESCRIPTION
New config knob USE_COLLECTOR_HOST_CNAME can be set to false to restore
the old behavior of resolving the given hostname and setting that as the
alias in the collector sinful we construct.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
