### PR TITLE
HTCONDOR-1364: Condor History stops after finding cluster(.proc) ads

### DIFF
--- a/docs/version-history/feature-versions-10-x.rst
+++ b/docs/version-history/feature-versions-10-x.rst
@@ -23,6 +23,10 @@ New Features:
   state unless passed ``-cumulative-time`` to show the jobs cumulative run time for all runs.
   :jira:`1064`
 
+- *condor_history* will now stop searching history files once all possible job ads are
+  found if passed ClusterIds or ClusterId.ProcId pairs.
+  :jira:`1364`
+
 Bugs Fixed:
 
 - None.

--- a/docs/version-history/feature-versions-10-x.rst
+++ b/docs/version-history/feature-versions-10-x.rst
@@ -23,7 +23,7 @@ New Features:
   state unless passed ``-cumulative-time`` to show the jobs cumulative run time for all runs.
   :jira:`1064`
 
-- *condor_history* will now stop searching history files once all possible job ads are
+- *condor_history* will now stop searching history files once all requested job ads are
   found if passed ClusterIds or ClusterId.ProcId pairs.
   :jira:`1364`
 

--- a/src/condor_tools/history.cpp
+++ b/src/condor_tools/history.cpp
@@ -1069,9 +1069,8 @@ static bool checkMatchJobIdsFound(ClassAd *ad) {
 	if (!ad->LookupInteger(ATTR_CLUSTER_ID,ad_cluster) ||
 		!ad->LookupInteger(ATTR_PROC_ID,ad_proc) ||
 		!ad->LookupInteger(ATTR_COMPLETION_DATE,ad_completion)) {
-			dprintf(D_FULLDEBUG,"ERROR: Malformed Job Ad. Unable to check Cluster.Proc matches.\n");
 			return false;
-	}
+	} //TODO: Replace these job ad calls with passed banner information
 
 	//For each match item info check record found
 	for (auto& match : jobIdFilterInfo) {
@@ -1082,7 +1081,7 @@ static bool checkMatchJobIdsFound(ClassAd *ad) {
 			jobIdFilterInfo.pop_back();
 		} else { //Else this is a cluster only find
 			//If the cluster submit time is greater than the current completion date remove from data structure
-			if (ad_completion != 0 && match.QDate > ad_completion) {
+			if (ad_completion <= 0 && match.QDate > ad_completion) {
 				std::swap(match,jobIdFilterInfo.back());
 				jobIdFilterInfo.pop_back();
 			} else if (match.clusterId == ad_cluster) { //If cluster matches do checks
@@ -1253,7 +1252,7 @@ static void readHistoryFromFileOld(const char *JobHistoryFileName, const char* c
             }
         }
 
-		if (cluster != -1 && !read_epoch_ads) { //User specified cluster or cluster.proc. Also, conficts with epochs so skip if reading epoch files
+		if (cluster > 0 && !read_epoch_ads) { //User specified cluster or cluster.proc. Also, conficts with epochs so skip if reading epoch files
 			if (checkMatchJobIdsFound(ad)) { //Check if all possible matches have been found
 				if (ad) {
 					delete ad;
@@ -1369,7 +1368,7 @@ static void printJobIfConstraint(std::vector<std::string> & exprs, const char* c
 		printJob(ad);
 		matchCount++; // if control reached here, match has occured
 	}
-	if (cluster != -1 && !read_epoch_ads) { //User specified cluster or cluster.proc. Also, conficts with epochs so skip if reading epoch files
+	if (cluster > 0 && !read_epoch_ads) { //User specified cluster or cluster.proc. Also, conficts with epochs so skip if reading epoch files
 		if (checkMatchJobIdsFound(&ad)) { //Check if all possible ads have been displayed
 			maxAds = adCount;
 			return;
@@ -1541,8 +1540,8 @@ static int set_print_mask_from_stream(
 static void findEpochFiles(std::deque<std::string> *epochFiles){
 	std::string jobID; //Make jobId to search for .XXX.YY.
 	bool oneJob = false;
-	if (cluster != -1) {
-		if (proc != -1) { formatstr(jobID,".%d.%d.",cluster,proc); oneJob = true; }
+	if (cluster > 0) {
+		if (proc >= 0) { formatstr(jobID,".%d.%d.",cluster,proc); oneJob = true; }
 		else { formatstr(jobID,".%d.",cluster); }
 	}
 

--- a/src/condor_tools/history.cpp
+++ b/src/condor_tools/history.cpp
@@ -1076,7 +1076,7 @@ static bool checkMatchJobIdsFound(ClassAd *ad) {
 	for (auto& match : jobIdFilterInfo) {
 		//fprintf(stdout,"Clust=%d | Proc=%d | Sub=%lld | Num=%d\n",match.clusterId,match.procId,match.QDate,match.numProcs); //Debug Match items
 		//If has a specified proc and matched proc and cluster then remove from data structure
-		if (match.procId != -1 && match.clusterId == ad_cluster && match.procId == ad_proc) {
+		if (match.procId >= 0 && match.clusterId == ad_cluster && match.procId == ad_proc) {
 			std::swap(match,jobIdFilterInfo.back());
 			jobIdFilterInfo.pop_back();
 		} else { //Else this is a cluster only find
@@ -1086,7 +1086,7 @@ static bool checkMatchJobIdsFound(ClassAd *ad) {
 				jobIdFilterInfo.pop_back();
 			} else if (match.clusterId == ad_cluster) { //If cluster matches do checks
 				//Get QDate from job ad if not set in info
-				if (match.QDate == -1) { ad->LookupInteger(ATTR_Q_DATE,match.QDate); }
+				if (match.QDate < 0) { ad->LookupInteger(ATTR_Q_DATE,match.QDate); }
 				//If numProcs is negative then set info to current ads info (TotalSubmitProcs)
 				if (match.numProcs < 0) {
 					int numProcOffest = match.numProcs;


### PR DESCRIPTION
-Made it so if user passes clusterIds or cluster.procIds condor history
 will stop searching the history files once all possible job ads have
 been found.
-Removed warning about fprintf being passed a unused variable

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
