### PR TITLE
HTCONDOR-1547: Gangliad metric lifetime work

### DIFF
--- a/docs/admin-manual/configuration-macros.rst
+++ b/docs/admin-manual/configuration-macros.rst
@@ -11007,6 +11007,13 @@ has.
     value. Negative values inhibit sending data to Ganglia. The default
     value is 60.
 
+:macro-def:`GANGLIAD_MIN_METRIC_LIFETIME`
+    An integer value representing the minimum DMAX value for all metrics.
+    Where DMAX is the number number of seconds without updating that
+    a metric will be kept before deletion. This value defaults to ``86400``
+    which is equivalent to 1 day. This value will be overridden by a
+    specific metric defined ``Lifetime`` value.
+
 :macro-def:`GANGLIAD_VERBOSITY`
     An integer that specifies the maximum verbosity level of metrics to
     be published to Ganglia. Basic metrics have a verbosity level of 0,

--- a/docs/admin-manual/monitoring.rst
+++ b/docs/admin-manual/monitoring.rst
@@ -212,6 +212,13 @@ Recognized metric attribute names and their use:
     an "@" sign, the default IP value will be set to the same value as
     ``Machine`` in order to make the IP value unique to each instance of
     HTCondor running on the same host.
+ Lifetime
+    A postive integer value representing the max number of seconds
+    without updating a metric will be kept before deletion. This is
+    represented in ganglia as DMAX. If no Lifetime is defined for a
+    metric then the default value will be set to a calculated value
+    based on the ganglia publish interval with a minimum value set by
+    :macro:`GANGLIAD_MIN_METRIC_LIFETIME`.
 
 Absent ClassAds
 ---------------

--- a/docs/version-history/feature-versions-10-x.rst
+++ b/docs/version-history/feature-versions-10-x.rst
@@ -45,6 +45,15 @@ New Features:
   deems appropriate.
   :jira:`1528`
 
+- Added ability to set a gangliad metrics lifetime (DMAX value) within the
+  metric definition language with the new ``Lifetime`` keyword.
+  :jira:`1547`
+
+- Added configuration knob :macro:`GANGLIAD_MIN_METRIC_LIFETIME` to set
+  the minimum value for gangliads calculated metric lifetime (DMAX value)
+  for all metrics without a specified ``Lifetime``.
+  :jira:`1547`
+
 Bugs Fixed:
 
 - The HTCondor starter now removes any cgroup that it has created for

--- a/src/gangliad/gangliad.cpp
+++ b/src/gangliad/gangliad.cpp
@@ -345,10 +345,10 @@ GangliaD::publishMetric(Metric const &m)
 	int slope = metric.gangliaSlope();
 
     m_ganglia_metrics_sent++;
-	dprintf(D_FULLDEBUG,"%spublishing %s=%s, group=%s, units=%s, derivative=%d, type=%s, title=%s, desc=%s, cluster=%s, spoof_host=%s, lifetime=%u\n",
+	dprintf(D_FULLDEBUG,"%spublishing %s=%s, group=%s, units=%s, derivative=%d, type=%s, title=%s, desc=%s, cluster=%s, spoof_host=%s, lifetime=%d\n",
 			m_ganglia_noop ? "noop mode: " : "",
 			metric.name.c_str(), value.c_str(), metric.group.c_str(),  metric.units.c_str(), metric.derivative, metric.gangliaMetricType(), metric.title.c_str(),
-			metric.desc.c_str(), metric.cluster.c_str(), spoof_host.c_str(), metric.lifetime > 0 ? metric.lifetime : m_dmax);
+			metric.desc.c_str(), metric.cluster.c_str(), spoof_host.c_str(), metric.lifetime < 0 ? m_dmax : metric.lifetime);
 	if( !m_ganglia_noop ) {
 		bool ok = ganglia_send(
 						  m_ganglia_context,
@@ -364,7 +364,7 @@ GangliaD::publishMetric(Metric const &m)
 						  spoof_host.c_str(),
 						  metric.cluster.c_str(),
 						  m_tmax,
-						  metric.lifetime > 0 ? metric.lifetime : m_dmax);
+						  metric.lifetime < 0 ? m_dmax : metric.lifetime);
 
 		if( !ok ) {
 			dprintf(D_ALWAYS,"Failed to publish %s%s\n",

--- a/src/gangliad/gangliad.cpp
+++ b/src/gangliad/gangliad.cpp
@@ -198,9 +198,13 @@ GangliaD::initAndReconfig()
 
 	// the interval we tell ganglia is the max time between updates
 	m_tmax = m_stats_pub_interval*2;
+	// the minimum dmax can be
+	int min_dmax = param_integer("GANGLIAD_MIN_METRIC_LIFETIME", 86400);
+	if(min_dmax < 0) { min_dmax = 86400; }
+	dprintf(D_ALWAYS,"Setting minimum calculated DMAX value to %d. Specified metric lifetimes with override this value.\n", min_dmax);
 	// the interval we tell ganglia is the lifetime of the metric
-	if( m_tmax*3 < 86400 ) {
-		m_dmax = 86400;
+	if( m_tmax*3 < (unsigned int)min_dmax ) {
+		m_dmax = min_dmax;
 	}
 	else {
 		m_dmax = m_tmax*3;
@@ -341,10 +345,10 @@ GangliaD::publishMetric(Metric const &m)
 	int slope = metric.gangliaSlope();
 
     m_ganglia_metrics_sent++;
-	dprintf(D_FULLDEBUG,"%spublishing %s=%s, group=%s, units=%s, derivative=%d, type=%s, title=%s, desc=%s, cluster=%s, spoof_host=%s\n",
+	dprintf(D_FULLDEBUG,"%spublishing %s=%s, group=%s, units=%s, derivative=%d, type=%s, title=%s, desc=%s, cluster=%s, spoof_host=%s, lifetime=%u\n",
 			m_ganglia_noop ? "noop mode: " : "",
-			metric.name.c_str(), value.c_str(), metric.group.c_str(),  metric.units.c_str(), metric.derivative, metric.gangliaMetricType(), metric.title.c_str(), metric.desc.c_str(), metric.cluster.c_str(), spoof_host.c_str());
-
+			metric.name.c_str(), value.c_str(), metric.group.c_str(),  metric.units.c_str(), metric.derivative, metric.gangliaMetricType(), metric.title.c_str(),
+			metric.desc.c_str(), metric.cluster.c_str(), spoof_host.c_str(), metric.lifetime > 0 ? metric.lifetime : m_dmax);
 	if( !m_ganglia_noop ) {
 		bool ok = ganglia_send(
 						  m_ganglia_context,
@@ -360,7 +364,7 @@ GangliaD::publishMetric(Metric const &m)
 						  spoof_host.c_str(),
 						  metric.cluster.c_str(),
 						  m_tmax,
-						  m_dmax);
+						  metric.lifetime > 0 ? metric.lifetime : m_dmax);
 
 		if( !ok ) {
 			dprintf(D_ALWAYS,"Failed to publish %s%s\n",

--- a/src/gangliad/statsd.cpp
+++ b/src/gangliad/statsd.cpp
@@ -47,7 +47,7 @@
 Metric::Metric():
 	derivative(false),
 	verbosity(0),
-	lifetime(0),
+	lifetime(-1),
     scale(1.0),
 	type(AUTO),
 	aggregate(NO_AGGREGATE),
@@ -169,9 +169,7 @@ Metric::evaluateDaemonAd(classad::ClassAd &metric_ad,classad::ClassAd const &dae
 		return false;
 	}
 
-	int temp_lifetime;
-	metric_ad.EvaluateAttrInt(ATTR_LIFETIME, temp_lifetime);
-	if (temp_lifetime > 0) { lifetime = temp_lifetime; }
+	metric_ad.EvaluateAttrInt(ATTR_LIFETIME, lifetime);
 
 	std::string target_type_str;
 	if( !evaluateOptionalString(ATTR_TARGET_TYPE,target_type_str,metric_ad,daemon_ad,regex_groups) ) return false;

--- a/src/gangliad/statsd.cpp
+++ b/src/gangliad/statsd.cpp
@@ -42,10 +42,12 @@
 #define ATTR_AGGREGATE_GROUP "AggregateGroup"
 #define ATTR_IP "IP"
 #define ATTR_SCALE "Scale"
+#define ATTR_LIFETIME "Lifetime"
 
 Metric::Metric():
 	derivative(false),
 	verbosity(0),
+	lifetime(0),
     scale(1.0),
 	type(AUTO),
 	aggregate(NO_AGGREGATE),
@@ -166,6 +168,10 @@ Metric::evaluateDaemonAd(classad::ClassAd &metric_ad,classad::ClassAd const &dae
 		// avoid doing more work; this metric requires higher verbosity
 		return false;
 	}
+
+	int temp_lifetime;
+	metric_ad.EvaluateAttrInt(ATTR_LIFETIME, temp_lifetime);
+	if (temp_lifetime > 0) { lifetime = temp_lifetime; }
 
 	std::string target_type_str;
 	if( !evaluateOptionalString(ATTR_TARGET_TYPE,target_type_str,metric_ad,daemon_ad,regex_groups) ) return false;

--- a/src/gangliad/statsd.h
+++ b/src/gangliad/statsd.h
@@ -66,6 +66,7 @@ public:
 	std::string cluster;
 	bool derivative;
 	int verbosity;
+	unsigned int lifetime;
     double scale;
 
 	enum MetricTypeEnum {

--- a/src/gangliad/statsd.h
+++ b/src/gangliad/statsd.h
@@ -66,7 +66,7 @@ public:
 	std::string cluster;
 	bool derivative;
 	int verbosity;
-	unsigned int lifetime;
+	int lifetime;
     double scale;
 
 	enum MetricTypeEnum {


### PR DESCRIPTION
-Added 'Lifetime' attribute to metric definition to set
 metrics DMAX to
-Added config knob GANGLIAD_MIN_METRIC_LIFETIME to be the
 minimum value the calculated DMAX can be set to.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
