### PR TITLE
HTCONDOR-1595 Check for unset captures in Regex

### DIFF
--- a/src/condor_utils/condor_regex.cpp
+++ b/src/condor_utils/condor_regex.cpp
@@ -108,8 +108,12 @@ Regex::match_str(const std::string & string, ExtArray<std::string> * groups) {
 	PCRE2_SIZE * ovector = pcre2_get_ovector_pointer(matchdata);
 	if (NULL != groups) {
 		for (int i = 0; i < rc; i++) {
-			(*groups)[i] = string.substr(static_cast<int>(ovector[i * 2]),
+			if (ovector[i * 2] == PCRE2_UNSET) {
+				(*groups)[i] = "";
+			} else {
+				(*groups)[i] = string.substr(static_cast<int>(ovector[i * 2]),
 			                             static_cast<int>(ovector[i * 2 + 1] - ovector[i * 2]));
+			}
 		}
 	}
 


### PR DESCRIPTION
If a capture occurs in an optional part of the pattern that ends up not matching, the indices of the capture are set to PCRE2_UNSET, which is -1. Using that with std::string::substr() will cause a crash. Return an empty string in this case.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
