### PR TITLE
HTCONDOR-1337 Fix memory leak in condor threads

### DIFF
--- a/src/condor_utils/threads_implementation.h
+++ b/src/condor_utils/threads_implementation.h
@@ -68,7 +68,7 @@ public:
 	int start_thread_safe_block();
 	int stop_thread_safe_block();
 	int yield();
-	int pool_init();
+	int pool_init(int num_threads);
 	int pool_add(condor_thread_func_t routine, void* arg, int* tid=NULL,
 				 const char* descrip=NULL);
 	static const WorkerThreadPtr_t get_handle(int tid = 0);


### PR DESCRIPTION
We used to always new up a ThreadImplementation,
then check to see if we are going to create "condor threads" and if we aren't (the default), destroy the ThreadImplementation, leaking a thread-local thread id along the way.

This created tons of noise in address sanitizer output, and was just redundant work.  Let's now check first to see if we need to create threads before boldly going down that road.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
