### PR TITLE
HTCONDOR-1531 Python bindings now always request ServerTime in job ads

### DIFF
--- a/docs/version-history/lts-versions-10-0.rst
+++ b/docs/version-history/lts-versions-10-0.rst
@@ -41,6 +41,10 @@ Bugs Fixed:
   provisioned filesystems were enabled
   :jira:`1524`
 
+- In the python bindings, the attribute ``ServerTime`` is now included
+  in job ads returned by ``Schedd.query()``.
+  :jira:`1531`
+
 .. _lts-version-history-1001:
 
 Version 10.0.1

--- a/src/python-bindings/schedd.cpp
+++ b/src/python-bindings/schedd.cpp
@@ -1438,7 +1438,10 @@ struct Schedd {
 
         CondorQ q;
 
-        q.requestServerTime(false);
+		// Existing uses of the bindings is relying on the presence of
+		// ServerTime in all of the job ads returned by the schedd.
+		// To avoid breaking this code, keep requesting it from the schedd.
+        q.requestServerTime(true);
 
         if (constraint.size())
             q.addAND(constraint.c_str());


### PR DESCRIPTION
Existing uses of the python bindings are relyin on the presence of ServerTime in the job ads returned by a schedd query. To avoid breaking this code, keep requesting it from the schedd.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
