### PR TITLE
(HTCONDOR-1365)  Make output_destination ignore the output and error files

### DIFF
--- a/docs/version-history/feature-versions-10-x.rst
+++ b/docs/version-history/feature-versions-10-x.rst
@@ -15,6 +15,12 @@ Release Notes:
 
 - This version includes all the updates from :ref:`lts-version-history-1002`.
 
+- This versions changes the semantics of the ``output_destination`` submit
+  command.  It no longer sends the files named by the ``output`` or
+  ``error`` submit commands to the output destination.  Submitters may
+  instead specify those locations with URLs directly.
+  :jira:`1365`
+
 New Features:
 
 - When HTCondor has root, and is running with cgroups, the cgroup the job is

--- a/src/condor_tests/CMakeLists.txt
+++ b/src/condor_tests/CMakeLists.txt
@@ -261,7 +261,13 @@ endif()
 				condor_pl_test(test_htcondor_736 "Test bugs fixed in HTCONDOR-736" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 				condor_pl_test(test_htcondor_809 "Additional file-transfer tests" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 				condor_pl_test(test_activation_metrics "Test activation metrics" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
-				condor_pl_test(test_htcondor_955 "Test output_destination with standard stream names" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
+				# HTCONDOR-1365 changed the behavior of output_destination so
+				# that it no longer sends standard output and error to the
+				# destination.  HTCONDOR-955 made output_destination respect
+				# the `output` and `error` submit file commands' remaps, so
+				# it's no longer relevant.  Leaving the test in source for
+				# now, pending a resolution of backwards-compability issues.
+				# condor_pl_test(test_htcondor_955 "Test output_destination with standard stream names" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 				condor_pl_test(test_xfer_stats_overflow_regression "Test TransferInputStats nested attributes don't overflow" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 				condor_pl_test(test_condor_manifest "Test MANIFEST implementation via condor_manifest tool" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 				condor_pl_test(test_condor_token_fetch_key "Test `condor_token_fetch -key`" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")

--- a/src/condor_tests/test_checkpoint_destination.py
+++ b/src/condor_tests/test_checkpoint_destination.py
@@ -659,8 +659,6 @@ def the_completed_job(default_condor, the_job_handle):
 def the_completed_job_stdout(test_dir, the_job_name, the_completed_job):
     cluster = the_completed_job.clusterid
     output_log_path = test_dir / f"test_job_{cluster}.out"
-    if the_job_name == "with_output_destination":
-        output_log_path = test_dir / "od" / f"test_job_{cluster}.out"
 
     with open(test_dir / output_log_path) as output:
         return output.readlines()

--- a/src/condor_utils/file_transfer.cpp
+++ b/src/condor_utils/file_transfer.cpp
@@ -4465,18 +4465,23 @@ FileTransfer::computeFileList(
 					// an absolute path for their logs.  See HTCONDOR-1221.
 					if( outputName == StdoutRemapName ) {
 						jobAd.LookupString( ATTR_JOB_ORIGINAL_OUTPUT, outputName );
+						local_output_url = outputName;
 					} else if( outputName == StderrRemapName ) {
 						jobAd.LookupString( ATTR_JOB_ORIGINAL_ERROR, outputName );
+						local_output_url = outputName;
+					} else {
+						local_output_url += outputName;
 					}
+				} else {
+					local_output_url += outputName;
 				}
-				local_output_url += outputName;
-			}
-			else {
+			} else {
 				MyString remap_filename;
 				if ((1 == filename_remap_find(download_filename_remaps.c_str(), fileitem.srcName().c_str(), remap_filename, 0)) && IsUrl(remap_filename.c_str())) {
 					local_output_url = remap_filename.c_str();
 				}
 			}
+
 			if (sign_s3_urls &&
 			  (starts_with_ignore_case(local_output_url, "s3://") || starts_with_ignore_case(local_output_url, "gs://"))) {
 				s3_urls_to_sign.push_back(local_output_url);


### PR DESCRIPTION
This change makes `output_destination` _not_ send the standard output and error files to the output destination; they instead go back to the AP as normal.  This should make `output_destination` useful as a way to simplify writing submit files.  This PR changes the semantics unconditionally on the theory that nobody is currently using this feature and that the work-around is pretty trivial.  There are, of course, other options.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
