### PR TITLE
HTCONDOR-1337 use ClassAdFunc directly and avoid void * casts

### DIFF
--- a/src/classad/classad/fnCall.h
+++ b/src/classad/classad/fnCall.h
@@ -29,15 +29,14 @@ namespace classad {
 
 typedef std::vector<ExprTree*> ArgumentList;
 
+typedef bool (*ClassAdFunc)(const char *, const ArgumentList &, EvalState &,
+							Value &);
+
 typedef struct 
 {
 	std::string       functionName;
 
-	// The function should be a ClassAdFunc. Because we use this structure
-	// as part of the interface with a shared library that uses an extern
-	// C interface, we keep it as a void*, unfortunately.
-	// The onus is on you to make sure that it's really a ClassAdFunc!
-	void         *function;
+	ClassAdFunc       function;
 	
 	// We are likely to add some flags here in the future.  These
 	// flags will describe things like how to cache results of the
@@ -55,9 +54,6 @@ typedef	 ClassAdFunctionMapping *(*ClassAdSharedLibraryInit)(void);
 class FunctionCall : public ExprTree
 {
  public:
- 	typedef	bool(*ClassAdFunc)(const char*, const ArgumentList&, EvalState&,
-							   Value&);
-
     /// Copy Constructor
     FunctionCall(FunctionCall &functioncall);
 
@@ -108,7 +104,7 @@ class FunctionCall : public ExprTree
 	/// Constructor
 	FunctionCall ();
 	
-	typedef std::map<std::string, void*, CaseIgnLTStr > FuncTable;
+	typedef std::map<std::string, ClassAdFunc, CaseIgnLTStr> FuncTable;
 	
  private:
 	virtual void _SetParentScope( const ClassAd* );

--- a/src/classad/fnCall.cpp
+++ b/src/classad/fnCall.cpp
@@ -74,29 +74,29 @@ FunctionCall( )
 
 		// load up the function dispatch table
 			// type predicates
-		functionTable["isundefined"	] = (void*)isType;
-		functionTable["iserror"		] =	(void*)isType;
-		functionTable["isstring"	] =	(void*)isType;
-		functionTable["isinteger"	] =	(void*)isType;
-		functionTable["isreal"		] =	(void*)isType;
-		functionTable["islist"		] =	(void*)isType;
-		functionTable["isclassad"	] =	(void*)isType;
-		functionTable["isboolean"	] =	(void*)isType;
-		functionTable["isabstime"	] =	(void*)isType;
-		functionTable["isreltime"	] =	(void*)isType;
+		functionTable["isundefined"	] = isType;
+		functionTable["iserror"		] =	isType;
+		functionTable["isstring"	] =	isType;
+		functionTable["isinteger"	] =	isType;
+		functionTable["isreal"		] =	isType;
+		functionTable["islist"		] =	isType;
+		functionTable["isclassad"	] =	isType;
+		functionTable["isboolean"	] =	isType;
+		functionTable["isabstime"	] =	isType;
+		functionTable["isreltime"	] =	isType;
 
 			// list membership
-		functionTable["member"		] =	(void*)testMember;
-		functionTable["identicalmember"	] =	(void*)testMember;
+		functionTable["member"		] =	testMember;
+		functionTable["identicalmember"	] =	testMember;
 
 		// Some list functions, useful for lists as sets
-		functionTable["size"        ] = (void*)size;
-		functionTable["sum"         ] = (void*)sumAvg;
-		functionTable["avg"         ] = (void*)sumAvg;
-		functionTable["min"         ] = (void*)minMax;
-		functionTable["max"         ] = (void*)minMax;
-		functionTable["anycompare"  ] = (void*)listCompare;
-		functionTable["allcompare"  ] = (void*)listCompare;
+		functionTable["size"        ] = size;
+		functionTable["sum"         ] = sumAvg;
+		functionTable["avg"         ] = sumAvg;
+		functionTable["min"         ] = minMax;
+		functionTable["max"         ] = minMax;
+		functionTable["anycompare"  ] = listCompare;
+		functionTable["allcompare"  ] = listCompare;
 
 			// basic apply-like functions
 		/*
@@ -107,86 +107,86 @@ FunctionCall( )
 		*/
 
 			// time management
-		functionTable["time"        ] = (void*)epochTime;
-		functionTable["currenttime"	] =	(void*)currentTime;
-		functionTable["timezoneoffset"] =(void*)timeZoneOffset;
-		functionTable["daytime"		] =	(void*)dayTime;
-		//functionTable["makedate"	] =	(void*)makeDate;
-		functionTable["getyear"		] =	(void*)getField;
-		functionTable["getmonth"	] =	(void*)getField;
-		functionTable["getdayofyear"] =	(void*)getField;
-		functionTable["getdayofmonth"] =(void*)getField;
-		functionTable["getdayofweek"] =	(void*)getField;
-		functionTable["getdays"		] =	(void*)getField;
-		functionTable["gethours"	] =	(void*)getField;
-		functionTable["getminutes"	] =	(void*)getField;
-		functionTable["getseconds"	] =	(void*)getField;
-		functionTable["splittime"   ] = (void*)splitTime;
-		functionTable["formattime"  ] = (void*)formatTime;
-		//functionTable["indays"		] =	(void*)inTimeUnits;
-		//functionTable["inhours"		] =	(void*)inTimeUnits;
-		//functionTable["inminutes"	] =	(void*)inTimeUnits;
-		//functionTable["inseconds"	] =	(void*)inTimeUnits;
+		functionTable["time"        ] = epochTime;
+		functionTable["currenttime"	] =	currentTime;
+		functionTable["timezoneoffset"] =timeZoneOffset;
+		functionTable["daytime"		] =	dayTime;
+		//functionTable["makedate"	] =	makeDate;
+		functionTable["getyear"		] =	getField;
+		functionTable["getmonth"	] =	getField;
+		functionTable["getdayofyear"] =	getField;
+		functionTable["getdayofmonth"] =getField;
+		functionTable["getdayofweek"] =	getField;
+		functionTable["getdays"		] =	getField;
+		functionTable["gethours"	] =	getField;
+		functionTable["getminutes"	] =	getField;
+		functionTable["getseconds"	] =	getField;
+		functionTable["splittime"   ] = splitTime;
+		functionTable["formattime"  ] = formatTime;
+		//functionTable["indays"		] =	inTimeUnits;
+		//functionTable["inhours"		] =	inTimeUnits;
+		//functionTable["inminutes"	] =	inTimeUnits;
+		//functionTable["inseconds"	] =	inTimeUnits;
 
 			// string manipulation
-		functionTable["strcat"		] =	(void*)strCat;
-		functionTable["join"		] =	(void*)strCat;
-		functionTable["toupper"		] =	(void*)changeCase;
-		functionTable["tolower"		] =	(void*)changeCase;
-		functionTable["substr"		] =	(void*)subString;
-		functionTable["strcmp"      ] = (void*)compareString;
-		functionTable["stricmp"     ] = (void*)compareString;
+		functionTable["strcat"		] =	strCat;
+		functionTable["join"		] =	strCat;
+		functionTable["toupper"		] =	changeCase;
+		functionTable["tolower"		] =	changeCase;
+		functionTable["substr"		] =	subString;
+		functionTable["strcmp"      ] = compareString;
+		functionTable["stricmp"     ] = compareString;
 
 			// version comparison
-		functionTable["versioncmp"  ] = (void*)compareVersion;
-		functionTable["versionLE"   ] = (void*)compareVersion;
-		functionTable["versionLT"   ] = (void*)compareVersion;
-		functionTable["versionGE"   ] = (void*)compareVersion;
-		functionTable["versionGT"   ] = (void*)compareVersion;
+		functionTable["versioncmp"  ] = compareVersion;
+		functionTable["versionLE"   ] = compareVersion;
+		functionTable["versionLT"   ] = compareVersion;
+		functionTable["versionGE"   ] = compareVersion;
+		functionTable["versionGT"   ] = compareVersion;
 		// Not identical to str1 =?= str2 because it won't eat undefined.
-		functionTable["versionEQ"   ] = (void*)compareVersion;
-		functionTable["version_in_range"] = (void*)versionInRange;
+		functionTable["versionEQ"   ] = compareVersion;
+		functionTable["version_in_range"] = versionInRange;
 
 			// pattern matching (regular expressions)
-		functionTable["regexp"		] =	(void*)matchPattern;
-		functionTable["regexpmember"] =	(void*)matchPatternMember;
-		functionTable["regexps"     ] = (void*)substPattern;
-		functionTable["replace"     ] = (void*)substPattern;
-		functionTable["replaceall"  ] = (void*)substPattern;
+		functionTable["regexp"		] =	matchPattern;
+		functionTable["regexpmember"] =	matchPatternMember;
+		functionTable["regexps"     ] = substPattern;
+		functionTable["replace"     ] = substPattern;
+		functionTable["replaceall"  ] = substPattern;
 
 			// conversion functions
-		functionTable["int"			] =	(void*)convInt;
-		functionTable["real"		] =	(void*)convReal;
-		functionTable["string"		] =	(void*)convString;
-		functionTable["bool"		] =	(void*)convBool;
-		functionTable["absTime"		] =	(void*)convTime;
-		functionTable["relTime"		] = (void*)convTime;
+		functionTable["int"			] =	convInt;
+		functionTable["real"		] =	convReal;
+		functionTable["string"		] =	convString;
+		functionTable["bool"		] =	convBool;
+		functionTable["absTime"		] =	convTime;
+		functionTable["relTime"		] = convTime;
 
 		// turn the contents of an expression into a string
 		// but *do not* evaluate it
-		functionTable["unparse"		] =	(void*)unparse;
-		functionTable["unresolved"	] = (void*)hasRefs;
+		functionTable["unparse"		] =	unparse;
+		functionTable["unresolved"	] = hasRefs;
 
 			// mathematical functions
-		functionTable["floor"		] =	(void*)doRound;
-		functionTable["ceil"		] =	(void*)doRound;
-		functionTable["ceiling"		] =	(void*)doRound;
-		functionTable["round"		] =	(void*)doRound;
-		functionTable["pow" 		] =	(void*)doMath2;
-		//functionTable["log" 		] =	(void*)doMath2;
-		functionTable["quantize"	] =	(void*)doMath2;
-		functionTable["random"      ] = (void*)random;
+		functionTable["floor"		] =	doRound;
+		functionTable["ceil"		] =	doRound;
+		functionTable["ceiling"		] =	doRound;
+		functionTable["round"		] =	doRound;
+		functionTable["pow" 		] =	doMath2;
+		//functionTable["log" 		] =	doMath2;
+		functionTable["quantize"	] =	doMath2;
+		functionTable["random"      ] = random;
 
 			// for compatibility with old classads:
-		functionTable["ifThenElse"  ] = (void*)ifThenElse;
-		functionTable["interval" ] = (void*)interval;
-		functionTable["eval"] = (void*)eval;
+		functionTable["ifThenElse"  ] = ifThenElse;
+		functionTable["interval" ] = interval;
+		functionTable["eval"] = eval;
 
 			// string list functions:
 			// Note that many other string list functions are defined
 			// externally in the Condor classad compatibility layer.
-		functionTable["stringListsIntersect" ] = (void*)stringListsIntersect;
-		functionTable["debug"      ] = (void*)debug;
+		functionTable["stringListsIntersect" ] = stringListsIntersect;
+		functionTable["debug"      ] = debug;
 
 		initialized = true;
 	}
@@ -316,7 +316,7 @@ void FunctionCall::RegisterFunction(
     FuncTable &functionTable = getFunctionTable();
 
 	if (functionTable.find(functionName) == functionTable.end()) {
-		functionTable[functionName] = (void *) function;
+		functionTable[functionName] = function;
 	}
 	return;
 }
@@ -327,7 +327,7 @@ void FunctionCall::RegisterFunctions(
 	if (functions != NULL) {
 		while (functions->function != NULL) {
 			RegisterFunction(functions->functionName, 
-							 (ClassAdFunc) functions->function);
+							 functions->function);
 			functions++;
 		}
 	}
@@ -374,12 +374,12 @@ bool FunctionCall::RegisterSharedLibraryFunctions(
 					success = true;
 					/*
 					while (functions->apparentFunctionName != NULL) {
-						void *function;
+						ClassAdFunc function;
 						string functionName = functions->apparentFunctionName;
 						function = dlsym(dynamic_library_handle, 
 										 functions->actualFunctionName);
 						RegisterFunction(functionName,
-										 (ClassAdFunc) function);
+										 function);
 						success = true;
 						functions++;
 					}
@@ -439,7 +439,7 @@ MakeFunctionCall( const string &str, vector<ExprTree*> &args )
 	FuncTable::iterator	itr = functionTable.find( str );
 
 	if( itr != functionTable.end( ) ) {
-		fc->function = (ClassAdFunc)itr->second;
+		fc->function = itr->second;
 	} else {
 		fc->function = NULL;
 	}

--- a/src/classad/shared.cpp
+++ b/src/classad/shared.cpp
@@ -54,10 +54,10 @@ static bool doublenum(const char *name, const ArgumentList &arguments,
  ***************************************************************************/
 static ClassAdFunctionMapping functions[] = 
 {
-    { "todays_date", (void *) todays_date, 0 },
-	{ "double",      (void *) doublenum,   0 },
-	{ "triple",      (void *) doublenum,   0 },
-    { "",            NULL,                 0 }
+    { "todays_date", todays_date, 0 },
+	{ "double",      doublenum,   0 },
+	{ "triple",      doublenum,   0 },
+    { "",            NULL,        0 }
 };
 
 /***************************************************************************

--- a/src/python-bindings/classad_python_user.cpp
+++ b/src/python-bindings/classad_python_user.cpp
@@ -37,8 +37,8 @@ python_invoke (const char *                 name,
 
 static classad::ClassAdFunctionMapping functions[] = 
 {
-    { "python_invoke",  (void *) python_invoke, 0 },
-    { "",        NULL,                          0 }
+    { "python_invoke",  python_invoke, 0 },
+    { "",        NULL,                 0 }
 };
 
 


### PR DESCRIPTION
Or, "What is a void *, and why can't I live without it?"

I stumbled on all these void * casts while looking for a list of classad functions...

The ClassAdFunctionMapping struct contains a std::string member, so I'm not sure I buy the explanation about having to cast function pointers to void * to make the extern C interface happy.

Notably, the cclassad.h interface does not expose this struct anyway, and cclassad.cpp (still) builds without complaint after this change.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
