### PR TITLE
Add OpenSearch support to Adstash using an extra flag

### DIFF
--- a/src/condor_scripts/adstash/config.py
+++ b/src/condor_scripts/adstash/config.py
@@ -42,6 +42,7 @@ def get_default_config(name="ADSTASH"):
         "startd_history_timeout": 2 * 60,
         "es_host": "localhost:9200",
         "es_use_https": False,
+        "es_use_opensearch": False,
         "es_timeout": 2 * 60,
         "es_bunch_size": 250,
         "es_index_name": "htcondor-000001",
@@ -73,6 +74,7 @@ def get_htcondor_config(name="ADSTASH"):
         "es_username": p.get(f"{name}_ES_USERNAME"),
         "es_password_file": p.get(f"{name}_ES_PASSWORD_FILE"),
         "es_use_https": p.get(f"{name}_ES_USE_HTTPS"),
+        "es_use_opensearch": p.get(f"{name}_ES_USE_OPENSEARCH")
         "es_timeout": p.get(f"{name}_ES_TIMEOUT"),
         "es_bunch_size": p.get(f"{name}_ES_BUNCH_SIZE"),
         "es_index_name": p.get(f"{name}_ES_INDEX_NAME"),
@@ -134,6 +136,7 @@ def get_environment_config(name="ADSTASH"):
         "es_username": env.get(f"{name}_ES_USERNAME"),
         "es_password": env.get(f"{name}_ES_PASSWORD"),
         "es_use_https": env.get(f"{name}_ES_USE_HTTPS"),
+        "es_use_opensearch": env.get(f"{name}_ES_USE_OPENSEARCH"),
         "es_timeout": env.get(f"{name}_ES_TIMEOUT"),
         "es_bunch_size": env.get(f"{name}_ES_BUNCH_SIZE"),
         "es_index_name": env.get(f"{name}_ES_INDEX_NAME"),
@@ -204,7 +207,7 @@ def normalize_config_types(conf):
         "es_timeout",
         "es_bunch_size",
     ]
-    bools = ["standalone", "schedd_history", "startd_history", "es_use_https", "json_local"]
+    bools = ["standalone", "schedd_history", "startd_history", "es_use_https", "es_use_opensearch", "json_local"]
 
     # integers
     for key in integers:
@@ -420,6 +423,11 @@ def get_config(argv=None):
         "--es_use_https",
         action="store_true",
         help=("Use HTTPS when connecting to Elasticsearch " "[default: %(default)s]"),
+    )
+    parser.add_argument(
+        "--es_use_opensearch",
+        action="store_true",
+        help=("Use an OpenSearch cluster rather than Elasticsearch" "[default: %(default)s]"),
     )
     #parser.add_argument(
     #    "--es_timeout",

--- a/src/condor_scripts/adstash/config.py
+++ b/src/condor_scripts/adstash/config.py
@@ -46,7 +46,6 @@ def get_default_config(name="ADSTASH"):
         "es_timeout": 2 * 60,
         "es_bunch_size": 250,
         "es_index_name": "htcondor-000001",
-        "json_local": False,
     }
     return defaults
 
@@ -74,11 +73,10 @@ def get_htcondor_config(name="ADSTASH"):
         "es_username": p.get(f"{name}_ES_USERNAME"),
         "es_password_file": p.get(f"{name}_ES_PASSWORD_FILE"),
         "es_use_https": p.get(f"{name}_ES_USE_HTTPS"),
-        "es_use_opensearch": p.get(f"{name}_ES_USE_OPENSEARCH")
+        "es_use_opensearch": p.get(f"{name}_ES_USE_OPENSEARCH"),
         "es_timeout": p.get(f"{name}_ES_TIMEOUT"),
         "es_bunch_size": p.get(f"{name}_ES_BUNCH_SIZE"),
         "es_index_name": p.get(f"{name}_ES_INDEX_NAME"),
-        "json_local": p.get(f"{name}_JSON_LOCAL"),
         "ca_certs": p.get(f"{name}_CA_CERTS"),
     }
 
@@ -140,7 +138,6 @@ def get_environment_config(name="ADSTASH"):
         "es_timeout": env.get(f"{name}_ES_TIMEOUT"),
         "es_bunch_size": env.get(f"{name}_ES_BUNCH_SIZE"),
         "es_index_name": env.get(f"{name}_ES_INDEX_NAME"),
-        "json_local": env.get(f"{name}_JSON_LOCAL"),
         "ca_certs": env.get(f"{name}_CA_CERTS"),
     }
 
@@ -207,7 +204,7 @@ def normalize_config_types(conf):
         "es_timeout",
         "es_bunch_size",
     ]
-    bools = ["standalone", "schedd_history", "startd_history", "es_use_https", "es_use_opensearch", "json_local"]
+    bools = ["standalone", "schedd_history", "startd_history", "es_use_https", "es_use_opensearch"]
 
     # integers
     for key in integers:
@@ -451,11 +448,6 @@ def get_config(argv=None):
             "Elasticsearch index name "
             "[default: %(default)s]"
         ),
-    )
-    parser.add_argument(
-        "--json_local",
-        action="store_true",
-        help=("Store only locally in json format " "[default: %(default)s]"),
     )
     parser.add_argument(
         "--ca_certs",

--- a/src/condor_scripts/adstash/elastic.py
+++ b/src/condor_scripts/adstash/elastic.py
@@ -19,7 +19,11 @@ import logging
 import collections
 import datetime
 
-import elasticsearch
+if args.es_use_opensearch:
+    import opensearchpy as elasticsearch
+else:
+    import elasticsearch
+
 import importlib.util
 
 from pathlib import Path
@@ -214,7 +218,10 @@ class ElasticInterface(GenericInterface):
             es_client["use_ssl"] = True
             es_client["verify_certs"] = True
 
-        self.handle = elasticsearch.Elasticsearch([es_client])
+        if args.es_use_opensearch:
+            self.handle = elasticsearch.OpenSearch([es_client])
+        else:
+            self.handle = elasticsearch.Elasticsearch([es_client])
         super().__init__(self, logdir)
 
     def make_mapping(self, idx):

--- a/src/condor_scripts/adstash/history.py
+++ b/src/condor_scripts/adstash/history.py
@@ -21,7 +21,11 @@ import traceback
 import multiprocessing
 
 import htcondor
-import elasticsearch
+
+if args.es_use_opensearch:
+    import opensearchpy as elasticsearch
+else:
+    import elasticsearch
 
 from . import elastic, utils, convert
 


### PR DESCRIPTION
At STFC (Science & Technology Facilities Council) we are migrating from Elasticsearch to OpenSearch for our search clusters. This PR adds OpenSearch support to Adstash so we can use it to send job logs from our HTCondor system to our search cluster.