### PR TITLE
Fixups for TOFU mode.  HTCONDOR-1455

### DIFF
--- a/src/condor_collector.V6/collector_main.cpp
+++ b/src/condor_collector.V6/collector_main.cpp
@@ -62,7 +62,7 @@ void main_init(int argc, char *argv[])
 #endif
 
 	std::string cafile, cakeyfile;
-	if (param_boolean("COLLECTOR_BOOTSTRAP_SSL_CERTIFICATE", false) &&
+	if (param_boolean("COLLECTOR_BOOTSTRAP_SSL_CERTIFICATE", true) &&
 		param(cafile, "TRUST_DOMAIN_CAFILE") &&
 		param(cakeyfile, "TRUST_DOMAIN_CAKEY"))
 	{
@@ -75,8 +75,8 @@ void main_init(int argc, char *argv[])
 		}
 
 		std::string certfile, keyfile;
-		if (param(certfile, "AUTH_SSL_SERVER_CERTFILE") &&
-			param(keyfile, "AUTH_SSL_SERVER_KEYFILE") &&
+		if (param(certfile, "AUTH_SSL_AUTOGENERATE_CERTFILE") &&
+			param(keyfile, "AUTH_SSL_AUTOGENERATE_KEYFILE") &&
 			(0 != access(certfile.c_str(), R_OK)) &&
 			(0 == access(cafile.c_str(), R_OK)) &&
 			(0 == access(cakeyfile.c_str(), R_OK)))

--- a/src/condor_io/condor_secman.cpp
+++ b/src/condor_io/condor_secman.cpp
@@ -3017,6 +3017,11 @@ SecMan::GenerateKeyExchange(CondorError *errstack)
 		return pkey;
 	}
 	pkey.reset(pkey_raw);
+
+	std::unique_ptr<EC_KEY, decltype(&EC_KEY_free)> key(EVP_PKEY_get1_EC_KEY(pkey.get()), &EC_KEY_free);
+	if (key) {
+		EC_KEY_set_asn1_flag(key.get(), OPENSSL_EC_NAMED_CURVE);
+	}
 	return pkey;
 }
 

--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -2490,16 +2490,30 @@ type=path
 tags=condor_auth_ssl
 
 [AUTH_SSL_SERVER_CERTFILE]
-default=/etc/pki/tls/certs/localhost.crt
+default=/etc/pki/tls/certs/localhost.crt,$(AUTH_SSL_AUTOGENERATE_CERTFILE)
 win32_default=
 description=Location of the host X509 certificate
 type=path
 tags=condor_auth_ssl
 
 [AUTH_SSL_SERVER_KEYFILE]
-default=/etc/pki/tls/private/localhost.key
+default=/etc/pki/tls/private/localhost.key,$(AUTH_SSL_AUTOGENERATE_KEYFILE)
 win32_default=
 description=Location of the host private key
+type=path
+tags=condor_auth_ssl
+
+[AUTH_SSL_AUTOGENERATE_CERTFILE]
+default=/etc/condor/hostcert.pem
+win32_default=
+description=Location of the auto-generated host X509 certificate
+type=path
+tags=condor_auth_ssl
+
+[AUTH_SSL_AUTOGENERATE_KEYFILE]
+default=/etc/condor/hostkey.pem
+win32_default=
+description=Location of the auto-generated host private key
 type=path
 tags=condor_auth_ssl
 
@@ -2514,7 +2528,7 @@ type=bool
 tags=io,condor_auth_ssl
 
 [COLLECTOR_BOOTSTRAP_SSL_CERTIFICATE]
-default=false
+default=true
 type=bool
 
 [TRUST_DOMAIN_CAFILE]

--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -2529,6 +2529,7 @@ tags=io,condor_auth_ssl
 
 [COLLECTOR_BOOTSTRAP_SSL_CERTIFICATE]
 default=true
+win32_default=false
 type=bool
 
 [TRUST_DOMAIN_CAFILE]


### PR DESCRIPTION
This puts in a few improvements to TOFU mode:

- Set OpenSSL flag to make generated key usable in a TLS connection.
- Auto-generate in a HTCondor-specific location, avoiding touching system files.
- Treat the cert/key config parameter as a list; iterate down the list until an existing file pair is found.
- Enable bootstrapping by default.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
