### PR TITLE
HTCONDOR-1519  Allow condor_now to claim resources from job ID <clusterID.1>

### DIFF
--- a/docs/version-history/lts-versions-10-0.rst
+++ b/docs/version-history/lts-versions-10-0.rst
@@ -7,6 +7,8 @@ These are Long Term Support (LTS) versions of HTCondor. As usual, only bug fixes
 
 The details of each version are described below.
 
+.. _lts-version-history-1002:
+
 Version 10.0.2
 --------------
 

--- a/docs/version-history/lts-versions-10-0.rst
+++ b/docs/version-history/lts-versions-10-0.rst
@@ -7,29 +7,6 @@ These are Long Term Support (LTS) versions of HTCondor. As usual, only bug fixes
 
 The details of each version are described below.
 
-.. _lts-version-history-1003:
-
-Version 10.0.3
---------------
-
-Release Notes:
-
-.. HTCondor version 10.0.3 released on Month Date, 2023.
-
-- HTCondor version 10.0.3 not yet released.
-
-New Features:
-
-- None.
-
-Bugs Fixed:
-
-- Fixed a bug where **condor_now** could not use the resources freed by
-  evicting a job if its procID was 1.
-  :jira:`1519`
-
-.. _lts-version-history-1002:
-
 Version 10.0.2
 --------------
 
@@ -45,6 +22,10 @@ New Features:
   a transfer output remap to create directories in allowed places if they
   do not exist at tranfser output time.
   :jira:`1480`
+
+- Fixed a bug where **condor_now** could not use the resources freed by
+  evicting a job if its procID was 1.
+  :jira:`1519`
 
 Bugs Fixed:
 

--- a/docs/version-history/lts-versions-10-0.rst
+++ b/docs/version-history/lts-versions-10-0.rst
@@ -7,6 +7,27 @@ These are Long Term Support (LTS) versions of HTCondor. As usual, only bug fixes
 
 The details of each version are described below.
 
+.. _lts-version-history-1003:
+
+Version 10.0.3
+--------------
+
+Release Notes:
+
+.. HTCondor version 10.0.3 released on Month Date, 2023.
+
+- HTCondor version 10.0.3 not yet released.
+
+New Features:
+
+- None.
+
+Bugs Fixed:
+
+- Fixed a bug where **condor_now** could not use the resources freed by
+  evicting a job if its procID was 1.
+  :jira:`1519`
+
 .. _lts-version-history-1002:
 
 Version 10.0.2

--- a/src/condor_includes/proc.h
+++ b/src/condor_includes/proc.h
@@ -51,7 +51,7 @@ typedef struct PROC_ID {
 	// the negative numbers for future expansion.
 	PROC_ID() : cluster( 0 ), proc( 11 ) {}
 	PROC_ID( int c, int p ) : cluster(c), proc(p) {}
-	bool isValid() const { return cluster != 0 && proc != 1; }
+	bool isValid() const { return !(cluster == 0 && proc == 1); }
 	void invalidate() { cluster = 0; proc = 1; }
 } PROC_ID;
 

--- a/src/condor_includes/proc.h
+++ b/src/condor_includes/proc.h
@@ -49,7 +49,7 @@ typedef struct PROC_ID {
 	// further defines all of cluster 0 (and all negative process numbers)
 	// as non-jobs, we'll use job 0.1 to mark the invalid job to preserve
 	// the negative numbers for future expansion.
-	PROC_ID() : cluster( 0 ), proc( 11 ) {}
+	PROC_ID() : cluster( 0 ), proc( 1 ) {}
 	PROC_ID( int c, int p ) : cluster(c), proc(p) {}
 	bool isValid() const { return !(cluster == 0 && proc == 1); }
 	void invalidate() { cluster = 0; proc = 1; }


### PR DESCRIPTION
Due to a bug in `isValid()`, which is only used by the `condor_now` code, any job ID with a proc ID of 1 was considered "invalid" and therefore didn't trigger the condor_now code even if it should have.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
