### PR TITLE
HTCONDOR-1541: Fixes to stop systemd complaining

### DIFF
--- a/build/packaging/debian/htcondor.postinst
+++ b/build/packaging/debian/htcondor.postinst
@@ -50,6 +50,8 @@ case "$1" in
         mkdir -p /usr/share/condor/config.d
         # tell systemd to create tmpfiles, but do no harm if not available
         systemd-tmpfiles --create --exclude-prefix=/dev || true
+        # reload system-daemon as service unit may have changed
+        systemctl daemon-reload >/dev/null || true
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/src/condor_examples/condor.service
+++ b/src/condor_examples/condor.service
@@ -17,7 +17,6 @@ Restart=on-failure
 RestartSec=1minute
 WatchdogSec=20minutes
 TimeoutStopSec=150seconds
-StandardOutput=syslog
 NotifyAccess=main
 KillSignal=SIGQUIT
 # Matches values in Linux Kernel Tuning script


### PR DESCRIPTION
This PR has two, partly related, patches.

1. Remove the obsolete `StandardOutput=syslog` setting from the example `condor.service`, which gets installed on Ubuntu as the service file. This setting produces the following warning from `systemctl status condor`:

        /lib/systemd/system/condor.service:20: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.

2. Add a call to `systemctl daemon-reload` in the Debian postinst script. Without this, after an upgrade of the htcondor package, `systemctl status condor` (and any other `systemctl {command} condor`) keeps giving this warning:

        Warning: The unit file, source configuration file or drop-ins of condor.service changed on disk. Run 'systemctl daemon-reload' to reload units.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
