### PR TITLE
HTCONDOR-1403: Multifile curl plugin logic is wrong

### DIFF
--- a/docs/version-history/lts-versions-10-0.rst
+++ b/docs/version-history/lts-versions-10-0.rst
@@ -24,7 +24,10 @@ New Features:
 
 Bugs Fixed:
 
-- None.
+- Fixed bug in where the multifile curl plugin would fail to timeout
+  due lack of upload or download progress if a large amount of bytes
+  where transfered at some point.
+  :jira:`1403`
 
 .. _lts-version-history-1000:
 

--- a/src/condor_filetransfer_plugins/multifile_curl_plugin.cpp
+++ b/src/condor_filetransfer_plugins/multifile_curl_plugin.cpp
@@ -36,18 +36,39 @@ static int xferInfo(void *p, double /* dltotal */, double dlnow, double /* ultot
     struct xferProgress *progress = (struct xferProgress *)p;
     CURL *curl = progress->curl;
     double curTime = 0;
-    
+    static double prevTime = 0; //Previous total time
+    static double dlprev   = 0; //Previous dlnow
+    static double ulprev   = 0; //Previous ulnow
+    /*Get download and upload differences from previous numbers to determine
+    if we should timeout since dlnow and ulnow are totals. This is to prevent
+    a stall out in file tranfser after a large change.*/
+    static double diffTime = 0;
+    static double diff_dl  = 0;
+    static double diff_ul  = 0;
+    diff_dl += dlnow - dlprev;
+    diff_ul += ulnow - ulprev;
+
+    dlprev = dlnow;
+    ulprev = ulnow;
+
     curl_easy_getinfo(curl, CURLINFO_TOTAL_TIME, &curTime);
+    diffTime += curTime - prevTime;
+    prevTime = curTime;
 
     // After 30 seconds, check if we're making forward progress (> 1 byte/s)
     if (curTime > 30) {
+        if (diffTime > 30) {
+            // If this is a download and not making progress, abort
+            if (dlnow > 0 && diffTime > diff_dl) return 1;
 
-        // If this is a download and not making progress, abort
-        if (dlnow > 0 && curTime > dlnow) return 1;
+            // If this is an upload and not making progress, abort
+            if (ulnow > 0 && diffTime > diff_ul) return 1;
 
-        // If this is an upload and not making progress, abort
-        if (ulnow > 0 && curTime > ulnow) return 1;
-
+            //Reset diffs for next check
+            diffTime = 0;
+            diff_dl  = 0;
+            diff_ul  = 0;
+        }
         // If not a single byte has been transferred either direction after 30 seconds, abort
         if (dlnow <= 0 && ulnow <= 0) return 1;
     }


### PR DESCRIPTION
-Changed mutlifile curl plugins logic for transfer progress
 timeout to use upload and download diffs from the last time
 check.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
