### PR TITLE
HTCONDOR-1640-replace-classy-counted-ptr-with-explicit

### DIFF
--- a/src/condor_daemon_core.V6/daemon_command.cpp
+++ b/src/condor_daemon_core.V6/daemon_command.cpp
@@ -207,10 +207,6 @@ DaemonCommandProtocol::CommandProtocolResult DaemonCommandProtocol::WaitForSocke
 		return CommandProtocolFinished;
 	}
 
-		// Do not allow ourselves to be deleted until after
-		// SocketCallback is called.
-	incRefCount();
-
 	condor_gettimestamp( m_async_waiting_start_time );
 
 	return CommandProtocolInProgress;
@@ -230,9 +226,6 @@ DaemonCommandProtocol::SocketCallback( Stream *stream )
 	m_prev_sock_ent = NULL;
 
 	int rc = doProtocol();
-
-		// get rid of ref counted when callback was registered
-	decRefCount();
 
 	return rc;
 }
@@ -1976,8 +1969,11 @@ int DaemonCommandProtocol::finalize()
 	}
 
 
-	if ( m_result == KEEP_STREAM || m_sock == NULL )
+	if ( m_result == KEEP_STREAM || m_sock == NULL ) {
+		delete this;
 		return KEEP_STREAM;
-	else
+	} else {
+		delete this;
 		return TRUE;
+	}
 }

--- a/src/condor_daemon_core.V6/daemon_command.h
+++ b/src/condor_daemon_core.V6/daemon_command.h
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-class DaemonCommandProtocol: Service, public ClassyCountedPtr {
+class DaemonCommandProtocol: Service {
 
 	friend class DaemonCore;
 

--- a/src/condor_daemon_core.V6/daemon_core.cpp
+++ b/src/condor_daemon_core.V6/daemon_core.cpp
@@ -4659,7 +4659,8 @@ int DaemonCore::HandleReq(Stream *insock, Stream* asock)
 		}
 	}
 
-	classy_counted_ptr<DaemonCommandProtocol> r = new DaemonCommandProtocol(asock,is_command_sock);
+	// DaemonCommandProtocol::finalize deletes r after last callback fires
+	DaemonCommandProtocol *r = new DaemonCommandProtocol(asock,is_command_sock);
 
 	int result = r->doProtocol();
 

--- a/src/condor_io/shared_port_server.cpp
+++ b/src/condor_io/shared_port_server.cpp
@@ -239,7 +239,10 @@ SharedPortServer::HandleConnectRequest(int,Stream *sock)
 	if( strcmp( shared_port_id, "self" ) == 0 ) {
 		// The last 'true' flags this protocol as being "loopback," so
 		// we won't ever end up back here and pass off the request.
-		classy_counted_ptr< DaemonCommandProtocol > r = new DaemonCommandProtocol( sock, true, true );
+
+		// This is delete'd by the DaemonCommandProtocol finalize method
+		// always make sure that all code paths end there.
+		DaemonCommandProtocol *r = new DaemonCommandProtocol( sock, true, true );
 		return r->doProtocol();
 	}
 


### PR DESCRIPTION
[HTCONDOR-1640]](https://opensciencegrid.atlassian.net/browse/HTCONDOR-1640)

G++ 12 is throwing an incomprensible warning about delete delete'ing non-heap memory (off by 8) in ClassyCountedPtr::decRefCnt.

This comes from code like:

{
   classy_counted_ptr<Foo> *f = new Foo;
   f->doSomething();
}

Note that the classy_counted_ptr template is completely superflous here. f's ref count should go to zero at the end of the block, and then it should be deleted.  There is no difference between this code, and just allocating an instance of Foo on the stack.

But, it turns out, that Foo::doSomething explicitly manipulates the reference count in the Foo's base class ClassyCountedPtr (note the case), so that when classy_counted_ptr [sic] goes out of scope, the reference count isn't zero, and the lifetime is extended.

So, wrapping the Foo in a classy_counted_ptr [sic] is completely useless here, and just adds confusion to what is going on.

This PR first removes the classy_counted_ptr [sic], to make it more obvious what is happening (and adds a comment at the call site).

Then, we notice that all code paths for instances of Foo end in Foo::finalize.  So, we add an explicit "delete this" call in finalize, remove the calls to increment and decrement the reference count, and remove the ClassyCountedPtr base class that Foo (in this case DaemonCommandProtocol) multiply-inherits from.

Is calling "delete this" dangerous?  Yes, but it is obviously dangerous and more obviously dangerous than the "delete this" burried inside a call to this->decRefCnt.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer


[HTCONDOR-1640]: https://opensciencegrid.atlassian.net/browse/HTCONDOR-1640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ