### PR TITLE
Add sub-second resolution to DaemonCore.  HTCONDOR-1674

### DIFF
--- a/src/condor_daemon_core.V6/condor_daemon_core.h
+++ b/src/condor_daemon_core.V6/condor_daemon_core.h
@@ -1112,6 +1112,16 @@ class DaemonCore : public Service
                         TimerHandler handler,
                         const char * event_descrip);
 
+    /** Register a fine-grained time callback
+        @param deltawhen       When the timer event callback should fire.
+        @param handler         Callback function for the handler
+        @param handler_descrip Human-friendly description of the timer.
+    */
+    int Register_Timer (const struct timespec &deltawhen,
+                        TimerHandler           handler,
+                        const char            *event_descrip);
+
+
 	/** Not_Yet_Documented
         @param deltawhen       Not_Yet_Documented
         @param event           Not_Yet_Documented

--- a/src/condor_utils/selector.h
+++ b/src/condor_utils/selector.h
@@ -55,6 +55,7 @@ public:
 	void delete_fd( int fd, IO_FUNC interest );
 	void set_timeout( time_t sec, long usec = 0 );
 	void set_timeout( timeval tv );
+	void set_timeout( const std::timespec &tv );
 	void unset_timeout();
 	void execute();
 	int select_retval() const;


### PR DESCRIPTION
This converts the internals of the TimerManager to do sub-second accounting using the newly-standardized `std::timespec` (which is the C++17 way of writing `struct timespec`).

Sub-second accounting will be required for HTCSS to switch to the new non-blocking API for SciTokens.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
