### PR TITLE
HTCONDOR-1427-shared_port_test-ipv6

### DIFF
--- a/src/condor_tests/lib_shared_port-check-ports_van.run
+++ b/src/condor_tests/lib_shared_port-check-ports_van.run
@@ -46,23 +46,20 @@ my $collector_path = `condor_config_val collector`; fullchomp($collector_path);
 if ($collector_path =~ /(condor_[a-z\.]+)$/) { $collector_exe = $1; }
 print "collector_exe=$collector_exe\n";
 
-system("condor_config_val -dump enable_ipv4 -v");
-system("condor_config_val -dump enable_ipv6 -v");
-
-my $ipv4 = `condor_config_val ENABLE_IPV4`;
+my $ipv4 = `condor_config_val IPV4_ADDRESS`;
 fullchomp($ipv4);
-print "IPV4=$ipv4\n";
-my $ipv6 = `condor_config_val ENABLE_IPV6`;
+print "IPV4_ADDRESS=$ipv4\n";
+my $ipv6 = `condor_config_val IPV6_ADDRESS`;
 fullchomp($ipv6);
 print "IPV6=$ipv6\n";
 
-if($ipv4 =~ /true/i) {
-	print "adding 1 to $mixedmode since ipv4 is enabled.\n";
+if (length($ipv4) > 1) {
+	print "adding 1 to $mixedmode since ipv4 address is $ipv4.\n";
 	$mixedmode += 1;
 }
 
-if($ipv6 =~ /true/i) {
-	print "adding 1 to $mixedmode since ipv6 is enabled.\n";
+if (length($ipv6) > 1) {
+	print "adding 1 to $mixedmode since ipv6 address is $ipv6.\n";
 	$mixedmode += 1;
 }
 


### PR DESCRIPTION
lib_shared_port-check-ports test counts the number of open TCP ports the shared port has.  It tries to detect if ipv6 should be in play, but did this by running condor_config_val IPV6_ENABLED.  This now returns "auto" by default which isn't useful for the test to decide if it is on or off

Instead, run condor_config_val IPV6_ADDRESS, to see if condor thinks we have a useful ipv6 address.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
