### PR TITLE
HTCONDOR-1337 function pointers can be called with normal fncall syntax

### DIFF
--- a/src/condor_io/condor_auth_kerberos.cpp
+++ b/src/condor_io/condor_auth_kerberos.cpp
@@ -407,7 +407,7 @@ int Condor_Auth_Kerberos :: wrap(const char*  input,
 	char* encrypted_data = 0;
 
 	// make a blank initialization vector
-	code = (*krb5_c_block_size_ptr)(krb_context_, sessionKey_->enctype, &blocksize);
+	code = krb5_c_block_size_ptr(krb_context_, sessionKey_->enctype, &blocksize);
 	if (code) {
 		// err
 	}
@@ -417,7 +417,7 @@ int Condor_Auth_Kerberos :: wrap(const char*  input,
     in_data.length = input_len;
 
     // Make the output buffer
-    code = (*krb5_c_encrypt_length_ptr)(krb_context_, sessionKey_->enctype, input_len, &encrypted_length);
+    code = krb5_c_encrypt_length_ptr(krb_context_, sessionKey_->enctype, input_len, &encrypted_length);
 	if(code) {
 		// err
 	}
@@ -430,14 +430,14 @@ int Condor_Auth_Kerberos :: wrap(const char*  input,
     out_data.ciphertext.data = (char*)encrypted_data;
 	out_data.ciphertext.length = encrypted_length;
 
-    if ((code = (*krb5_c_encrypt_ptr)(krb_context_, sessionKey_, 1024, /* key usage */
+    if ((code = krb5_c_encrypt_ptr(krb_context_, sessionKey_, 1024, /* key usage */
 				0, &in_data, &out_data)) != 0) {			/* 0 = no ivec */
         output     = 0;
         output_len = 0;
         if (out_data.ciphertext.data) {    
             free(out_data.ciphertext.data);
         }
-        dprintf( D_ALWAYS, "KERBEROS: %s\n", (*error_message_ptr)(code) );
+        dprintf( D_ALWAYS, "KERBEROS: %s\n", error_message_ptr(code) );
         return false;
     }
     
@@ -501,21 +501,21 @@ int Condor_Auth_Kerberos :: unwrap(const char*  input,
 			enc_data.enctype, sessionKey_->enctype);
 
 	// make a blank initialization vector
-	code = (*krb5_c_block_size_ptr)(krb_context_, sessionKey_->enctype, &blocksize);
+	code = krb5_c_block_size_ptr(krb_context_, sessionKey_->enctype, &blocksize);
 	if (code) {
-		dprintf(D_ALWAYS, "AUTH_ERROR: %s\n", (*error_message_ptr)(code));
+		dprintf(D_ALWAYS, "AUTH_ERROR: %s\n", error_message_ptr(code));
 	}
 
     out_data.length = enc_data.ciphertext.length;
 	out_data.data = (char*)malloc(out_data.length);
 
-	if ((code = (*krb5_c_decrypt_ptr)(krb_context_, sessionKey_, 1024, /* key usage */
+	if ((code = krb5_c_decrypt_ptr(krb_context_, sessionKey_, 1024, /* key usage */
 				0, &enc_data, &out_data))!=0) {			/* 0 = no ivec */
 
-	//if (code = (*krb5_decrypt_data_ptr)(krb_context_, sessionKey_, 0, &enc_data, &out_data)) {
+	//if (code = krb5_decrypt_data_ptr(krb_context_, sessionKey_, 0, &enc_data, &out_data)) {
         output_len = 0;
         output = 0;
-        dprintf( D_ALWAYS, "KERBEROS: %s\n", (*error_message_ptr)(code) );
+        dprintf( D_ALWAYS, "KERBEROS: %s\n", error_message_ptr(code) );
         if (out_data.data) {
             free(out_data.data);
         }
@@ -569,7 +569,7 @@ int Condor_Auth_Kerberos :: init_daemon()
 
 	if (daemonPrincipal) {
 		// it was defined explicitly in the config file
-		if ((code = (*krb5_parse_name_ptr)(krb_context_, daemonPrincipal, &krb_principal_))) {
+		if ((code = krb5_parse_name_ptr(krb_context_, daemonPrincipal, &krb_principal_))) {
 			free(daemonPrincipal);
 			goto error;
 		}
@@ -581,7 +581,7 @@ int Condor_Auth_Kerberos :: init_daemon()
 			daemonPrincipal = strdup(STR_DEFAULT_CONDOR_SERVICE);
 		}
 
-    	if ((code = (*krb5_sname_to_principal_ptr)(krb_context_, 
+    	if ((code = krb5_sname_to_principal_ptr(krb_context_, 
                                         	NULL, 
                                         	daemonPrincipal,
                                         	KRB5_NT_SRV_HST, 
@@ -598,12 +598,12 @@ int Condor_Auth_Kerberos :: init_daemon()
 
     if (keytabName_) {
     	dprintf(D_SECURITY, "init_daemon: Using keytab %s\n", keytabName_);
-        code = (*krb5_kt_resolve_ptr)(krb_context_, keytabName_, &keytab);
+        code = krb5_kt_resolve_ptr(krb_context_, keytabName_, &keytab);
     } else {
 		char defktname[_POSIX_PATH_MAX];
-		(*krb5_kt_default_name_ptr)(krb_context_, defktname, _POSIX_PATH_MAX);
+		krb5_kt_default_name_ptr(krb_context_, defktname, _POSIX_PATH_MAX);
     	dprintf(D_SECURITY, "init_daemon: Using default keytab %s\n", defktname);
-        code = (*krb5_kt_default_ptr)(krb_context_, &keytab);
+        code = krb5_kt_default_ptr(krb_context_, &keytab);
     }
 	if (code) {
 		goto error;
@@ -611,7 +611,7 @@ int Condor_Auth_Kerberos :: init_daemon()
 
 	// get the service name out of the member variable server_
 	tmpsname = 0;
-	code = (*krb5_unparse_name_ptr)(krb_context_, server_, &tmpsname);
+	code = krb5_unparse_name_ptr(krb_context_, server_, &tmpsname);
 	if (code) {
 		goto error;
 	}
@@ -623,7 +623,7 @@ int Condor_Auth_Kerberos :: init_daemon()
 	dprintf(D_SECURITY, "init_daemon: Trying to get tgt credential for service %s\n", sname.c_str());
 
 	priv = set_root_priv();   // Get the old privilige
-	code = (*krb5_get_init_creds_keytab_ptr)(krb_context_, creds_, krb_principal_, keytab, 0, const_cast<char*>(sname.c_str()), 0);
+	code = krb5_get_init_creds_keytab_ptr(krb_context_, creds_, krb_principal_, keytab, 0, const_cast<char*>(sname.c_str()), 0);
 	set_priv(priv);
 	if(code) {
 		goto error;
@@ -640,14 +640,14 @@ int Condor_Auth_Kerberos :: init_daemon()
     
  error:
     
-    dprintf(D_ALWAYS, "AUTH_ERROR: %s\n", (*error_message_ptr)(code));
+    dprintf(D_ALWAYS, "AUTH_ERROR: %s\n", error_message_ptr(code));
 
     rc = FALSE;
     
  cleanup:
     
     if (keytab) {
-        (*krb5_kt_close_ptr)(krb_context_, keytab);
+        krb5_kt_close_ptr(krb_context_, keytab);
     }
     
     return rc;
@@ -667,24 +667,24 @@ int Condor_Auth_Kerberos :: init_user()
     //------------------------------------------
     // First, try the default credential cache
     //------------------------------------------
-    ccname_ = strdup((*krb5_cc_default_name_ptr)(krb_context_));
+    ccname_ = strdup(krb5_cc_default_name_ptr(krb_context_));
     
-    if ((code = (*krb5_cc_resolve_ptr)(krb_context_, ccname_, &ccache))) {
+    if ((code = krb5_cc_resolve_ptr(krb_context_, ccname_, &ccache))) {
         goto error;
     }
     
     //------------------------------------------
     // Get principal info
     //------------------------------------------
-    if ((code = (*krb5_cc_get_principal_ptr)(krb_context_, ccache, &krb_principal_))) {
+    if ((code = krb5_cc_get_principal_ptr(krb_context_, ccache, &krb_principal_))) {
         goto error;
     }
 
-    if ((code = (*krb5_copy_principal_ptr)(krb_context_,krb_principal_,&mcreds.client))){
+    if ((code = krb5_copy_principal_ptr(krb_context_,krb_principal_,&mcreds.client))){
         goto error;
     }
     
-    if ((code = (*krb5_copy_principal_ptr)(krb_context_, server_, &mcreds.server))) {
+    if ((code = krb5_copy_principal_ptr(krb_context_, server_, &mcreds.server))) {
         goto error;
     }
     
@@ -697,7 +697,7 @@ int Condor_Auth_Kerberos :: init_user()
 		dprintf ( D_FULLDEBUG, "init_user: pre creds_ is NULL\n");
 	}		
 
-    if ((code = (*krb5_get_credentials_ptr)(krb_context_, 0, ccache, &mcreds, &creds_))) {
+    if ((code = krb5_get_credentials_ptr(krb_context_, 0, ccache, &mcreds, &creds_))) {
         goto error;
     }                                   
 
@@ -716,15 +716,15 @@ int Condor_Auth_Kerberos :: init_user()
     goto cleanup;
     
  error:
-    dprintf( D_ALWAYS, "KERBEROS: %s\n", (*error_message_ptr)(code) );
+    dprintf( D_ALWAYS, "KERBEROS: %s\n", error_message_ptr(code) );
     rc = FALSE;
 
  cleanup:
 
-    (*krb5_free_cred_contents_ptr)(krb_context_, &mcreds);
+    krb5_free_cred_contents_ptr(krb_context_, &mcreds);
 
     if (ccache) {  // maybe should destroy this
-        (*krb5_cc_close_ptr)(krb_context_, ccache);
+        krb5_cc_close_ptr(krb_context_, ccache);
     }
     return rc;
 }
@@ -749,7 +749,7 @@ int Condor_Auth_Kerberos :: authenticate_client_kerberos()
 	assert(creds_);
     if (creds_->addresses == NULL) {
 		dprintf ( D_SECURITY, "KERBEROS: creds_->addresses == NULL\n");
-        if ((code = (*krb5_os_localaddr_ptr)(krb_context_, &(creds_->addresses)))) {
+        if ((code = krb5_os_localaddr_ptr(krb_context_, &(creds_->addresses)))) {
             goto error;
         }
     }
@@ -760,7 +760,7 @@ int Condor_Auth_Kerberos :: authenticate_client_kerberos()
     //------------------------------------------
     // Let's create the KRB_AP_REQ message
     //------------------------------------------    
-    if ((code = (*krb5_mk_req_extended_ptr)(krb_context_, 
+    if ((code = krb5_mk_req_extended_ptr(krb_context_, 
                                     &auth_context_, 
                                     flags,
                                     0, 
@@ -809,7 +809,7 @@ int Condor_Auth_Kerberos :: authenticate_client_kerberos()
     //------------------------------------------
     // Store the session key for encryption
     //------------------------------------------
-    if ((code = (*krb5_copy_keyblock_ptr)(krb_context_, &(creds_->keyblock), &sessionKey_))) {
+    if ((code = krb5_copy_keyblock_ptr(krb_context_, &(creds_->keyblock), &sessionKey_))) {
         goto error;			  
     } 
 
@@ -817,7 +817,7 @@ int Condor_Auth_Kerberos :: authenticate_client_kerberos()
     goto cleanup;
     
  error:
-    dprintf( D_ALWAYS, "KERBEROS: %s\n", (*error_message_ptr)(code) );
+    dprintf( D_ALWAYS, "KERBEROS: %s\n", error_message_ptr(code) );
     // Abort
     mySock_->encode();
     reply = KERBEROS_ABORT;
@@ -829,7 +829,7 @@ int Condor_Auth_Kerberos :: authenticate_client_kerberos()
     
  cleanup:
     
-   (*krb5_free_creds_ptr)(krb_context_, creds_);
+   krb5_free_creds_ptr(krb_context_, creds_);
     
     if (request.data) {
         free(request.data);
@@ -881,15 +881,15 @@ int Condor_Auth_Kerberos :: authenticate_server_kerberos_1()
     // Getting keytab info
     //------------------------------------------
     if (keytabName_) {
-        code = (*krb5_kt_resolve_ptr)(krb_context_, keytabName_, &keytab);
+        code = krb5_kt_resolve_ptr(krb_context_, keytabName_, &keytab);
     }
     else {
-        code = (*krb5_kt_default_ptr)(krb_context_, &keytab);
+        code = krb5_kt_default_ptr(krb_context_, &keytab);
     }
     
     if (code) {
         dprintf( D_ALWAYS, "1: Kerberos server authentication error:%s\n",
-				 (*error_message_ptr)(code) );
+				 error_message_ptr(code) );
         goto error;
     }
     
@@ -907,7 +907,7 @@ int Condor_Auth_Kerberos :: authenticate_server_kerberos_1()
 
  priv = set_root_priv();   // Get the old privilige
     
- if ((code = (*krb5_rd_req_ptr)(krb_context_,
+ if ((code = krb5_rd_req_ptr(krb_context_,
                            &auth_context_,
                            &request,
                            //krb_principal_,
@@ -917,7 +917,7 @@ int Condor_Auth_Kerberos :: authenticate_server_kerberos_1()
                            &ticket_))) {
         set_priv(priv);   // Reset
         dprintf( D_ALWAYS, "2: Kerberos server authentication error:%s\n",
-				 (*error_message_ptr)(code) );
+				 error_message_ptr(code) );
         goto error;
     }
     set_priv(priv);   // Reset
@@ -927,9 +927,9 @@ int Condor_Auth_Kerberos :: authenticate_server_kerberos_1()
     //------------------------------------------
     // Mutual authentication is always required
     //------------------------------------------
-    if ((code = (*krb5_mk_rep_ptr)(krb_context_, auth_context_, &reply))) {
+    if ((code = krb5_mk_rep_ptr(krb_context_, auth_context_, &reply))) {
         dprintf( D_ALWAYS, "3: Kerberos server authentication error:%s\n",
-                           (*error_message_ptr)(code) );
+                           error_message_ptr(code) );
         goto error;
     }
 
@@ -952,7 +952,7 @@ int Condor_Auth_Kerberos :: authenticate_server_kerberos_1()
     // state in ticket_ member variable.
 
     if (keytab) {
-        (*krb5_kt_close_ptr)(krb_context_, keytab);
+        krb5_kt_close_ptr(krb_context_, keytab);
     }
 
     if (request.data) {
@@ -979,11 +979,11 @@ int Condor_Auth_Kerberos :: authenticate_server_kerberos_1()
     // Free up anything we allocated since we are done (failed).
     //------------------------------------------
     if (ticket_) {
-        (*krb5_free_ticket_ptr)(krb_context_, ticket_);
+        krb5_free_ticket_ptr(krb_context_, ticket_);
     }
 
     if (keytab) {
-        (*krb5_kt_close_ptr)(krb_context_, keytab);
+        krb5_kt_close_ptr(krb_context_, keytab);
     }
 
     if (request.data) {
@@ -1033,10 +1033,10 @@ int Condor_Auth_Kerberos :: authenticate_server_kerberos_2()
     }
 
     // copy the session key
-    if ((code = (*krb5_copy_keyblock_ptr)(krb_context_, 
+    if ((code = krb5_copy_keyblock_ptr(krb_context_, 
                                   ticket_->enc_part2->session,
                                   &sessionKey_))){
-        dprintf(D_SECURITY, "4: Kerberos server authentication error:%s\n", (*error_message_ptr)(code));
+        dprintf(D_SECURITY, "4: Kerberos server authentication error:%s\n", error_message_ptr(code));
         goto error;
     }
     
@@ -1076,7 +1076,7 @@ int Condor_Auth_Kerberos :: authenticate_server_kerberos_2()
     //------------------------------------------
     // Free up some stuff
     //------------------------------------------
-    (*krb5_free_ticket_ptr)(krb_context_, ticket_);
+    krb5_free_ticket_ptr(krb_context_, ticket_);
 
     return rc;
 }
@@ -1098,12 +1098,12 @@ int Condor_Auth_Kerberos :: client_mutual_authenticate()
         return KERBEROS_DENY;
     }
     
-    if ((code = (*krb5_rd_rep_ptr)(krb_context_, auth_context_, &request, &rep))) {
+    if ((code = krb5_rd_rep_ptr(krb_context_, auth_context_, &request, &rep))) {
         goto error;
     }
     
     if (rep) {
-        (*krb5_free_ap_rep_enc_part_ptr)(krb_context_, rep);
+        krb5_free_ap_rep_enc_part_ptr(krb_context_, rep);
     }
     
     message = KERBEROS_GRANT;
@@ -1123,7 +1123,7 @@ int Condor_Auth_Kerberos :: client_mutual_authenticate()
  error:
     free(request.data);
     
-    dprintf( D_ALWAYS, "KERBEROS: %s\n", (*error_message_ptr)(code) );
+    dprintf( D_ALWAYS, "KERBEROS: %s\n", error_message_ptr(code) );
     return KERBEROS_DENY;
 }
 
@@ -1136,22 +1136,22 @@ int Condor_Auth_Kerberos :: init_kerberos_context()
 
     // kerberos context_
     if (krb_context_ == NULL) {
-        if ((code = (*krb5_init_context_ptr)(&krb_context_))) {
+        if ((code = krb5_init_context_ptr(&krb_context_))) {
             goto error;
         }
     }
 
-    if ((code = (*krb5_auth_con_init_ptr)(krb_context_, &auth_context_))) {
+    if ((code = krb5_auth_con_init_ptr(krb_context_, &auth_context_))) {
         goto error;
     }
 
-    if ((code = (*krb5_auth_con_setflags_ptr)(krb_context_, 
+    if ((code = krb5_auth_con_setflags_ptr(krb_context_, 
                                       auth_context_, 
                                       KRB5_AUTH_CONTEXT_DO_SEQUENCE))) {
         goto error;
     }
         
-    if ((code = (*krb5_auth_con_genaddrs_ptr)(krb_context_, 
+    if ((code = krb5_auth_con_genaddrs_ptr(krb_context_, 
                                       auth_context_, 
                                       mySock_->get_file_desc(),
                                       KRB5_AUTH_CONTEXT_GENERATE_LOCAL_FULL_ADDR|
@@ -1165,7 +1165,7 @@ int Condor_Auth_Kerberos :: init_kerberos_context()
     // allowed. This call should be a noop, but just in case it can fail
     // and that's a useful indicator of problems on other platforms, leave
     // it in place for them.
-    if ((code = (*krb5_auth_con_getaddrs_ptr)(krb_context_,
+    if ((code = krb5_auth_con_getaddrs_ptr(krb_context_,
                                       auth_context_,
                                       nullptr,
                                       nullptr))) {
@@ -1183,7 +1183,7 @@ int Condor_Auth_Kerberos :: init_kerberos_context()
     return TRUE;
  error:
     dprintf( D_ALWAYS, "Unable to initialize kerberos: %s\n",
-			 (*error_message_ptr)(code) );
+			 error_message_ptr(code) );
     return FALSE;
 }
 
@@ -1195,10 +1195,10 @@ int Condor_Auth_Kerberos :: map_kerberos_name(krb5_principal * princ_to_map)
     //------------------------------------------
     // Decode the client name
     //------------------------------------------    
-    if ((code = (*krb5_unparse_name_ptr)(krb_context_, 
+    if ((code = krb5_unparse_name_ptr(krb_context_, 
                                  *princ_to_map, 
                                  &client))){
-		dprintf(D_ALWAYS, "%s\n", (*error_message_ptr)(code));
+		dprintf(D_ALWAYS, "%s\n", error_message_ptr(code));
 		return FALSE;
     } 
     else {
@@ -1428,7 +1428,7 @@ int Condor_Auth_Kerberos :: init_server_info()
         if (!service)
             service = strdup(STR_DEFAULT_CONDOR_SERVICE);
 
-        err = (*krb5_sname_to_principal_ptr)(krb_context_, remoteName.c_str(), service, KRB5_NT_SRV_HST, &server_);
+        err = krb5_sname_to_principal_ptr(krb_context_, remoteName.c_str(), service, KRB5_NT_SRV_HST, &server_);
         dprintf(D_SECURITY, "KERBEROS: get remote server principal for \"%s/%s\"%s\n",
                 service, remoteName.c_str(), err ? " FAILED" : "");
 
@@ -1442,7 +1442,7 @@ int Condor_Auth_Kerberos :: init_server_info()
         // if server principal is set then this overrides detection
         if (principal) {
 
-            err = (*krb5_parse_name_ptr)(krb_context_, principal, &krb_principal_);
+            err = krb5_parse_name_ptr(krb_context_, principal, &krb_principal_);
             dprintf(D_SECURITY, "KERBEROS: set local server principal from %s = \"%s\"%s\n",
                     STR_KERBEROS_SERVER_PRINCIPAL, principal, err ? " FAILED" : "");
 
@@ -1454,7 +1454,7 @@ int Condor_Auth_Kerberos :: init_server_info()
             if (!service)
                 service = strdup(STR_DEFAULT_CONDOR_SERVICE);
 
-            err = (*krb5_sname_to_principal_ptr)(krb_context_, NULL, service, KRB5_NT_SRV_HST, &krb_principal_);
+            err = krb5_sname_to_principal_ptr(krb_context_, NULL, service, KRB5_NT_SRV_HST, &krb_principal_);
             dprintf(D_SECURITY, "KERBEROS: get local server principal for \"%s\" %s\n",
                     service, err ? " FAILED" : "");
 
@@ -1464,7 +1464,7 @@ int Condor_Auth_Kerberos :: init_server_info()
 
     if (IsDebugLevel(D_SECURITY) && !err) {
         char *tmp;
-        if (!(*krb5_unparse_name_ptr)(krb_context_, mySock_->isClient() ? krb_principal_ : server_, &tmp))
+        if (!krb5_unparse_name_ptr(krb_context_, mySock_->isClient() ? krb_principal_ : server_, &tmp))
 	    dprintf(D_SECURITY, "KERBEROS: the server principal is \"%s\"\n", tmp);
         free(tmp);
     }
@@ -1532,7 +1532,7 @@ void Condor_Auth_Kerberos :: setRemoteAddress()
     krb5_address** remoteAddrs = (krb5_address**)calloc(2, sizeof(krb5_address*));
 
     // Get remote host's address first
-    if ((code = (*krb5_auth_con_getaddrs_ptr)(krb_context_, 
+    if ((code = krb5_auth_con_getaddrs_ptr(krb_context_, 
                                       auth_context_, 
                                       localAddrs,
                                       remoteAddrs))) {
@@ -1545,19 +1545,19 @@ void Condor_Auth_Kerberos :: setRemoteAddress()
         memcpy(&(in.s_addr), (remoteAddrs[0])[0].contents, sizeof(in_addr));
         setRemoteHost(inet_ntoa(in));
     }
-    (*krb5_free_addresses_ptr)(krb_context_, localAddrs);
-    (*krb5_free_addresses_ptr)(krb_context_, remoteAddrs);
+    krb5_free_addresses_ptr(krb_context_, localAddrs);
+    krb5_free_addresses_ptr(krb_context_, remoteAddrs);
     
     dprintf(D_SECURITY, "Remote host is %s\n", getRemoteHost());
 
     return;
 
  error:
-    (*krb5_free_addresses_ptr)(krb_context_, localAddrs);
-    (*krb5_free_addresses_ptr)(krb_context_, remoteAddrs);
+    krb5_free_addresses_ptr(krb_context_, localAddrs);
+    krb5_free_addresses_ptr(krb_context_, remoteAddrs);
 
     dprintf( D_ALWAYS, "KERBEROS: Unable to obtain remote address: %s\n",
-			 (*error_message_ptr)(code) );
+			 error_message_ptr(code) );
 }
 
 int Condor_Auth_Kerberos :: endTime() const
@@ -1581,9 +1581,9 @@ void Condor_Auth_Kerberos :: dprintf_krb5_principal ( int deblevel,
 
 	if (p) {
 		char * tmpprincname = 0;
-		if (int code = (*krb5_unparse_name_ptr)(krb_context_, p, &tmpprincname)){
+		if (int code = krb5_unparse_name_ptr(krb_context_, p, &tmpprincname)){
 			dprintf( deblevel, fmt, "ERROR FOLLOWS");
-			dprintf( deblevel, fmt, (*error_message_ptr)(code));
+			dprintf( deblevel, fmt, error_message_ptr(code));
 		} else {
 			dprintf( deblevel, fmt, tmpprincname );
 		}

--- a/src/condor_io/condor_auth_munge.cpp
+++ b/src/condor_io/condor_auth_munge.cpp
@@ -110,16 +110,16 @@ int Condor_Auth_MUNGE::authenticate(const char * /* remoteHost */, CondorError* 
 		// For tools and daemons not started as root, this
 		// is a no-op.
 		priv_state saved_priv = set_condor_priv();
-		err = (*munge_encode_ptr) (&munge_token, NULL, key, 24);
+		err = munge_encode_ptr(&munge_token, NULL, key, 24);
 		set_priv(saved_priv);
 
 		if ( err != EMUNGE_SUCCESS ) {
-			dprintf(D_ALWAYS, "AUTHENTICATE_MUNGE: Client error: %i: %s\n", err, (*munge_strerror_ptr) (err));
-			errstack->pushf("MUNGE", 1000,  "Client error: %i: %s", err, (*munge_strerror_ptr) (err));
+			dprintf(D_ALWAYS, "AUTHENTICATE_MUNGE: Client error: %i: %s\n", err, munge_strerror_ptr(err));
+			errstack->pushf("MUNGE", 1000,  "Client error: %i: %s", err, munge_strerror_ptr(err));
 
 			// send the text of the error as the token so we stay sync in on
 			// the wire protocol and the other side can print out a reason.
-			munge_token = strdup((*munge_strerror_ptr)(err));
+			munge_token = strdup(munge_strerror_ptr(err));
 			client_result = -1;
 		} else {
 			// success on client side
@@ -194,12 +194,12 @@ int Condor_Auth_MUNGE::authenticate(const char * /* remoteHost */, CondorError* 
 
 		unsigned char *key;
 		int   len;
-		err = (*munge_decode_ptr) (munge_token, NULL, (void**)&key, &len, &uid, &gid);
+		err = munge_decode_ptr(munge_token, NULL, (void**)&key, &len, &uid, &gid);
 		free(munge_token);
 
 		if (err != EMUNGE_SUCCESS) {
-			dprintf(D_ALWAYS, "AUTHENTICATE_MUNGE: Server error: %i: %s.\n", err, (*munge_strerror_ptr)(err));
-			errstack->pushf("MUNGE", 1005, "Server error: %i: %s", err, (*munge_strerror_ptr)(err));
+			dprintf(D_ALWAYS, "AUTHENTICATE_MUNGE: Server error: %i: %s.\n", err, munge_strerror_ptr(err));
+			errstack->pushf("MUNGE", 1005, "Server error: %i: %s", err, munge_strerror_ptr(err));
 			server_result = -1;
 		} else {
 			char *tmpOwner = nullptr;

--- a/src/condor_io/condor_auth_ssl.cpp
+++ b/src/condor_io/condor_auth_ssl.cpp
@@ -441,15 +441,15 @@ int Condor_Auth_SSL::authenticate(const char * /* remoteHost */, CondorError* er
             ouch( "Error creating buffer for SSL authentication\n" );
             m_auth_state->m_client_status = AUTH_SSL_ERROR;
         }
-        if( !(m_auth_state->m_ssl = (*SSL_new_ptr)( m_auth_state->m_ctx )) ) {
+        if( !(m_auth_state->m_ssl = SSL_new_ptr( m_auth_state->m_ctx )) ) {
             ouch( "Error creating SSL context\n" );
             m_auth_state->m_client_status = AUTH_SSL_ERROR;
         } else {
-            (*SSL_set_bio_ptr)( m_auth_state->m_ssl, m_auth_state->m_conn_in,
+            SSL_set_bio_ptr( m_auth_state->m_ssl, m_auth_state->m_conn_in,
 				m_auth_state->m_conn_out );
         }
 		if (g_last_verify_error_index >= 0)
-			(*SSL_set_ex_data_ptr)( m_auth_state->m_ssl, g_last_verify_error_index, &m_last_verify_error);
+			SSL_set_ex_data_ptr( m_auth_state->m_ssl, g_last_verify_error_index, &m_last_verify_error);
         m_auth_state->m_server_status = client_share_status( m_auth_state->m_client_status );
         if( m_auth_state->m_server_status != AUTH_SSL_A_OK ||
 		m_auth_state->m_client_status != AUTH_SSL_A_OK ) {
@@ -463,14 +463,14 @@ int Condor_Auth_SSL::authenticate(const char * /* remoteHost */, CondorError* er
         while( !m_auth_state->m_done ) {
             if( m_auth_state->m_client_status != AUTH_SSL_HOLDING ) {
                 ouch("Trying to connect.\n");
-                m_auth_state->m_ssl_status = (*SSL_connect_ptr)( m_auth_state->m_ssl );
+                m_auth_state->m_ssl_status = SSL_connect_ptr( m_auth_state->m_ssl );
                 dprintf(D_SECURITY, "Tried to connect: %d\n", m_auth_state->m_ssl_status);
             }
             if( m_auth_state->m_ssl_status < 1 ) {
                 m_auth_state->m_client_status = AUTH_SSL_QUITTING;
                 m_auth_state->m_done = 1;
                 //ouch( "Error performing SSL authentication\n" );
-                m_auth_state->m_err = (*SSL_get_error_ptr)( m_auth_state->m_ssl, m_auth_state->m_ssl_status );
+                m_auth_state->m_err = SSL_get_error_ptr( m_auth_state->m_ssl, m_auth_state->m_ssl_status );
                 switch( m_auth_state->m_err ) {
                 case SSL_ERROR_ZERO_RETURN:
                     ouch("SSL: connection has been closed.\n");
@@ -496,7 +496,7 @@ int Condor_Auth_SSL::authenticate(const char * /* remoteHost */, CondorError* er
                     ouch("SSL: Syscall.\n" );
                     break;
                 case SSL_ERROR_SSL:
-                    dprintf(D_SECURITY, "SSL: library failure: %s\n", (*ERR_error_string_ptr)((*ERR_get_error_ptr)(), NULL));
+                    dprintf(D_SECURITY, "SSL: library failure: %s\n", ERR_error_string_ptr((*ERR_get_error_ptr)(), NULL));
                     break;
                 default:
                     ouch("SSL: unknown error?\n" );
@@ -539,7 +539,7 @@ int Condor_Auth_SSL::authenticate(const char * /* remoteHost */, CondorError* er
         }
         dprintf(D_SECURITY,"Client trying post connection check.\n");
         dprintf(D_SECURITY, "Cipher used: %s.\n",
-            (*SSL_CIPHER_get_name_ptr)((*SSL_get_current_cipher_ptr)(m_auth_state->m_ssl)));
+            SSL_CIPHER_get_name_ptr((*SSL_get_current_cipher_ptr)(m_auth_state->m_ssl)));
 
         if((m_auth_state->m_err = post_connection_check(
                 m_auth_state->m_ssl, AUTH_SSL_ROLE_CLIENT )) != X509_V_OK ) {
@@ -586,11 +586,11 @@ int Condor_Auth_SSL::authenticate(const char * /* remoteHost */, CondorError* er
                 break;
             }
             if( m_auth_state->m_client_status != AUTH_SSL_HOLDING) {
-                m_auth_state->m_ssl_status = (*SSL_read_ptr)(m_auth_state->m_ssl, 
+                m_auth_state->m_ssl_status = SSL_read_ptr(m_auth_state->m_ssl, 
 									  m_auth_state->m_session_key, AUTH_SSL_SESSION_KEY_LEN);
             }
             if(m_auth_state->m_ssl_status < 1) {
-                m_auth_state->m_err = (*SSL_get_error_ptr)( m_auth_state->m_ssl,
+                m_auth_state->m_err = SSL_get_error_ptr( m_auth_state->m_ssl,
 					m_auth_state->m_ssl_status);
                 switch( m_auth_state->m_err ) {
                 case SSL_ERROR_WANT_READ:
@@ -658,11 +658,11 @@ int Condor_Auth_SSL::authenticate(const char * /* remoteHost */, CondorError* er
 				}
 
 				if( m_auth_state->m_client_status != AUTH_SSL_HOLDING) {
-					m_auth_state->m_ssl_status = (*SSL_write_ptr)(m_auth_state->m_ssl,
+					m_auth_state->m_ssl_status = SSL_write_ptr(m_auth_state->m_ssl,
 						&network_bytes[0], sizeof(network_size) + scitoken.size());
 				}
 				if(m_auth_state->m_ssl_status < 1) {
-					m_auth_state->m_err = (*SSL_get_error_ptr)( m_auth_state->m_ssl,
+					m_auth_state->m_err = SSL_get_error_ptr( m_auth_state->m_ssl,
 						m_auth_state->m_ssl_status);
 					switch( m_auth_state->m_err ) {
 						case SSL_ERROR_WANT_READ:
@@ -730,12 +730,12 @@ int Condor_Auth_SSL::authenticate(const char * /* remoteHost */, CondorError* er
             ouch( "Error creating buffer for SSL authentication\n" );
             m_auth_state->m_server_status = AUTH_SSL_ERROR;
         }
-        if (!(m_auth_state->m_ssl = (*SSL_new_ptr)(m_auth_state->m_ctx))) {
+        if (!(m_auth_state->m_ssl = SSL_new_ptr(m_auth_state->m_ctx))) {
             ouch("Error creating SSL context\n");
             m_auth_state->m_server_status = AUTH_SSL_ERROR;
         } else {
             // SSL_set_accept_state(ssl); // Do I really have to do this?
-            (*SSL_set_bio_ptr)(m_auth_state->m_ssl, m_auth_state->m_conn_in,
+            SSL_set_bio_ptr(m_auth_state->m_ssl, m_auth_state->m_conn_in,
 				m_auth_state->m_conn_out);
         }
 		if( send_status( m_auth_state->m_server_status ) == AUTH_SSL_ERROR ) {
@@ -777,13 +777,13 @@ Condor_Auth_SSL::authenticate_server_connect(CondorError *errstack, bool non_blo
         while( !m_auth_state->m_done ) {
             if( m_auth_state->m_server_status != AUTH_SSL_HOLDING ) {
                 ouch("Trying to accept.\n");
-                m_auth_state->m_ssl_status = (*SSL_accept_ptr)( m_auth_state->m_ssl );
+                m_auth_state->m_ssl_status = SSL_accept_ptr( m_auth_state->m_ssl );
                 dprintf(D_SECURITY, "Accept returned %d.\n", m_auth_state->m_ssl_status);
             }
             if( m_auth_state->m_ssl_status < 1 ) {
                 m_auth_state->m_server_status = AUTH_SSL_QUITTING;
                 m_auth_state->m_done = 1;
-                m_auth_state->m_err = (*SSL_get_error_ptr)( m_auth_state->m_ssl,
+                m_auth_state->m_err = SSL_get_error_ptr( m_auth_state->m_ssl,
 					m_auth_state->m_ssl_status );
                 switch( m_auth_state->m_err ) {
                 case SSL_ERROR_ZERO_RETURN:
@@ -810,7 +810,7 @@ Condor_Auth_SSL::authenticate_server_connect(CondorError *errstack, bool non_blo
                     ouch("SSL: Syscall.\n" );
                     break;
                 case SSL_ERROR_SSL:
-                    dprintf(D_SECURITY, "SSL: library failure: %s\n", (*ERR_error_string_ptr)((*ERR_get_error_ptr)(), NULL));
+                    dprintf(D_SECURITY, "SSL: library failure: %s\n", ERR_error_string_ptr((*ERR_get_error_ptr)(), NULL));
                     break;
                 default:
                     ouch("SSL: unknown error?\n" );
@@ -907,11 +907,11 @@ Condor_Auth_SSL::authenticate_server_key(CondorError *errstack, bool non_blockin
                 break;
             }
             if( m_auth_state->m_server_status != AUTH_SSL_HOLDING ) {
-                m_auth_state->m_ssl_status = (*SSL_write_ptr)(m_auth_state->m_ssl, 
+                m_auth_state->m_ssl_status = SSL_write_ptr(m_auth_state->m_ssl, 
 									   m_auth_state->m_session_key, AUTH_SSL_SESSION_KEY_LEN);
             }
             if(m_auth_state->m_ssl_status < 1) {
-                m_auth_state->m_err = (*SSL_get_error_ptr)( m_auth_state->m_ssl,
+                m_auth_state->m_err = SSL_get_error_ptr( m_auth_state->m_ssl,
 					m_auth_state->m_ssl_status);
                 switch( m_auth_state->m_err ) {
                 case SSL_ERROR_WANT_READ:
@@ -1003,13 +1003,13 @@ Condor_Auth_SSL::authenticate_server_scitoken(CondorError *errstack, bool non_bl
 			}
 			if (m_auth_state->m_token_length >= 0) {
 				token_contents.resize(m_auth_state->m_token_length + sizeof(uint32_t), 0);
-				m_auth_state->m_ssl_status = (*SSL_read_ptr)(m_auth_state->m_ssl,
+				m_auth_state->m_ssl_status = SSL_read_ptr(m_auth_state->m_ssl,
 					static_cast<void*>(&token_contents[0]),
 					m_auth_state->m_token_length + sizeof(uint32_t));
 			}
 		}
 		if(m_auth_state->m_ssl_status < 1) {
-			m_auth_state->m_err = (*SSL_get_error_ptr)( m_auth_state->m_ssl,
+			m_auth_state->m_err = SSL_get_error_ptr( m_auth_state->m_ssl,
 				m_auth_state->m_ssl_status);
 			switch( m_auth_state->m_err ) {
 			case SSL_ERROR_WANT_READ:
@@ -1163,7 +1163,7 @@ Condor_Auth_SSL::authenticate_finish(CondorError * /*errstack*/, bool /*non_bloc
 		setRemoteUser("scitokens");
 		setAuthenticatedName( m_scitokens_auth_name.c_str() );
 	} else {
-		X509 *peer = (*SSL_get_peer_certificate_ptr)(m_auth_state->m_ssl);
+		X509 *peer = SSL_get_peer_certificate_ptr(m_auth_state->m_ssl);
 		if (peer) {
 			X509_NAME_oneline(X509_get_subject_name(peer), subjectname, 1024);
 			(*X509_free)(peer);
@@ -1337,12 +1337,12 @@ Condor_Auth_SSL::unwrap(const char *   input,
 int Condor_Auth_SSL :: init_OpenSSL(void)
 {
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-    if (!(*SSL_library_init_ptr)()) {
+    if (!SSL_library_init_ptr()) {
         return AUTH_SSL_ERROR;
     }
-    (*SSL_load_error_strings_ptr)();
+    SSL_load_error_strings_ptr();
 #else
-    if (!(*OPENSSL_init_ssl_ptr)(OPENSSL_INIT_LOAD_SSL_STRINGS \
+    if (!OPENSSL_init_ssl_ptr(OPENSSL_INIT_LOAD_SSL_STRINGS \
                                | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL)) {
         return AUTH_SSL_ERROR;
     }
@@ -1393,8 +1393,8 @@ int verify_callback(int ok, X509_STORE_CTX *store)
         dprintf( D_SECURITY, "  subject  = %s\n", data );
         dprintf( D_SECURITY, "  err %i:%s\n", err, X509_verify_cert_error_string( err ) );
 
-		const SSL* ssl = (const SSL*)(*X509_STORE_CTX_get_ex_data_ptr)(store, (*SSL_get_ex_data_X509_STORE_CTX_idx_ptr)());
-		Condor_Auth_SSL::LastVerifyError *verify_ptr = (Condor_Auth_SSL::LastVerifyError *)(g_last_verify_error_index >= 0 ? (*SSL_get_ex_data_ptr)(ssl, g_last_verify_error_index) : nullptr);
+		const SSL* ssl = (const SSL*)X509_STORE_CTX_get_ex_data_ptr(store, (*SSL_get_ex_data_X509_STORE_CTX_idx_ptr)());
+		Condor_Auth_SSL::LastVerifyError *verify_ptr = (Condor_Auth_SSL::LastVerifyError *)(g_last_verify_error_index >= 0 ? SSL_get_ex_data_ptr(ssl, g_last_verify_error_index) : nullptr);
 		if (verify_ptr) verify_ptr->m_skip_error = 0;
 
 		if (verify_ptr && ((err == X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT) ||
@@ -1438,7 +1438,7 @@ int verify_callback(int ok, X509_STORE_CTX *store)
 					unsigned char md[EVP_MAX_MD_SIZE];
 					auto digest = EVP_get_digestbyname("sha256");
 					unsigned int len;
-					if (1 != (*X509_digest_ptr)(cert, digest, md, &len)) {
+					if (1 != X509_digest_ptr(cert, digest, md, &len)) {
 						dprintf(D_SECURITY, "Failed to create a digest of the provided X.509 certificate.\n");
 						return ok;
 					}
@@ -1678,7 +1678,7 @@ long Condor_Auth_SSL :: post_connection_check(SSL *ssl, int role )
      * require a client certificate.
      * (Comment from book.  -Ian)
      */
-	cert = (*SSL_get_peer_certificate_ptr)(ssl);
+	cert = SSL_get_peer_certificate_ptr(ssl);
 	if( cert == NULL ) {
 		if (mySock_->isClient()) {
 			dprintf(D_SECURITY,"SSL_get_peer_certificate returned null.\n" );
@@ -1706,7 +1706,7 @@ long Condor_Auth_SSL :: post_connection_check(SSL *ssl, int role )
 		X509_free( cert );
 		ouch("Server role: returning from post connection check.\n");
 
-		return (*SSL_get_verify_result_ptr)( ssl );
+		return SSL_get_verify_result_ptr( ssl );
 	} // else ROLE_CLIENT: check dns (arg 2) against CN and the SAN
 
 	if (param_boolean("SSL_SKIP_HOST_CHECK", false)) {
@@ -1809,7 +1809,7 @@ success:
     
 		X509_free(cert);
 
-		auto verify_result = (*SSL_get_verify_result_ptr)( ssl );
+		auto verify_result = SSL_get_verify_result_ptr( ssl );
 
 		if ((verify_result == X509_V_OK) && mySock_->isClient() && !m_host_alias.empty() &&
 			!m_last_verify_error.m_used_known_host)
@@ -1883,26 +1883,26 @@ SSL_CTX *Condor_Auth_SSL :: setup_ssl_ctx( bool is_server )
     if (!m_scitokens_file.empty())
 	dprintf( D_SECURITY, "SCITOKENSFILE:   '%s'\n", m_scitokens_file.c_str()   );
         
-    ctx = (*SSL_CTX_new_ptr)( (*SSL_method_ptr)(  ) );
+    ctx = SSL_CTX_new_ptr( (*SSL_method_ptr)(  ) );
 	if(!ctx) {
 		ouch( "Error creating new SSL context.\n");
 		goto setup_server_ctx_err;
 	}
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-	(*SSL_CTX_ctrl_ptr)( ctx, SSL_CTRL_OPTIONS, SSL_OP_NO_SSLv2, NULL );
-	(*SSL_CTX_ctrl_ptr)( ctx, SSL_CTRL_OPTIONS, SSL_OP_NO_SSLv3, NULL );
+	SSL_CTX_ctrl_ptr( ctx, SSL_CTRL_OPTIONS, SSL_OP_NO_SSLv2, NULL );
+	SSL_CTX_ctrl_ptr( ctx, SSL_CTRL_OPTIONS, SSL_OP_NO_SSLv3, NULL );
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L
-	(*SSL_CTX_ctrl_ptr)( ctx, SSL_CTRL_OPTIONS, SSL_OP_NO_TLSv1, NULL );
-	(*SSL_CTX_ctrl_ptr)( ctx, SSL_CTRL_OPTIONS, SSL_OP_NO_TLSv1_1, NULL );
+	SSL_CTX_ctrl_ptr( ctx, SSL_CTRL_OPTIONS, SSL_OP_NO_TLSv1, NULL );
+	SSL_CTX_ctrl_ptr( ctx, SSL_CTRL_OPTIONS, SSL_OP_NO_TLSv1_1, NULL );
 #endif
 #else
-	(*SSL_CTX_set_options_ptr)( ctx, SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1);
+	SSL_CTX_set_options_ptr( ctx, SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1);
 #endif
 
 	// Only load the verify locations if they are explicitly specified;
 	// otherwise, we will use the system default.
-    if( (cafile || cadir) && (*SSL_CTX_load_verify_locations_ptr)( ctx, cafile, cadir ) != 1 ) {
+    if( (cafile || cadir) && SSL_CTX_load_verify_locations_ptr( ctx, cafile, cadir ) != 1 ) {
         auto error_number = ERR_get_error();
 		auto error_string = error_number ? ERR_error_string(error_number, nullptr) : "Unknown error";
         dprintf(D_SECURITY, "SSL Auth: Error loading CA file (%s) and/or directory (%s): %s \n",
@@ -1911,11 +1911,11 @@ SSL_CTX *Condor_Auth_SSL :: setup_ssl_ctx( bool is_server )
     }
     {
         TemporaryPrivSentry sentry(PRIV_ROOT);
-        if( certfile && (*SSL_CTX_use_certificate_chain_file_ptr)( ctx, certfile ) != 1 ) {
+        if( certfile && SSL_CTX_use_certificate_chain_file_ptr( ctx, certfile ) != 1 ) {
             ouch( "Error loading certificate from file\n" );
             goto setup_server_ctx_err;
         }
-        if( keyfile && (*SSL_CTX_use_PrivateKey_file_ptr)( ctx, keyfile, SSL_FILETYPE_PEM) != 1 ) {
+        if( keyfile && SSL_CTX_use_PrivateKey_file_ptr( ctx, keyfile, SSL_FILETYPE_PEM) != 1 ) {
             ouch( "Error loading private key from file\n" );
             goto setup_server_ctx_err;
         }
@@ -1925,8 +1925,8 @@ SSL_CTX *Condor_Auth_SSL :: setup_ssl_ctx( bool is_server )
 		g_last_verify_error_index = CRYPTO_get_ex_new_index(CRYPTO_EX_INDEX_SSL, 0, const_cast<char *>("last verify error"), nullptr, nullptr, nullptr);
 
     (*SSL_CTX_set_verify_ptr)( ctx, SSL_VERIFY_PEER, verify_callback ); 
-    (*SSL_CTX_set_verify_depth_ptr)( ctx, 4 ); // TODO arbitrary?
-    if((*SSL_CTX_set_cipher_list_ptr)( ctx, cipherlist ) != 1 ) {
+    SSL_CTX_set_verify_depth_ptr( ctx, 4 ); // TODO arbitrary?
+    if(SSL_CTX_set_cipher_list_ptr( ctx, cipherlist ) != 1 ) {
         ouch( "Error setting cipher list (no valid ciphers)\n" );
         goto setup_server_ctx_err;
     }
@@ -1935,7 +1935,7 @@ SSL_CTX *Condor_Auth_SSL :: setup_ssl_ctx( bool is_server )
 		// Enable the automatic ephemeral ECDH setup.
 		// This is automatic in OpenSSL 1.1.0+ and this value has been
 		// removed there.
-	(*SSL_CTX_ctrl_ptr)( ctx, SSL_CTRL_SET_ECDH_AUTO, 1, NULL );
+	SSL_CTX_ctrl_ptr( ctx, SSL_CTRL_SET_ECDH_AUTO, 1, NULL );
 #endif
 
     if(cafile)          free(cafile);
@@ -1950,7 +1950,7 @@ SSL_CTX *Condor_Auth_SSL :: setup_ssl_ctx( bool is_server )
     if(certfile)        free(certfile);
     if(keyfile)         free(keyfile);
     if(cipherlist)      free(cipherlist);
-	if(ctx)		        (*SSL_CTX_free_ptr)(ctx);
+	if(ctx)		        SSL_CTX_free_ptr(ctx);
     return NULL;
 }
 


### PR DESCRIPTION
Clean up security code call sites where we call through functin pointers to use the normal syntax, not the explicitly derefenced pointer synatx

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
