### PR TITLE
HTCONDOR-1419-ephemeral-filesystem

### DIFF
--- a/docs/version-history/lts-versions-10-0.rst
+++ b/docs/version-history/lts-versions-10-0.rst
@@ -24,7 +24,9 @@ New Features:
 
 Bugs Fixed:
 
-- None.
+- Fixed a bug that prevented the starter from properly mounting
+  thinpool provisioned ephemeral scratch directories.
+  :jira:`1419`
 
 .. _lts-version-history-1000:
 

--- a/src/condor_startd.V6/VolumeManager.cpp
+++ b/src/condor_startd.V6/VolumeManager.cpp
@@ -182,7 +182,7 @@ VolumeManager::MountFilesystem(const std::string &device_path, const std::string
     }
 
     if (-1 == chown(mountpoint.c_str(), get_user_uid(), get_user_gid())) {
-        err.pushf("VolumeManager", 14, "Failed to chown the new execute mount to condor user: %s (errno=%d)",
+        err.pushf("VolumeManager", 14, "Failed to chown the new execute mount to user: %s (errno=%d)",
             strerror(errno), errno);
         return false;
     }

--- a/src/condor_startd.V6/VolumeManager.cpp
+++ b/src/condor_startd.V6/VolumeManager.cpp
@@ -181,7 +181,7 @@ VolumeManager::MountFilesystem(const std::string &device_path, const std::string
         return false;
     }
 
-    if (-1 == chown(mountpoint.c_str(), get_real_condor_uid(), get_real_condor_gid())) {
+    if (-1 == chown(mountpoint.c_str(), get_user_uid(), get_user_gid())) {
         err.pushf("VolumeManager", 14, "Failed to chown the new execute mount to condor user: %s (errno=%d)",
             strerror(errno), errno);
         return false;
@@ -304,7 +304,7 @@ VolumeManager::CreateLoopback(const std::string &filename, uint64_t size_kb, Con
 
         // TODO: Would be friendlier to unmount everything and resize instead of failing
     if (backing_stat.st_size < static_cast<off_t>(size_kb*1.02)*1024) {
-        err.pushf("VolumeManager", 6, "Pre-existing loopback file is too small (is %ld, asking for %ld\n)", backing_stat.st_size, (size_kb * 1.02) / 1024);
+        err.pushf("VolumeManager", 6, "Pre-existing loopback file is too small (is %g, asking for %g\n)", (double) backing_stat.st_size, (size_kb * 1.02) * 1024);
         return "";
     }
 
@@ -519,7 +519,7 @@ VolumeManager::UnmountFilesystem(const std::string &mountpoint, CondorError &err
             strerror(errno), errno);
     }
     int exit_status = 0;
-    if (-1 == umount(mountpoint.c_str())) {
+    if (-1 == umount2(mountpoint.c_str(), MNT_DETACH)) {
         exit_status = errno;
         err.pushf("VolumeManager", 17, "Failed to unmount %s: %s (errno=%d)",
             mountpoint.c_str(), strerror(errno), errno);

--- a/src/condor_starter.V6.1/starter.cpp
+++ b/src/condor_starter.V6.1/starter.cpp
@@ -162,40 +162,6 @@ Starter::Init( JobInfoCommunicator* my_jic, const char* original_cwd,
 				 (long)daemonCore->getpid() );
 	}
 
-#ifdef LINUX
-	const char *thinpool = getenv("_CONDOR_THINPOOL");
-	const char *thinpool_vg = getenv("_CONDOR_THINPOOL_VG");
-	const char *thinpool_size = getenv("_CONDOR_THINPOOL_SIZE_KB");
-	if (thinpool && thinpool_vg && thinpool_size) {
-		try {
-			m_lvm_max_size_kb = std::stol(thinpool_size);
-		} catch (...) {
-			m_lvm_max_size_kb = -1;
-		}
-		if (m_lvm_max_size_kb > 0) {
-			CondorError err;
-                        std::string thinpool_str(thinpool), slot_name(getMySlotName());
-                        bool do_encrypt = thinpool_str.substr(thinpool_str.size() - 4, 4) == "-enc";
-                        if (do_encrypt) {
-                            slot_name += "-enc";
-                            thinpool_str = thinpool_str.substr(0, thinpool_str.size() - 4);
-                        }
-			m_volume_mgr.reset(new VolumeManager::Handle(Execute, slot_name, thinpool_str, thinpool_vg, m_lvm_max_size_kb, err));
-			if (!err.empty()) {
-				dprintf(D_ALWAYS, "Failure when setting up filesystem for job: %s\n", err.getFullText().c_str());
-				m_volume_mgr.reset();
-			}
-			m_lvm_thin_volume = slot_name;
-			m_lvm_thin_pool = thinpool_str;
-			m_lvm_volume_group = thinpool_vg;
-			m_lvm_poll_tid = daemonCore->Register_Timer(10, 10,
-				(TimerHandlercpp)&Starter::CheckDiskUsage,
-				"check disk usage", this);
-		}
-	}
-#endif // LINUX
-
-
 		//
 		// We have switched all of these to call the "Remote"
 		// version of the appropriate method. The difference between the 
@@ -1990,6 +1956,40 @@ Starter::createTempExecuteDir( void )
 	WriteAdFiles();
 
 #endif /* WIN32 */
+
+#ifdef LINUX
+	const char *thinpool = getenv("_CONDOR_THINPOOL");
+	const char *thinpool_vg = getenv("_CONDOR_THINPOOL_VG");
+	const char *thinpool_size = getenv("_CONDOR_THINPOOL_SIZE_KB");
+	if (thinpool && thinpool_vg && thinpool_size) {
+		try {
+			m_lvm_max_size_kb = std::stol(thinpool_size);
+		} catch (...) {
+			m_lvm_max_size_kb = -1;
+		}
+		if (m_lvm_max_size_kb > 0) {
+			CondorError err;
+                        std::string thinpool_str(thinpool), slot_name(getMySlotName());
+                        bool do_encrypt = thinpool_str.substr(thinpool_str.size() - 4, 4) == "-enc";
+                        if (do_encrypt) {
+                            slot_name += "-enc";
+                            thinpool_str = thinpool_str.substr(0, thinpool_str.size() - 4);
+                        }
+			m_volume_mgr.reset(new VolumeManager::Handle(WorkingDir, slot_name, thinpool_str, thinpool_vg, m_lvm_max_size_kb, err));
+			if (!err.empty()) {
+				dprintf(D_ALWAYS, "Failure when setting up filesystem for job: %s\n", err.getFullText().c_str());
+				m_volume_mgr.reset();
+			}
+			m_lvm_thin_volume = slot_name;
+			m_lvm_thin_pool = thinpool_str;
+			m_lvm_volume_group = thinpool_vg;
+			m_lvm_poll_tid = daemonCore->Register_Timer(10, 10,
+				(TimerHandlercpp)&Starter::CheckDiskUsage,
+				"check disk usage", this);
+		}
+	}
+#endif // LINUX
+
 
 	// switch to user priv -- it's the owner of the directory we just made
 	priv_state ch_p = set_user_priv();


### PR DESCRIPTION
https://opensciencegrid.atlassian.net/browse/HTCONDOR-1419

This fixes the most egregious bugs with ephemeral scratch mounting.  I suspect there are still filesystem leaks, but this will let us do more testing in CHTC.

WIth this PR, the starter now mounts the fileystems on `$(EXECUTE)/dir_xxx` instead of just `$(EXECUTE)`, and uses the lazy flag to umount them, which works around all kinds of problems.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
