### PR TITLE
HTCONDOR-1564: fixed condor_history remote query with const expr seg …

### DIFF
--- a/docs/version-history/lts-versions-10-0.rst
+++ b/docs/version-history/lts-versions-10-0.rst
@@ -70,6 +70,11 @@ Bugs Fixed:
   (Bionic Beaver).
   :jira:`1548`
 
+- Fixed a bug where the *condor_history* tool would segmentation fault
+  when doing a remote query with a constraint expression or specified
+  job id's.
+  :jira:`1564`
+
 .. _lts-version-history-1001:
 
 Version 10.0.1

--- a/src/condor_tools/history.cpp
+++ b/src/condor_tools/history.cpp
@@ -700,7 +700,7 @@ static void readHistoryRemote(classad::ExprTree *constraintExpr, bool want_start
 	printHeader(); // this has the side effect of setting the projection for the default output
 
 	ClassAd ad;
-	ad.Insert(ATTR_REQUIREMENTS, constraintExpr);
+	if (constraintExpr) { ad.Insert(ATTR_REQUIREMENTS, constraintExpr->Copy()); }
 	ad.InsertAttr(ATTR_NUM_MATCHES, specifiedMatch <= 0 ? -1 : specifiedMatch);
 	// in 8.5.6, we can request that the remote side stream the results back. othewise
 	// the 8.4 protocol will only send EOM after the last result, and thus we print nothing


### PR DESCRIPTION
condor_history seg fault when doing a remote query with a constraint expression or specific job id(s)

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
