### PR TITLE
HTCONDOR-1489: Automatically act upon prerelease

### DIFF
--- a/nmi_tools/glue/build/build_uw_deb.sh
+++ b/nmi_tools/glue/build/build_uw_deb.sh
@@ -50,32 +50,43 @@ export DEBEMAIL=${DEBEMAIL-htcondor-admin@cs.wisc.edu}
 # if running in a condor slot, set parallelism to slot size
 export DEB_BUILD_OPTIONS="parallel=${OMP_NUM_THREADS-1}"
 
+# Extract prerelease value from top level CMake file
+PRE_RELEASE=$(grep '^set(PRE_RELEASE' CMakeLists.txt)
+PRE_RELEASE=${PRE_RELEASE#*\"} # Trim up to and including leading "
+PRE_RELEASE=${PRE_RELEASE%\"*} # Trim trailing " to end of line
+
 # Distribution should be one of experimental, unstable, testing, stable, oldstable, oldoldstable
 # unstable -> daily repo
 # testing -> rc repo
 # stable -> release repo
 
-#dist='unstable'
-dist='testing'
-#dist='stable'
+if [ "$PRE_RELEASE" = 'OFF' ]; then
+    dist='stable'
+elif [ "$PRE_RELEASE" = 'RC' ]; then
+    dist='testing'
+else
+    dist='unstable'
+fi
 echo "Distribution is $dist"
 
-# Nightly build changelog
-dch --distribution $dist --newversion "$condor_version-0.$condor_build_id" "Nightly build"
-
-# Final release changelog
-#dch --release --distribution $dist ignored
+if [ "$PRE_RELEASE" = 'OFF' ]; then
+    # Changelog entry is present for final release build
+    dch --release --distribution $dist ignored
+else
+    # Generate a changelog entry
+    dch --distribution $dist --newversion "$condor_version-0.$condor_build_id" "Automated build"
+fi
 
 . /etc/os-release
-if [ $VERSION_CODENAME = 'bullseye' ]; then
+if [ "$VERSION_CODENAME" = 'bullseye' ]; then
     true
-elif [ $VERSION_CODENAME = 'bookworm' ]; then
+elif [ "$VERSION_CODENAME" = 'bookworm' ]; then
     dch --distribution $dist --nmu 'place holder entry'
-elif [ $VERSION_CODENAME = 'bionic' ]; then
+elif [ "$VERSION_CODENAME" = 'bionic' ]; then
     true
-elif [ $VERSION_CODENAME = 'focal' ]; then
+elif [ "$VERSION_CODENAME" = 'focal' ]; then
     dch --distribution $dist --nmu 'place holder entry'
-elif [ $VERSION_CODENAME = 'jammy' ]; then
+elif [ "$VERSION_CODENAME" = 'jammy' ]; then
     dch --distribution $dist --nmu 'place holder entry'
     dch --distribution $dist --nmu 'place holder entry'
 else

--- a/nmi_tools/glue/build/build_uw_rpm.sh
+++ b/nmi_tools/glue/build/build_uw_rpm.sh
@@ -74,13 +74,22 @@ update_spec_define () {
   sed -i "s|^ *%define * $1 .*|%define $1 $2|" SOURCES/condor.spec
 }
 
+# Extract prerelease value from top level CMake file
+PRE_RELEASE=$(grep '^set(PRE_RELEASE' CMakeLists.txt)
+PRE_RELEASE=${PRE_RELEASE#*\"} # Trim up to and including leading "
+PRE_RELEASE=${PRE_RELEASE%\"*} # Trim trailing " to end of line
+
 update_spec_define git_build 0
 update_spec_define tarball_version "$condor_version"
 update_spec_define condor_build_id "$condor_build_id"
-# Set HTCondor base release for pre-release build
-update_spec_define condor_base_release "0.$condor_build_id"
-# Set HTCondor base release to 1 for final release.
-#update_spec_define condor_base_release "1"
+
+if [ "$PRE_RELEASE" = 'OFF' ]; then
+    # Set HTCondor base release to 1 for final release.
+    update_spec_define condor_base_release "1"
+else
+    # Set HTCondor base release for pre-release build
+    update_spec_define condor_base_release "0.$condor_build_id"
+fi
 
 VERBOSE=1
 export VERBOSE

--- a/nmi_tools/glue/build/build_uw_rpm.sh
+++ b/nmi_tools/glue/build/build_uw_rpm.sh
@@ -65,19 +65,19 @@ mkdir SOURCES BUILD BUILDROOT RPMS SPECS SRPMS
 mv "../condor-${condor_version}.tgz" "SOURCES/condor-${condor_version}.tar.gz"
 
 # copy rpm files from condor sources into the SOURCES directory
-tar xvfpz "SOURCES/condor-${condor_version}.tar.gz" "condor-${condor_version}/build/packaging/rpm"
+tar xvfpz "SOURCES/condor-${condor_version}.tar.gz" "condor-${condor_version}/build/packaging/rpm" "condor-${condor_version}/CMakeLists.txt"
 cp -p condor-"${condor_version}"/build/packaging/rpm/* SOURCES
+
+# Extract prerelease value from top level CMake file
+PRE_RELEASE=$(grep '^set(PRE_RELEASE' condor-${condor_version}/CMakeLists.txt)
+PRE_RELEASE=${PRE_RELEASE#*\"} # Trim up to and including leading "
+PRE_RELEASE=${PRE_RELEASE%\"*} # Trim trailing " to end of line
 rm -rf "condor-${condor_version}"
 
 # inject the version and build id into the spec file
 update_spec_define () {
   sed -i "s|^ *%define * $1 .*|%define $1 $2|" SOURCES/condor.spec
 }
-
-# Extract prerelease value from top level CMake file
-PRE_RELEASE=$(grep '^set(PRE_RELEASE' CMakeLists.txt)
-PRE_RELEASE=${PRE_RELEASE#*\"} # Trim up to and including leading "
-PRE_RELEASE=${PRE_RELEASE%\"*} # Trim trailing " to end of line
 
 update_spec_define git_build 0
 update_spec_define tarball_version "$condor_version"


### PR DESCRIPTION
I used the be commenting and uncommenting lines in these files for every release. Let's automate this.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
