### PR TITLE
Add `DOCKER_SHM_SIZE` knob.

### DIFF
--- a/docs/admin-manual/configuration-macros.rst
+++ b/docs/admin-manual/configuration-macros.rst
@@ -4263,6 +4263,14 @@ details.
     may request with the ``docker_network_type`` submit file command.
     Advertised into the slot attribute DockerNetworks.
 
+:macro-def:`DOCKER_SHM_SIZE`
+    An optional knob that can be configured to adapt the ``--shm-size`` Docker
+    container create argument. Allowed values are integers in bytes.
+    If not set, ``--shm-size`` will not be specified by HTCondor and Docker's
+    default is used.
+    This is used to configure the size of the container's ``/dev/shm`` size adapting
+    to the job's requested memory.
+
 :macro-def:`OPENMPI_INSTALL_PATH`
     The location of the Open MPI installation on the local machine.
     Referenced by ``examples/openmpiscript``, which is used for running

--- a/docs/admin-manual/setting-up-vm-docker-universes.rst
+++ b/docs/admin-manual/setting-up-vm-docker-universes.rst
@@ -317,3 +317,22 @@ jobs that request these network type will only match to machines
 that support it.  Note that HTCondor cannot test the validity
 of these networks, and merely trusts that the administrator has
 correctly configured them.
+
+To deal with a potentially user influencing option, there is an optional knob that
+can be configured to adapt the ``--shm-size`` Docker container create argument
+taking the machine's and job's classAds into account.
+Exemplary, setting the ``/dev/shm`` size to half the requested memory is achieved by:
+
+.. code-block:: condor-config
+
+    DOCKER_SHM_SIZE = Memory * 1024 * 1024 / 2
+
+or, using a user provided value ``DevShmSize`` if available and within the requested
+memory limit:
+
+.. code-block:: condor-config
+
+    DOCKER_SHM_SIZE = ifThenElse(DevShmSize isnt Undefined && isInteger(DevShmSize) && int(DevShmSize) <= (Memory * 1024 * 1024), int(DevShmSize), 2 * 1024 * 1024 * 1024)
+
+    
+Note: ``Memory`` is in MB, thus it needs to be scaled to bytes.

--- a/src/condor_utils/docker-api.cpp
+++ b/src/condor_utils/docker-api.cpp
@@ -13,6 +13,7 @@
 #include "docker-api.h"
 #include <algorithm>
 #include <sstream>
+#include <string>
 
 #if !defined(WIN32)
 #include <sys/un.h>
@@ -342,6 +343,14 @@ int DockerAPI::createContainer(
 		return -1;
 	}
 	if (tmp) free(tmp);
+
+	long long shm_size = 0;
+	if(param_longlong("DOCKER_SHM_SIZE", shm_size, false, 0, true,
+		(std::numeric_limits<long long>::min)(),
+		(std::numeric_limits<long long>::max)(), &machineAd, &jobAd)) {
+		runArgs.AppendArg("--shm-size");
+		runArgs.AppendArg(std::to_string(shm_size));
+	}
 
 	// Run the command with its arguments in the image.
 	runArgs.AppendArg( imageID );


### PR DESCRIPTION
It is desirable to be able to configure Docker's `--shm-size` depending on a job's requested memory or even allow users to specify the value for it in their submission file.
Thus this adds a knob that is parsed as integral value with the machine's and job's classAd available.
If present, the value passed to `--shm-size`.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
