### PR TITLE
HTCONDOR-1601 Allow use of C++20 in Windows

### DIFF
--- a/src/classad/classad/common.h
+++ b/src/classad/classad/common.h
@@ -72,6 +72,7 @@
 
 // must be defined before windows.h
 #define NOMINMAX
+struct IUnknown;
 
 #include <windows.h>
 #include <float.h>

--- a/src/condor_daemon_core.V6/condor_softkill.WINDOWS.cpp
+++ b/src/condor_daemon_core.V6/condor_softkill.WINDOWS.cpp
@@ -44,7 +44,7 @@ static bool message_posted = false;
 static FILE* debug_fp = NULL;
 
 static void
-debug(wchar_t* format, ...)
+debug(const wchar_t* format, ...)
 {
 	if (debug_fp != NULL) {
 		va_list ap;
@@ -214,7 +214,7 @@ wWinMain(__in HINSTANCE, __in_opt HINSTANCE, __in wchar_t*, __in int)
 	// see if a debug output file was given
 	//
 	if (__argc > 2) {
-		wchar_t * opt = L"a";
+		const wchar_t * opt = L"a";
 		wchar_t * pszFile = __wargv[2];
 		debug_fp = _wfopen(pszFile, opt);
 		if (debug_fp == NULL) {

--- a/src/condor_daemon_core.V6/daemon_core.cpp
+++ b/src/condor_daemon_core.V6/daemon_core.cpp
@@ -7615,6 +7615,7 @@ int DaemonCore::Create_Process(
 	if (priv == PRIV_USER_FINAL) {
 		set_priv(gbt_prv);
 	}
+	}
 
 	// test if the executable is either unexecutable, or if GetBinaryType()
 	// thinks its a DOS 16-bit app, but in reality the actual binary

--- a/src/condor_daemon_core.V6/daemon_core.cpp
+++ b/src/condor_daemon_core.V6/daemon_core.cpp
@@ -7586,13 +7586,14 @@ int DaemonCore::Create_Process(
 
 	// if working in an encrypted execute directory, we won't be able to check the exe type
 	// unless we first switch to user priv
+	BOOL cp_result, gbt_result;
+	DWORD binType;
 	priv_state gbt_prv = PRIV_UNKNOWN;
+	{
 	if (priv == PRIV_USER_FINAL) {
 		gbt_prv = set_user_priv();
 	}
 
-	BOOL cp_result, gbt_result;
-	DWORD binType;
 	gbt_result = GetBinaryType(executable, &binType);
 
 	// if GetBinaryType() failed,
@@ -7673,7 +7674,7 @@ int DaemonCore::Create_Process(
 			// making this a NULL string tells NT to dynamically
 			// create a new Window Station for the process we are about
 			// to create....
-		si.lpDesktop = "";
+		si.lpDesktop = (LPSTR)"";
 
 			// Check USE_VISIBLE_DESKTOP in condor_config.  If set to TRUE,
 			// then run the job on the visible desktop, otherwise create
@@ -7684,7 +7685,7 @@ int DaemonCore::Create_Process(
 			if ( GrantDesktopAccess(user_token) == 0 ) {
 					// Success!!  The user now has permission to use
 					// the visible desktop, so change si.lpDesktop
-				si.lpDesktop = "winsta0\\default";
+				si.lpDesktop = (LPSTR)"winsta0\\default";
 			} else {
 					// The system refuses to grant access to the visible
 					// desktop.  Log a message & we'll fall back on using

--- a/src/condor_includes/condor_sys_nt.h
+++ b/src/condor_includes/condor_sys_nt.h
@@ -74,6 +74,7 @@
 // Make sure to define this *before* we include winsock2.h
 #define FD_SETSIZE 1024
 
+struct IUnknown; // Hack to fix older C runtimes with C++20
 // the ordering of the two following header files 
 // is important! Starting with the new SDK, we want 
 // winsock2.h not winsock.h, so we include it first. 
@@ -266,21 +267,6 @@ END_C_DECLS
 # define HAVE__FTIME	1
 
 #endif
-
-// leave this code here, but disable it when not actively checking for MSVC_WARNINGS
-// defeat warnings MSVC_WARNINGS about isspace, isdigit, etc
-inline int is_space(char ch) { return isspace( (int)( (unsigned char)(ch) ) ); }
-inline int is_digit(char ch) { return isdigit( (int)( (unsigned char)(ch) ) ); }
-inline int is_xdigit(char ch){ return isxdigit((int)( (unsigned char)(ch) ) ); }
-inline int is_alnum(char ch) { return isalnum( (int)( (unsigned char)(ch) ) ); }
-inline int is_alpha(char ch) { return isalpha( (int)( (unsigned char)(ch) ) ); }
-
-#define isspace(ch) is_space(ch)
-#define isdigit(ch) is_digit(ch)
-#define isxdigit(ch) is_xdigit(ch)
-#define isalnum(ch) is_alnum(ch)
-#define isalpha(ch) is_alpha(ch)
-//*/
 
 /* Define the PRIx64 macros */
 

--- a/src/condor_io/condor_auth_sspi.cpp
+++ b/src/condor_io/condor_auth_sspi.cpp
@@ -56,11 +56,11 @@ Condor_Auth_SSPI :: sspi_client_auth( CredHandle&    cred,
     
     dprintf( D_FULLDEBUG,"sspi_client_auth() entered\n" );
     
-    rc = (pf->QuerySecurityPackageInfo)( "NTLM", &secPackInfo );
+    rc = (pf->QuerySecurityPackageInfo)( (SEC_CHAR *)"NTLM", &secPackInfo );
     
     TimeStamp useBefore;
     
-    rc = (pf->AcquireCredentialsHandle)( NULL, "NTLM", SECPKG_CRED_OUTBOUND,
+    rc = (pf->AcquireCredentialsHandle)( NULL, (SEC_CHAR *)"NTLM", SECPKG_CRED_OUTBOUND,
                                          NULL, NULL, NULL, NULL, &cred, &useBefore );
     
     // input and output buffers
@@ -201,11 +201,11 @@ Condor_Auth_SSPI::sspi_server_auth(CredHandle& cred,CtxtHandle& srvCtx)
     
     dprintf(D_FULLDEBUG, "sspi_server_auth() entered\n" );
     
-    rc = (pf->QuerySecurityPackageInfo)( "NTLM", &secPackInfo );
+    rc = (pf->QuerySecurityPackageInfo)( (SEC_CHAR *)"NTLM", &secPackInfo );
     
     TimeStamp useBefore;
     
-    rc = (pf->AcquireCredentialsHandle)( NULL, "NTLM", SECPKG_CRED_INBOUND,
+    rc = (pf->AcquireCredentialsHandle)( NULL, (SEC_CHAR *)"NTLM", SECPKG_CRED_INBOUND,
                                          NULL, NULL, NULL, NULL, &cred, &useBefore );
     
     // input and output buffers

--- a/src/condor_kbdd/kbdd.cpp
+++ b/src/condor_kbdd/kbdd.cpp
@@ -313,7 +313,7 @@ int WINAPI WinMain( __in HINSTANCE hInstance, __in_opt HINSTANCE hPrevInstance, 
 	}
 	char **parameters = (char**)malloc(sizeof(char*)*cArgs + 1);
 	ASSERT( parameters != NULL );
-	parameters[0] = "condor_kbdd";
+	parameters[0] = (char *)"condor_kbdd";
 	parameters[cArgs] = NULL;
 
 	/*

--- a/src/condor_master.V6/service.WINDOWS.cpp
+++ b/src/condor_master.V6/service.WINDOWS.cpp
@@ -50,7 +50,7 @@ extern Daemons daemons;
 
 // Static variables
 // The name of the service
-static char *SERVICE_NAME = "Condor Master";
+static const char *SERVICE_NAME = "Condor Master";
 // Handle used to communicate status info with
 // the SCM. Created by RegisterServiceCtrlHandler
 static SERVICE_STATUS_HANDLE serviceStatusHandle;
@@ -58,7 +58,7 @@ static SERVICE_STATUS_HANDLE serviceStatusHandle;
 static BOOL pauseService = FALSE;
 static BOOL runningService = FALSE;
 
-static void ErrorHandler(char *s, DWORD err)
+static void ErrorHandler(const char *s, DWORD err)
 {
 	cout << s << endl;
 	cout << "Error number: " << err << endl;
@@ -433,7 +433,7 @@ DWORD start_as_service()
 {
 	SERVICE_TABLE_ENTRY serviceTable[] = 
 	{ 
-	{ SERVICE_NAME,
+	{ (LPSTR) SERVICE_NAME,
 		(LPSERVICE_MAIN_FUNCTION) ServiceMain},
 	{ NULL, NULL }
 	};

--- a/src/condor_negotiator.V6/accountant_log_fixer.cpp
+++ b/src/condor_negotiator.V6/accountant_log_fixer.cpp
@@ -32,6 +32,8 @@ the new copy into place.
 #define _CRT_NONSTDC_NO_DEPRECATE
 #define _CRT_NONSTDC_NO_WARNINGS
 
+struct IUnknown; // hackey fix for broken headers
+
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>

--- a/src/condor_negotiator.V6/matchmaker.h
+++ b/src/condor_negotiator.V6/matchmaker.h
@@ -282,7 +282,7 @@ class Matchmaker : public Service
 		friend int comparisonFunction (ClassAd *, ClassAd *,
 										void *);
 
-		friend class submitterLessThan;
+		friend struct submitterLessThan;
 
 		std::vector<std::pair<ClassAd*,ClassAd*> > unmutatedSlotAds;
 		std::map<std::string, ClassAd *> m_slotNameToAdMap;

--- a/src/condor_procapi/procapi.cpp
+++ b/src/condor_procapi/procapi.cpp
@@ -1639,7 +1639,7 @@ ProcAPI::GetProcessPerfData()
 
         // '2' is the 'system' , '230' is 'process'  
         // I hope these numbers don't change over time... 
-    dwStatus = GetSystemPerfData ( TEXT("230") );
+    dwStatus = GetSystemPerfData (const_cast<char *>(TEXT("230")));
 
     if( dwStatus != ERROR_SUCCESS ) {
         dprintf( D_ALWAYS,

--- a/src/condor_procapi/procapi_killfamily.cpp
+++ b/src/condor_procapi/procapi_killfamily.cpp
@@ -50,7 +50,7 @@ ProcAPI::getPidFamily( pid_t daddypid, PidEnvID *penvid, std::vector<pid_t>& pid
 
         // '2' is the 'system' , '230' is 'process'  
         // I hope these numbers don't change over time... 
-    dwStatus = GetSystemPerfData ( TEXT("230") );
+    dwStatus = GetSystemPerfData (const_cast<char *>(TEXT("230")));
     
 	if ( dwStatus != ERROR_SUCCESS ) {
         dprintf( D_ALWAYS,
@@ -665,7 +665,7 @@ ProcAPI::getProcSetInfo( pid_t *pids, int numpids, piPTR& pi, int &status ) {
 
         // '2' is the 'system' , '230' is 'process'  
         // I hope these numbers don't change over time... 
-    dwStatus = GetSystemPerfData( TEXT("230") );
+    dwStatus = GetSystemPerfData(const_cast<char *>(TEXT("230")));
     
     if( dwStatus != ERROR_SUCCESS ) {
 		dprintf( D_ALWAYS,

--- a/src/condor_rmdir/condor_rmdir.cpp
+++ b/src/condor_rmdir/condor_rmdir.cpp
@@ -18,6 +18,7 @@
  ***************************************************************/
 
 #define UNICODE
+struct IUnknown;
 #include <windows.h>
 #include <shlwapi.h>
 #include "common.h"

--- a/src/condor_rmdir/harylist.h
+++ b/src/condor_rmdir/harylist.h
@@ -292,7 +292,7 @@ HRESULT PtrList_AppendItem(HaryList<T> * hlst, T pItem, LONG * pix = NULL) {
 
 template <class T>
 HRESULT PtrList_InsertItem(HaryList<T> * hlst, LONG ixInsert, T pItem) {
-   return HaryList_InsertList((HARYLIST)hlst, ixInsert, &pItem, 1, pix);
+   return HaryList_InsertList((HARYLIST)hlst, ixInsert, &pItem, 1);
 }
 
 template <class T>
@@ -555,6 +555,7 @@ HRESULT FNEXPORT HaryList_InsertList (
     // move all items after the insertion point down by the
     // to make room for the iterms we want to insert.
     //
+    {
     LONG cItemsToMove = cItems - ixInsert;
     if (cItemsToMove > 0)
     {
@@ -567,6 +568,7 @@ HRESULT FNEXPORT HaryList_InsertList (
     //
     LPVOID pvDst = HaryList_RawItemAddr(hlst, ixInsert);
     RtlCopyMemory(pvDst, pvItems, cItemsToInsert * plst->cbItem);
+    }
 
     // grow the count by the number of items we inserted.
     //

--- a/src/condor_startd.V6/CondorSystrayNotifier.windows.cpp
+++ b/src/condor_startd.V6/CondorSystrayNotifier.windows.cpp
@@ -128,7 +128,7 @@ void CondorSystrayNotifier::writeToRegistryForCpu(int iCpuId, int iStatus)
 {
 	HKEY hNotifyHandle;
 	DWORD dwCreatedOrOpened, result;
-	result = RegCreateKeyEx(HKEY_LOCAL_MACHINE, "SOFTWARE\\condor", 0, "REG_DWORD", 
+	result = RegCreateKeyEx(HKEY_LOCAL_MACHINE, "SOFTWARE\\condor", 0, (LPSTR)"REG_DWORD", 
 		REG_OPTION_VOLATILE, KEY_ALL_ACCESS, NULL, &hNotifyHandle, &dwCreatedOrOpened);
 
 	if ( result != ERROR_SUCCESS ) {

--- a/src/condor_startd.V6/winreg.windows.cpp
+++ b/src/condor_startd.V6/winreg.windows.cpp
@@ -573,7 +573,7 @@ DWORDHash( const DWORD & n )
 #if 1 // def TIMER_TYPE_NAME_TABLE
 static const struct {
 	DWORD type;
-	char * psz;
+	const char * psz;
 } aPerfTimerTypeNames[] = {
 
 #define _TABLE_ITEM(a) a, #a 

--- a/src/condor_submit.V6/submit.cpp
+++ b/src/condor_submit.V6/submit.cpp
@@ -940,7 +940,7 @@ main( int argc, const char *argv[] )
 		std::string userdom;
 		auto_free_ptr the_username(my_username());
 		auto_free_ptr the_domainname(my_domainname());
-		userdom = the_username;
+		userdom = the_username.ptr();
 		userdom += "@";
 		if (the_domainname) { userdom += the_domainname.ptr(); }
 

--- a/src/condor_utils/directory.WINDOWS.cpp
+++ b/src/condor_utils/directory.WINDOWS.cpp
@@ -1129,7 +1129,7 @@ CondorCopyDirectory (
     DWORD       last_error    = ERROR_SUCCESS,
                 i;
     HANDLE      have_access   = NULL;
-    PSTR        privelages[]  = { SE_BACKUP_NAME, SE_RESTORE_NAME };
+    LPCTSTR     privelages[]  = { SE_BACKUP_NAME, SE_RESTORE_NAME };
     BOOL        opened        = TRUE,
                 added         = FALSE,
                 copied        = FALSE,
@@ -1313,7 +1313,7 @@ CondorCopyDirectory (
 static BOOL
 CondorRemoveDirectoryAs ( 
      priv_state  who,
-     PCHAR       name,
+     const char *name,
      PCWSTR      w_path ) {
 
      priv_state  priv       = PRIV_UNKNOWN;
@@ -1374,7 +1374,7 @@ CondorRemoveDirectoryAs (
 static BOOL
 CondorRemoveFileAs ( 
      priv_state  who,
-     PCHAR       name,
+     const char *name,
      PCWSTR      w_path ) {
 
      priv_state  priv       = PRIV_UNKNOWN;
@@ -1786,7 +1786,7 @@ CondorRemoveDirectory ( PCSTR directory ) {
     PWSTR       w_directory  = NULL;
     DWORD       last_error   = ERROR_SUCCESS,
                 i;
-    PSTR        privelages[] = { SE_BACKUP_NAME, SE_RESTORE_NAME };
+    LPCTSTR     privelages[] = { SE_BACKUP_NAME, SE_RESTORE_NAME };
     BOOL        opened       = FALSE,
                 added        = FALSE,
                 removed      = FALSE,

--- a/src/condor_utils/dprintf.cpp
+++ b/src/condor_utils/dprintf.cpp
@@ -577,7 +577,7 @@ _dprintf_global_func(int cat_and_flags, int hdr_flags, DebugHeaderInfo & info, c
 					MEMORY_BASIC_INFORMATION mbi;
 					SIZE_T cb = VirtualQuery (pfn, &mbi, sizeof(mbi));
 					int off = (int)((const char*)pfn - (const char*)mbi.AllocationBase);
-					if (cb == sizeof(mbi) && mbi.AllocationBase > 0) {
+					if (cb == sizeof(mbi) && mbi.AllocationBase != nullptr) {
 						if (GetModuleFileNameA ((HMODULE)mbi.AllocationBase, szModule, COUNTOF(szModule))) {
 							// print only the part after the last path separator.
 							char * pname = filename_from_path(szModule);
@@ -2368,7 +2368,7 @@ static void backtrace_symbols_fd(void* trace[], int cFrames, int fd)
 	#endif // _DGBHELP_
 		MEMORY_BASIC_INFORMATION mbi;
 		SIZE_T cb = VirtualQuery (trace[ix], &mbi, sizeof(mbi));
-		if (cb == sizeof(mbi) && mbi.AllocationBase > 0) {
+		if (cb == sizeof(mbi) && mbi.AllocationBase != nullptr) {
 			if (GetModuleFileNameA ((HMODULE)mbi.AllocationBase, szModule, COUNTOF(szModule))) {
 				args[1] = (ULONG_PTR)szModule;
 				// print only the part after the last path separator.

--- a/src/condor_utils/dynuser.WINDOWS.cpp
+++ b/src/condor_utils/dynuser.WINDOWS.cpp
@@ -521,10 +521,10 @@ void InitString( UNICODE_STRING &us, wchar_t *psz ) {
 void dynuser::createaccount() {
 	USER_INFO_1 userInfo = { accountname_t, password_t, 0,				// Name / Password
 							 USER_PRIV_USER,							// Priv Level 
-							 L"",										// Home Dir
-							 L"Dynamically created Condor account.",	// Comment
+							 (wchar_t *)L"",										// Home Dir
+							 (wchar_t *)L"Dynamically created Condor account.",	// Comment
 							 UF_SCRIPT,									// flags (req'd)
-							 L"" };										// script path
+							 (wchar_t *)L"" };										// script path
 	DWORD nParam = 0;
 
 	// this is a bad idea! We shouldn't be deleting accounts
@@ -911,7 +911,7 @@ bool dynuser::deleteuser(char const * username ) {
 
 // this function will remove all accounts starting with user_prefix
 
-bool dynuser::cleanup_condor_users(char* user_prefix) {
+bool dynuser::cleanup_condor_users(const char* user_prefix) {
 
 	LPUSER_INFO_10 pBuf = NULL;
 	LPUSER_INFO_10 pTmpBuf;

--- a/src/condor_utils/dynuser.h
+++ b/src/condor_utils/dynuser.h
@@ -57,7 +57,7 @@ public:
 
 	HANDLE get_token();
 
-    bool cleanup_condor_users(char* user_prefix);
+    bool cleanup_condor_users(const char* user_prefix);
 
 	void reset(); // used to be private
 

--- a/src/condor_utils/lsa_mgr.cpp
+++ b/src/condor_utils/lsa_mgr.cpp
@@ -447,7 +447,7 @@ lsa_mgr::storeDataToRegistry( const PLSA_UNICODE_STRING lsaString ) {
 
 
 void
-lsa_mgr::InitLsaString( PLSA_UNICODE_STRING LsaString, const LPWSTR String ) {
+lsa_mgr::InitLsaString( PLSA_UNICODE_STRING LsaString,  PCWSTR String ) {
 	DWORD StringLength;
 	if(String == NULL) {
 		LsaString->Buffer = NULL;
@@ -457,7 +457,7 @@ lsa_mgr::InitLsaString( PLSA_UNICODE_STRING LsaString, const LPWSTR String ) {
 	}
 	//StringLength = lstrlenW(String);
 	StringLength = wcslen(String);
-	LsaString->Buffer = String;
+	LsaString->Buffer = (PWSTR) String;
 	LsaString->Length = (USHORT) StringLength * sizeof(WCHAR);
 	LsaString->MaximumLength = (USHORT) (StringLength + 1) * sizeof(WCHAR);
 }

--- a/src/condor_utils/lsa_mgr.h
+++ b/src/condor_utils/lsa_mgr.h
@@ -82,7 +82,7 @@ class lsa_mgr {
 		
 
 		// convert unicode to LSA_UNICODE_STRING object
-		void InitLsaString( PLSA_UNICODE_STRING LsaString, const LPWSTR String );
+		void InitLsaString( PLSA_UNICODE_STRING LsaString, PCWSTR String );
 
 		// load all password data from registry
 		bool loadDataFromRegistry();

--- a/src/condor_utils/stl_string_utils.h
+++ b/src/condor_utils/stl_string_utils.h
@@ -181,12 +181,13 @@ public:
 		return *this;
 	}
 
-	bool operator!=(const StringTokenIterator &rhs) {
-		return (this->ixNext != rhs.ixNext) || (this->pastEnd != rhs.pastEnd);
-	}
-	bool operator==(const StringTokenIterator &rhs) {
-		return this->ixNext == rhs.ixNext && this->pastEnd == rhs.pastEnd;
-	}
+friend bool operator==(const StringTokenIterator &lhs, const StringTokenIterator &rhs) {
+	return lhs.ixNext == rhs.ixNext && lhs.pastEnd == rhs.pastEnd;
+}
+
+friend bool operator!=(const StringTokenIterator &lhs, const StringTokenIterator &rhs) {
+	return (lhs.ixNext != rhs.ixNext) || (lhs.pastEnd != rhs.pastEnd);
+}
 
 protected:
 	const char * str;   // The string we are tokenizing. it's not a copy, caller must make sure it continues to exist.

--- a/src/condor_utils/system_info.WINDOWS.cpp
+++ b/src/condor_utils/system_info.WINDOWS.cpp
@@ -75,7 +75,7 @@ void SystemInfoUtils::LPCWSTR2MyString( LPCWSTR strW, MyString& str )
 
 	TCHAR* actChar = (TCHAR*)strW;
 
-	if ( actChar == '\0' )
+	if ( actChar == nullptr)
 		return;
 
 	size_t len = wcslen(strW) + 1;

--- a/src/gpu/condor_gpu_utilization.cpp
+++ b/src/gpu/condor_gpu_utilization.cpp
@@ -16,6 +16,7 @@
 #define NOSERVICE
 #define NOMCX
 #define NOIME
+struct IUnknown;
 #include <Windows.h>
 #endif /* defined(WIN32) */
 #include <algorithm>


### PR DESCRIPTION
MSVC's C++20 mode is much more strict about C++ than C++17 It is much more const-correct, which is a headache to fix, but generally a good thing to have.

It is so strict, that it can't compile Win7 headers, unless you predeclare a "struct IUnknown" before include'ing windows.h.  This patch does some of that, but not enough. Do we really need to support Win7?

Because of that, we don't turn on C++20 mode in the Cmake in this patch.  Nevertheless, the drudge work is done here.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
