### PR TITLE
HTCONDOR-1490: Don't set the build date from the changelog

### DIFF
--- a/build/packaging/rpm/condor.spec
+++ b/build/packaging/rpm/condor.spec
@@ -5,6 +5,9 @@
 %define _python_bytecompile_errors_terminate_build 0
 %endif
 
+# Don't use changelog date in CondorVersion
+%global source_date_epoch_from_changelog 0
+
 # optionally define any of these, here or externally
 # % define fedora   16
 # % define osg      0


### PR DESCRIPTION
Alma Linux 9 turns on this option which sets the build date from the most recent changelog entry. This presents a problem for daily and RC build which do not have a changelog entry.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
