### PR TITLE
V10_0-HTCONDOR-1385-despam-proclog

### DIFF
--- a/docs/version-history/lts-versions-10-0.rst
+++ b/docs/version-history/lts-versions-10-0.rst
@@ -30,6 +30,12 @@ Bugs Fixed:
   files.
   :jira:`1354`
 
+- Fixed a bug where on certain Linux kernels, the ProcLog would be filled
+  with thousands of errors of the form  "Internal cgroup error when 
+  retrieving iowait statistics".  This error was harmless, but filled
+  the ProcLog with noise.
+  :jira:`1385`
+
 - Fixed bug where certain **submit file** variables like ``accounting_group`` and
   ``accounting_group_user`` couldn't be declared specifically for DAGMan jobs because
   DAGMan would always write over the variables at job submission time.

--- a/src/condor_procd/proc_family.cpp
+++ b/src/condor_procd/proc_family.cpp
@@ -589,6 +589,14 @@ ProcFamily::aggregate_usage_cgroup_io_wait(ProcFamilyUsage* usage) {
 	}
 
 	// kernels with BFQ enabled don't have io_wait_time, don't spam logs if it isn't here
+
+	// Errors like ENOENT are encoded by returning ECGOTHER, and saving the real kernel errno
+	// in cgroup_get_last_errno.  cgroup error start at 50,000, so there's no
+	// worry about collisions with Linux errno
+	if (ret == ECGOTHER) {
+		ret = cgroup_get_last_errno();
+	}
+
 	if ((ret != ECGEOF) && (ret != ENOENT)) {
 		dprintf(D_ALWAYS, "Internal cgroup error when retrieving iowait statistics: %s\n", cgroup_strerror(ret));
 		return 1;


### PR DESCRIPTION
Errors of the form

Internal cgroup error when retrieving iowait statistics

no longer appear in the ProcLog when iowait statistics are not available in the blkio cgroup

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
