### PR TITLE
HTCONDOR-1643 Always write job submit event in schedd

### DIFF
--- a/docs/version-history/lts-versions-10-0.rst
+++ b/docs/version-history/lts-versions-10-0.rst
@@ -27,7 +27,9 @@ New Features:
 
 Bugs Fixed:
 
-- None.
+- Fixed a bug where the submit event wasn't written to the job event
+  log if the job ad didn't contain a ``CondorVersion`` attribute.
+  :jira:`1643`
 
 .. _lts-version-history-1003:
 

--- a/src/condor_schedd.V6/qmgmt.cpp
+++ b/src/condor_schedd.V6/qmgmt.cpp
@@ -6435,20 +6435,11 @@ int CommitTransactionInternal( bool durable, CondorError * errorStack ) {
 				//IncrementLiveJobCounter(scheduler.liveJobCounts, procad->Universe(), job_status, 1);
 				//if (ownerinfo) { IncrementLiveJobCounter(ownerinfo->live, procad->Universe(), job_status, 1); }
 
-				std::string version;
-				if ( procad->LookupString( ATTR_VERSION, version ) ) {
-					CondorVersionInfo vers( version.c_str() );
-					// CRUFT If the submitter is older than 7.5.4, then
-					// they are responsible for writing the submit event
-					// to the user log.
-					if ( vers.built_since_version( 7, 5, 4 ) ) {
-						std::string warning;
-						if(errorStack && (! errorStack->empty())) {
-							warning = errorStack->getFullText();
-						}
-						scheduler.WriteSubmitToUserLog( procad, doFsync, warning.empty() ? NULL : warning.c_str() );
-					}
+				std::string warning;
+				if(errorStack && (! errorStack->empty())) {
+					warning = errorStack->getFullText();
 				}
+				scheduler.WriteSubmitToUserLog( procad, doFsync, warning.empty() ? NULL : warning.c_str() );
 
 				int iDup, iTotal;
 				iDup = procad->PruneChildAd();


### PR DESCRIPTION
We don't need to worry about submitters older than HTCondor 7.5.4, and a job ad missing CondorVersion resulted in no submit event.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
