### PR TITLE
HTCONDOR-1465-non-rootly-cgroups

### DIFF
--- a/docs/version-history/feature-versions-10-x.rst
+++ b/docs/version-history/feature-versions-10-x.rst
@@ -21,6 +21,12 @@ Release Notes:
   cause jobs that used to go on hold (because they couldn't write their
   ``output`` or ``error`` files, or a remapped output file) to instead succeed.
   :jira:`1325`
+  
+- HTCondor can now put a job in a Linux control (cgroup), not only if it has
+  root privilege, but also if the administrator or some external entity
+  has made the cgroup HTCondor is configured to use writeable by the
+  non-rootly user a personal condor or glidein is running as.
+  :jira:`1465`
 
 New Features:
 


### PR DESCRIPTION
HTCondor should uses cgroups if we can write to them, not just if we are root. This will open the possibility to using cgroups in glideins, after we get support from having the base batch system give the pilot a writeable cgroup Also, it allows testing of cgroups with the regression test suite and a non-rootly HTCondor.

https://opensciencegrid.atlassian.net/browse/HTCONDOR-1465

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
