### PR TITLE
HTCONDOR-1652 Fix bad dereference when SCITOKENS_SERVER_AUDIENCE not set

### DIFF
--- a/docs/version-history/lts-versions-10-0.rst
+++ b/docs/version-history/lts-versions-10-0.rst
@@ -101,6 +101,11 @@ Bugs Fixed:
   submit description weren't properly sent to the ARC CE service.
   :jira:`1648`
 
+- Fixed a bug that can cause a daemon to crash during SciTokens
+  authentication if the configuration parameter
+  ``SCITOKENS_SERVER_AUDIENCE`` isn't set.
+  :jira:`1652`
+
 .. _lts-version-history-1002:
 
 Version 10.0.2

--- a/src/condor_utils/condor_scitokens.cpp
+++ b/src/condor_utils/condor_scitokens.cpp
@@ -258,8 +258,8 @@ htcondor::validate_scitoken(const std::string &scitoken_str, std::string &issuer
 			audiences.emplace_back(aud);
 			audience_ptr.push_back(audiences.back().c_str());
 		}
-		audience_ptr.push_back(nullptr);
 	}
+	audience_ptr.push_back(nullptr);
 	long long expiry_value;
 	if ((*scitoken_deserialize_ptr)(scitoken_str.c_str(), &token, nullptr, &err_msg)) {
 		err.pushf("SCITOKENS", 2, "Failed to deserialize scitoken: %s",


### PR DESCRIPTION
Also add a nullptr to the end of audience_ptr. Otherwise, our attempt to get the address of the vector data can crash if it's otherwise empty.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
