### PR TITLE
HTCONDOR-1337: Fix trivial typo in docs for self-checkpointing applications

### DIFF
--- a/docs/users-manual/self-checkpointing-applications.rst
+++ b/docs/users-manual/self-checkpointing-applications.rst
@@ -20,7 +20,7 @@ consider error code ``85``.  On Linux systems, this is ``ERESTART``, which
 seems appropriate.)  If the ``executable`` exits
 with ``checkpoint_exit_code``, HTCondor will transfer the checkpoint to
 the submit node, and then immediately restart the ``executable`` in the
-same sandbox on the same machine, with same the ``arguments``.  This
+same sandbox on the same machine, with the same ``arguments``.  This
 immediate transfer makes the checkpoint available for continuing the job
 even if the job is interrupted in a way that doesn't allow for files to
 be transferred (e.g., power failure), or if the file transfer doesn't


### PR DESCRIPTION
This PR fixes a trivial typo in the docs for self-checkpointing applications.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
