### PR TITLE
HTCONDOR-1112: Handle UNDEFINED and ERROR in TransferInput in job ads

### DIFF
--- a/src/condor_tools/htcondor_cli/annex_create.py
+++ b/src/condor_tools/htcondor_cli/annex_create.py
@@ -14,6 +14,7 @@ import subprocess
 from pathlib import Path
 
 import htcondor
+import classad
 
 #
 # We could try to import colorama here -- see condor_watch_q -- but that's
@@ -1056,6 +1057,8 @@ def annex_inner_func(
             schedd.edit(job_id, "ContainerImage", f'"{remote_sif_file}"')
 
             transfer_input = job_ad.get("TransferInput", "")
+            if isinstance(transfer_input, classad.Value):  # UNDEFINED or ERROR
+                transfer_input = ""
             input_files = transfer_input.split(",")
             if job_ad["ContainerImage"] in input_files:
                 logger.debug(


### PR DESCRIPTION
When TransferInput is UNDEFINED, `jobad.get("TransferInput", "")` actually returns a classad.Value, not an empty string - this causes an AttributeError when we try to split it later on.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
