### PR TITLE
HTCONDOR-1689: Default condor home to /var/lib/condor on Debian/Unbuntu

### DIFF
--- a/build/packaging/debian/htcondor.postinst
+++ b/build/packaging/debian/htcondor.postinst
@@ -9,14 +9,16 @@ db_version 2.0
 
 condor_user=condor
 condor_gecos="HTCondor Daemons"
-local_dir=$(condor_config_val LOCAL_DIR 2>/dev/null)
+# make this one fixed because 'condor_config_val -tilde' relies on the user
+# home dir to exist
+condor_home=/var/lib/condor
 
 
 case "$1" in
     configure)
         # according to http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=621833#119
         # this should always work
-        if ! adduser --system --group --gecos "$condor_gecos" --home $local_dir \
+        if ! adduser --system --group --gecos "$condor_gecos" --home $condor_home \
                 --disabled-password --disabled-login $condor_user --quiet 2>/dev/null; then
             # the only time where it would fail, is when there is an existing
             # non-system 'condor' user. This could happen e.g. in a heterogenous
@@ -37,11 +39,10 @@ case "$1" in
                 exit 1
             fi
         fi
-        # The local dir (which is often condor's home directry)
-        # needs to be world readable for proper operation
-        if [ -d $local_dir ]; then
+        # condor's home directory needs to be world readable for proper operation
+        if [ -d $condor_home ]; then
             # Open up the permission, if the directory exists
-            chmod o+rx $local_dir
+            chmod o+rx $condor_home
         fi
         # condor_master needs a log directory to start up
         dirname=$(condor_config_val LOG 2>/dev/null)

--- a/docs/version-history/lts-versions-10-0.rst
+++ b/docs/version-history/lts-versions-10-0.rst
@@ -46,6 +46,10 @@ New Features:
 
 Bugs Fixed:
 
+- Fix bug, introduced in HTCondor version 10.0.2, that prevented new
+  installations of HTCondor from working on Debian or Ubuntu.
+  :jira:`1689`
+
 - Fixed a rare bug in the late materialization code that could
   cause a schedd crash.
   :jira:`1581`


### PR DESCRIPTION
This commit corrects my blunder with confusing LOCAL_DIR and condor's home directory. (HTCONDOR-1537) It retains the change to open up the permissions on /var/lib/condor if it exists. This is required on later versions of Debian and Ubuntu because user's home directories are not world readble.  It conditionally checks for the directory's existance, because if the script produces an error, the whole installation fails.

[HTCONDOR-1689](https://opensciencegrid.atlassian.net/browse/HTCONDOR-1689)

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer


[HTCONDOR-1689]: https://opensciencegrid.atlassian.net/browse/HTCONDOR-1689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ