### PR TITLE
HTCONDOR-1285: EL9 Support

### DIFF
--- a/build/nmi-build/build-batlab-images.sh
+++ b/build/nmi-build/build-batlab-images.sh
@@ -45,8 +45,10 @@ PATCH_VER=${AVERSION[2]}
 CONTAINER_VERSION=$(printf "%02d%02d%02d%02d" "$MAJOR_VER" "$MINOR_VER" "$PATCH_VER" "$SERIAL")
 
 buildimage aarch64_AlmaLinux8 arm64v8/almalinux:8
+buildimage aarch64_AlmaLinux9 arm64v8/almalinux:9
 buildimage ppc64le_AlmaLinux8 ppc64le/almalinux:8
 buildimage x86_64_AlmaLinux8 almalinux:8
+buildimage x86_64_AlmaLinux9 almalinux:9
 buildimage x86_64_CentOS7 centos:7
 buildimage x86_64_Debian11 debian:bullseye
 buildimage x86_64_Ubuntu18 ubuntu:bionic

--- a/build/nmi-build/setup.sh
+++ b/build/nmi-build/setup.sh
@@ -121,7 +121,7 @@ if [ $VERSION_CODENAME = 'bionic' ] || [ $VERSION_CODENAME = 'jammy' ]; then
     sed -i s+repo/+repo-test/+ /etc/apt/sources.list.d/htcondor-test.list
     apt update
 fi
-if [ $ID = 'amzn' ]; then
+if [ $ID = 'almalinux' ] && [ $VERSION_ID -eq 9 ]; then
     cp -p /etc/yum.repos.d/htcondor.repo /etc/yum.repos.d/htcondor-test.repo
     sed -i s+repo/+repo-test/+ /etc/yum.repos.d/htcondor-test.repo
     sed -i s/\\[htcondor/[htcondor-test/ /etc/yum.repos.d/htcondor-test.repo
@@ -173,11 +173,11 @@ if [ $ID = 'debian' ] || [ $ID = 'ubuntu' ]; then
 fi
 
 if [ $ID = 'almalinux' ] || [ $ID = 'amzn' ] || [ $ID = 'centos' ] || [ $ID = 'fedora' ]; then
-    $INSTALL condor java openssh-clients openssh-server
+    $INSTALL condor java procps-ng openssh-clients openssh-server
     if [ $ID != 'amzn' ]; then
         $INSTALL apptainer
     fi
-    $INSTALL 'perl(Archive::Tar)' 'perl(Data::Dumper)' 'perl(Digest::MD5)' 'perl(Digest::SHA)' 'perl(Env)' 'perl(Net::Domain)' 'perl(Time::HiRes)' 'perl(XML::Parser)'
+    $INSTALL 'perl(Archive::Tar)' 'perl(Data::Dumper)' 'perl(Digest::MD5)' 'perl(Digest::SHA)' 'perl(English)' 'perl(Env)' 'perl(File::Copy)' 'perl(FindBin)' 'perl(Net::Domain)' 'perl(Sys::Hostname)' 'perl(Time::HiRes)' 'perl(XML::Parser)'
 fi
 
 if [ $ID = 'amzn' ] || [ $ID = 'centos' ]; then

--- a/build/packaging/rpm/condor.spec
+++ b/build/packaging/rpm/condor.spec
@@ -173,8 +173,10 @@ BuildRequires: voms-devel
 BuildRequires: munge-devel
 BuildRequires: scitokens-cpp-devel
 
+%if 0%{?rhel} <= 8
 BuildRequires: libcgroup-devel
 Requires: libcgroup
+%endif
 
 %if 0%{?rhel} == 7 && 0%{?devtoolset}
 BuildRequires: which
@@ -669,6 +671,11 @@ export CMAKE_PREFIX_PATH=/usr
        -DCMAKE_SKIP_RPATH:BOOL=TRUE \
        -DCONDOR_PACKAGE_BUILD:BOOL=TRUE \
        -DCONDOR_RPMBUILD:BOOL=TRUE \
+%if 0%{?rhel} >= 9
+       -DWITH_LIBCGROUP:BOOL=FALSE \
+%else
+       -DWITH_LIBCGROUP:BOOL=TRUE \
+%endif
        -D_VERBOSE:BOOL=TRUE \
        -DBUILD_TESTING:BOOL=TRUE \
        -DPLATFORM:STRING=${NMI_PLATFORM:-unknown} \
@@ -697,6 +704,11 @@ export CMAKE_PREFIX_PATH=/usr
        -DCONDOR_RPMBUILD:BOOL=TRUE \
        -DHAVE_BOINC:BOOL=TRUE \
        -DWITH_MANAGEMENT:BOOL=FALSE \
+%if 0%{?rhel} >= 9
+       -DWITH_LIBCGROUP:BOOL=FALSE \
+%else
+       -DWITH_LIBCGROUP:BOOL=TRUE \
+%endif
        -DCMAKE_INSTALL_PREFIX:PATH=/ \
        -DINCLUDE_INSTALL_DIR:PATH=/usr/include \
        -DSYSCONF_INSTALL_DIR:PATH=/etc \
@@ -707,12 +719,18 @@ export CMAKE_PREFIX_PATH=/usr
        -DBUILD_SHARED_LIBS:BOOL=ON
 %endif
 
+%if 0%{?rhel} == 9
+cd redhat-linux-build
+%endif
 make %{?_smp_mflags}
 %if %uw_build
 make %{?_smp_mflags} tests
 %endif
 
 %install
+%if 0%{?rhel} == 9
+cd redhat-linux-build
+%endif
 # installation happens into a temporary location, this function is
 # useful in moving files into their final locations
 function populate {
@@ -728,7 +746,11 @@ make install DESTDIR=%{buildroot}
 %if %uw_build
 make tests-tar-pkg
 # tarball of tests
+%if 0%{?rhel} == 9
+cp -p %{_builddir}/%{name}-%{version}/redhat-linux-build/condor_tests-*.tar.gz %{buildroot}/%{_libdir}/condor/condor_tests-%{version}.tar.gz
+%else
 cp -p %{_builddir}/%{name}-%{version}/condor_tests-*.tar.gz %{buildroot}/%{_libdir}/condor/condor_tests-%{version}.tar.gz
+%endif
 %endif
 
 # Drop in a symbolic link for backward compatibility

--- a/nmi_tools/condor_nmi_submit
+++ b/nmi_tools/condor_nmi_submit
@@ -991,7 +991,8 @@ sub createSubmitFilesNew
 		# Request 1 core.  It gets quantized up to four or eight cores for some machines
 		print CMDFILE "request_cpus = 1\n";
 		# Need 11Gb to match test runs.  Otherwise, this could be 8Gb (1 Gb per core)
-		print CMDFILE "request_memory = 11G\n";
+		# ARM EL9 (qemu) needs 17G to build on 8 cores
+		print CMDFILE "request_memory = 17G\n";
 		print CMDFILE "request_disk = 8G\n";
 
 		# Select Docker NAT network for more reliable HTCondor startup
@@ -999,7 +1000,7 @@ sub createSubmitFilesNew
 	} else {
 		print CMDFILE "request_cpus = 1\n";
 		# Need 11Gb for qemu platforms.  Otherwise, this could be 4Gb
-		print CMDFILE "request_memory = 11G\n";
+		print CMDFILE "request_memory = 17G\n";
 		print CMDFILE "request_disk = 8G\n";
 
 		# Select Docker NAT network to avoid port exhaustion when running lots of test runs

--- a/nmi_tools/glue/SubmitInfo.pm
+++ b/nmi_tools/glue/SubmitInfo.pm
@@ -313,6 +313,8 @@ our %submit_info = (
 	'nmi-build:aarch64_AlmaLinux8' => 'x86_64_CentOS8',
 	'nmi-build:ppc64le_AlmaLinux8' => 'x86_64_CentOS8',
 	'nmi-build:x86_64_AlmaLinux8' => 'x86_64_CentOS8',
+	'nmi-build:aarch64_AlmaLinux9' => 'x86_64_CentOS8',
+	'nmi-build:x86_64_AlmaLinux9' => 'x86_64_CentOS8',
 	'nmi-build:x86_64_AmazonLinux2' => 'x86_64_Ubuntu18',
 
 	##########################################################################

--- a/nmi_tools/glue/build/make-tarball-from-rpms
+++ b/nmi_tools/glue/build/make-tarball-from-rpms
@@ -48,6 +48,8 @@ elif [[ $dist == el7 ]]; then
     arch_dist="${arch}_CentOS7"
 elif [[ $dist == el8 ]]; then
     arch_dist="${arch}_AlmaLinux8"
+elif [[ $dist == el9 ]]; then
+    arch_dist="${arch}_AlmaLinux9"
 elif [[ $dist == fc32 ]]; then
     arch_dist="${arch}_Fedora32"
 fi
@@ -72,8 +74,7 @@ rm -r condor_tests-$version-$release-$arch_dist
 mv tarball/etc/condor/config.d/* tarball/usr/share/doc/condor*/examples/
 
 
-common_externals="libcgroup \
-    condor-stash-plugin \
+common_externals="condor-stash-plugin \
     libgomp \
     munge-libs \
     pcre2 \
@@ -88,11 +89,13 @@ if [[ $arch_dist =~ CentOS7 || $arch_dist =~ AmazonLinux2 ]]; then
         python36-requests \
         python36-six \
         python36-urllib3"
-    externals="$common_externals $el7_externals"
+    externals="libcgroup $common_externals $el7_externals"
 elif [[ $arch_dist =~ AlmaLinux8 ]]; then
+    externals="libcgroup $common_externals boost-python3"
+elif [[ $arch_dist =~ AlmaLinux9 ]]; then
     externals="$common_externals boost-python3"
 elif [[ $arch_dist =~ Fedora32 ]]; then
-    externals="$common_externals boost-python3"
+    externals="libcgroup $common_externals boost-python3"
 fi
 
 mkdir external-packages

--- a/nmi_tools/nmi-build-platforms
+++ b/nmi_tools/nmi-build-platforms
@@ -2,10 +2,10 @@
 
 # Officially supported platforms
 docker://htcondor/nmi-build:aarch64_AlmaLinux8-10000006
-docker://htcondor/nmi-build:aarch64_AlmaLinux9-10020000
+docker://htcondor/nmi-build:aarch64_AlmaLinux9-10030001
 docker://htcondor/nmi-build:ppc64le_AlmaLinux8-10000006
 docker://htcondor/nmi-build:x86_64_AlmaLinux8-10000006
-docker://htcondor/nmi-build:x86_64_AlmaLinux8-10020000
+docker://htcondor/nmi-build:x86_64_AlmaLinux8-10030017
 docker://htcondor/nmi-build:x86_64_CentOS7-10000108
 docker://htcondor/nmi-build:x86_64_Debian11-10000111
 x86_64_MacOSX15

--- a/nmi_tools/nmi-build-platforms
+++ b/nmi_tools/nmi-build-platforms
@@ -5,7 +5,7 @@ docker://htcondor/nmi-build:aarch64_AlmaLinux8-10000006
 docker://htcondor/nmi-build:aarch64_AlmaLinux9-10030001
 docker://htcondor/nmi-build:ppc64le_AlmaLinux8-10000006
 docker://htcondor/nmi-build:x86_64_AlmaLinux8-10000006
-docker://htcondor/nmi-build:x86_64_AlmaLinux8-10030017
+docker://htcondor/nmi-build:x86_64_AlmaLinux9-10030017
 docker://htcondor/nmi-build:x86_64_CentOS7-10000108
 docker://htcondor/nmi-build:x86_64_Debian11-10000111
 x86_64_MacOSX15

--- a/nmi_tools/nmi-build-platforms
+++ b/nmi_tools/nmi-build-platforms
@@ -2,8 +2,10 @@
 
 # Officially supported platforms
 docker://htcondor/nmi-build:aarch64_AlmaLinux8-10000006
+docker://htcondor/nmi-build:aarch64_AlmaLinux9-10020000
 docker://htcondor/nmi-build:ppc64le_AlmaLinux8-10000006
 docker://htcondor/nmi-build:x86_64_AlmaLinux8-10000006
+docker://htcondor/nmi-build:x86_64_AlmaLinux8-10020000
 docker://htcondor/nmi-build:x86_64_CentOS7-10000108
 docker://htcondor/nmi-build:x86_64_Debian11-10000111
 x86_64_MacOSX15


### PR DESCRIPTION
[HTCONDOR-1285](https://opensciencegrid.atlassian.net/browse/HTCONDOR-1285)

Add Support for EL9 on x86_64 and aarch64.
Unfortunately, I had to bump up the memory request to 17G to compile on ARM EL9. That will reduce our slot count from 16 to 14 on our Docker build machine.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
