### PR TITLE
Update Google Cloud Storage links and wording

### DIFF
--- a/docs/users-manual/file-transfer.rst
+++ b/docs/users-manual/file-transfer.rst
@@ -819,12 +819,12 @@ Google Cloud Storage implements an `XML API which is interoperable with S3
 <https://cloud.google.com/storage/docs/interoperability>`_. This requires an
 extra step of `generating HMAC credentials
 <https://console.cloud.google.com/storage/settings;tab=interoperability>`_
-to access Cloud Storage through the XML API. Google Cloud best practices are
-to create a Service Account with read/write permission to the bucket and
-`generate HMAC credentials for the service account
-<https://cloud.google.com/storage/docs/migrating#keys>`_.
+to access Cloud Storage. Google Cloud best practices are to create a Service
+Account with read/write permission to the bucket. Read `HMAC keys for Cloud
+Storage <https://cloud.google.com/storage/docs/authentication/hmackeys>`_ for
+more details.
 
-After generating HMAC credentials, they can be used within an HTCondor job:
+After generating HMAC credentials, they can be used within a job:
 
 .. code-block:: condor-submit
 
@@ -835,7 +835,7 @@ After generating HMAC credentials, they can be used within an HTCondor job:
 
 If `Cloud Storage is configured with Private Service Connect
 <https://cloud.google.com/vpc/docs/private-service-connect>`_, then use the S3 URL
-approach defined above. e.g.
+approach with the private Cloud Storage endpoint. e.g.,
 
 .. code-block:: condor-submit
 


### PR DESCRIPTION
The links for Google Cloud Storage in documentation are out-of-date and require updating. I would like to see this change reflected in both the LTS and Feature Releases of HTCondor 10 documentation.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
