### PR TITLE
HTCONDOR-1337 fix warnings

### DIFF
--- a/src/condor_unit_tests/OTEST_Env.cpp
+++ b/src/condor_unit_tests/OTEST_Env.cpp
@@ -287,7 +287,6 @@ static const char
 	   *V2R_MISS_BOTH ="=1 two2 three=3",
 	   *ARRAY_SKIP_BAD_STR = "one=1 two2 three=3",
 	   *V2R_SEMI ="one=1 two=2 three=3 semi=" V1_ENV_DELIM,
-	   *V2R_MARK =" one=1 two=2 three=3 semi=" V1_ENV_DELIM ,
 	*V2Q ="\"one=1 two=2 three=3\"",	//V2Quoted format
 	   *V2Q_MISS_NAME = "\"=1 two=2 three=3\"",
 	   *V2Q_MISS_DELIM = "\"one1 two=2 three=3\"",
@@ -315,17 +314,14 @@ static const char
 	   *AD_V1_WIN = "\tEnv = \"one=1|two=2|three=3\"\nEnvDelim = \"|\"", 
 	   *AD_V1_MISS_NAME = "\tEnv = \"=1" V1_ENV_DELIM "two=2" V1_ENV_DELIM "three=3\"",
 	   *AD_V1_MISS_DELIM = "\tEnv = \"one1" V1_ENV_DELIM "two=2" V1_ENV_DELIM "three=3\"",
-	   *AD_V1_MISS_BOTH = "\tEnv = \"=1" V1_ENV_DELIM "two2" V1_ENV_DELIM "three=3\"",
 	   *AD_V1_REP = "\tEnv = \"one=10" V1_ENV_DELIM "two=200" V1_ENV_DELIM "three=3000\"", 
 	   *AD_V1_REP_ADD = "\tEnv = \"one=10" V1_ENV_DELIM "two=200" V1_ENV_DELIM "three=3000" V1_ENV_DELIM "four=4" V1_ENV_DELIM "five=5\"", 
 	*AD_V2 = "\tEnvironment = \"one=1 two=2 three=3\"",	//ClassAd with V2 Env
 	   *AD_V2_MISS_NAME = "\tEnvironment = \"=1 two=2 three=3\"",
 	   *AD_V2_MISS_DELIM = "\tEnvironment = \"one1 two=2 three=3\"",
-	   *AD_V2_MISS_BOTH = "\tEnvironment = \"=1 two2 three=3\"",
 	   *AD_V2_REP = "\tEnvironment = \"one=10 two=200 three=3000\"",
 	   *AD_V2_REP_ADD = "\tEnvironment = \"one=10 two=200 three=3000 four=4 "
 	    	"five=5\"",
-		*AD_V2_SEMI = "\tEnvironment = \"one=1 two=2 three=3 semi=" V1_ENV_DELIM "\"",
 	*ONE = "one=1",	//Single Env Var string
 	   *ONE_MISS_NAME = "=1",
 	   *ONE_MISS_DELIM = "one1",

--- a/src/condor_utils/generic_stats.cpp
+++ b/src/condor_utils/generic_stats.cpp
@@ -304,11 +304,11 @@ void stats_recent_counter_timer::Delete(stats_recent_counter_timer * probe) {
 void stats_recent_counter_timer::Unpublish(ClassAd & ad, const char * pattr) const
 {
    ad.Delete(pattr);
-   MyString attr;
-   attr.formatstr("Recent%s",pattr);
-   ad.Delete(attr.c_str());
-   attr.formatstr("Recent%sRuntime",pattr);
-   ad.Delete(attr.c_str());
+   std::string attr;
+   formatstr(attr, "Recent%s",pattr);
+   ad.Delete(attr);
+   formatstr(attr, "Recent%sRuntime",pattr);
+   ad.Delete(attr);
    ad.Delete(attr.c_str()+6); // +6 to skip "Recent" prefix
 }
 


### PR DESCRIPTION
https://opensciencegrid.atlassian.net/browse/HTCONDOR-1337

Fix a couple of small compiler warnings.  One introduced when we simplified the env object, and left behind some unused data members in a unit test.  The second is a simple string pointer warning.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
