### PR TITLE
Add almalinux to sysapi_find_linux_name

### DIFF
--- a/src/condor_sysapi/arch.cpp
+++ b/src/condor_sysapi/arch.cpp
@@ -671,6 +671,10 @@ sysapi_find_linux_name( const char *info_str )
         {
                 distro = strdup("Rocky");
         }
+        else if ( strstr(distro_name_lc, "almalinux") )
+        {
+	        distro = strdup("AlmaLinux");
+        }
         else if ( strstr(distro_name_lc, "amazon linux") )
         {
                 distro = strdup("AmazonLinux");


### PR DESCRIPTION
Hi, I noticed that AlmaLinux was missing from the OpsSysAndVer of our test node, ie:

`[root@b9jantest02 ~]# condor_status  $(hostname) -af CondorVersion OpSysAndVer
$CondorVersion: 10.2.3 2023-02-21 BuildID: 629848 PackageID: 10.2.3-1 $ LINUX0
[root@b9jantest02 ~]# cat /etc/redhat-release
AlmaLinux release 9.1 (Lime Lynx)`

Not sure this is everything to fix, but hoped it was at least one better than complaining on the mailing list.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
