### PR TITLE
HTCONDOR-1491-fewer-plugins-at-startup

### DIFF
--- a/src/condor_scripts/CondorPersonal.pm
+++ b/src/condor_scripts/CondorPersonal.pm
@@ -1240,6 +1240,7 @@ debug( "HMMMMMMMMMMM personal local is $personal_local , mytoppath is $mytoppath
 				print NEW "JOB_START_DELAY = 0\n";
 				print NEW "DAGMAN_USER_LOG_SCAN_INTERVAL = 1\n";
 				print NEW "LOCK = \$(LOG)\n";
+				print NEW "FILETRANSFER_PLUGINS = \$(LIBEXEC)/curl_plugin\n";
 				if($iswindows == 1) {
 				#print NEW "PROCD_LOG = \$(LOG)/ProcLog\n";
 					print NEW "# Adding procd pipe for windows\n";

--- a/src/condor_tests/ctest_driver
+++ b/src/condor_tests/ctest_driver
@@ -28,6 +28,11 @@ SENDMAIL=/bin/true
 LOCAL_CONFIG_FILE={pwd}/condor_config.local
 DOCKER_PERFORM_TEST=false
 
+# By default, there are also the python-base box and gdrive
+# plugins which are very expensive to the hundreds of
+# personal condors to start up and test with -classad
+FILETRANSFER_PLUGINS=$(LIBEXEC)/curl_plugin
+
 # ctest allows tests to run for up to 1500 seconds; after that, we are
 # potentially a runaway personal condor instance.
 DAEMON_SHUTDOWN=time() - DaemonStartTime > 1500

--- a/src/condor_tests/ornithology/condor.py
+++ b/src/condor_tests/ornithology/condor.py
@@ -55,6 +55,7 @@ DEFAULT_PARAMS = {
     "RUNBENCHMARKS": "0",
     "MAX_JOB_QUEUE_LOG_ROTATIONS": "10",
     "STARTER_LIST": "STARTER",  # no standard universe starter
+    "FILETRANSFER_PLUGINS": "$(LIBEXEC)/curl_plugin",
 }
 
 


### PR DESCRIPTION
test suite.  We don't test them, and running -classad at startup is causing a huge load when running in parallel.  This change lowers the load average by almost 30% on my laptop when running -j 40

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
