### PR TITLE
HTCONDOR-1595 regex-capture-crash-test

### DIFF
--- a/src/condor_unit_tests/OTEST_Regex.cpp
+++ b/src/condor_unit_tests/OTEST_Regex.cpp
@@ -102,7 +102,9 @@ static bool test_captures() {
 	int erroffset = 0;
 	uint32_t options = 0;
 	// pattern is three space separated words, each captured, and a capture around the whole
-	bool compile_result = r.compile("(([a-z]+) ([a-z]+) ([a-z]+))", &errcode, &erroffset, options);
+	// At the start of the first word is a capture of an optional subpattern
+	// that won't match anything.
+	bool compile_result = r.compile("((0)?([a-z]+) ([a-z]+) ([a-z]+))", &errcode, &erroffset, options);
 	bool regex_match = false;
 	std::vector<std::string> groups(8);
 	if (compile_result) {
@@ -119,9 +121,12 @@ static bool test_captures() {
 	emit_param("regex.match[2]   RETURN", "%s", groups[2].c_str());
 	emit_param("regex.match[3]   RETURN", "%s", groups[3].c_str());
 	emit_param("regex.match[4]   RETURN", "%s", groups[4].c_str());
-	if(!compile_result || !regex_match || (groups[0] != "yabba dabba doo") || 
-			(groups[1] != "yabba dabba doo") || (groups[2] != "yabba") || 
-			(groups[3] != "dabba") || (groups[4] != "doo")) {
+	emit_param("regex.match[5]   RETURN", "%s", groups[5].c_str());
+	if(!compile_result || !regex_match || (groups.size() != 6) ||
+			(groups[0] != "yabba dabba doo") ||
+			(groups[1] != "yabba dabba doo") || (groups[2] != "") ||
+			(groups[3] != "yabba") || (groups[4] != "dabba") ||
+			(groups[5] != "doo")) {
 		FAIL;
 	}
 	PASS;


### PR DESCRIPTION
Test that an optional capture that didn't capture anything doesn't cause a crash. Currently, the Regex class doesn't let you distinguish between this and a capture of the empty string.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
