### PR TITLE
draft of plugin change to handle plain SciTokens

### DIFF
--- a/src/condor_filetransfer_plugins/multifile_curl_plugin.cpp
+++ b/src/condor_filetransfer_plugins/multifile_curl_plugin.cpp
@@ -128,6 +128,11 @@ GetToken(const std::string & cred_name, std::string & token) {
 		auto iter = line.begin();
 		while (isspace(*iter)) {iter++;}
 		if (*iter == '#') continue;
+                if (*iter != '{' && *iter != '[' ) {
+                    // we have just a plain base64 token, not wrapped in JSON
+                    token = line;
+                    break;
+                }
 		rapidjson::Document doc;
 		if (doc.Parse(line.c_str()).HasParseError()) {
 			// DO NOT include the error message as part of the exception; the error


### PR DESCRIPTION
This change attempts to make the multifile_curl_plugin for end of job data transfers work with
both types of token credmon -- one which has the scitoken wrapped in a JSON file, the vault one has 
just the base64 encoded  Scitoken.  We check the start of the file for curly braces or brackets; and if 
it has them it unpacks the JSON data, if not it treats the whole file as the raw token.
 
# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
