### PR TITLE
HTCONDOR-1687  Child process clean-up.

### DIFF
--- a/docs/version-history/feature-versions-10-x.rst
+++ b/docs/version-history/feature-versions-10-x.rst
@@ -43,6 +43,12 @@ New Features:
 
 Bugs Fixed:
 
+- Fixed a bug where certain errors during file transfer could result in
+  file-transfer processes not being cleaned up.  This would manifest as
+  jobs completing succesfully, including final file transfer, but ending
+  up without one of their output files (the one the error occurred during).
+  :jira:`1687`
+
 - Fixed a bug where if the docker command emitted warnings to stderr, the
   startd would not correctly advertise the amount of used image cache.
   :jira:`1645`

--- a/src/condor_daemon_core.V6/condor_daemon_core.h
+++ b/src/condor_daemon_core.V6/condor_daemon_core.h
@@ -1780,7 +1780,9 @@ class DaemonCore : public Service
 		// its selfAd.
 	bool SetupAdministratorSession(unsigned duration, std::string &capability);
 
-  private:      
+	void kill_immediate_children();
+
+  private:
 
 		// do and our parents/children want/have a udp comment socket?
 	bool m_wants_dc_udp;

--- a/src/condor_daemon_core.V6/daemon_core.cpp
+++ b/src/condor_daemon_core.V6/daemon_core.cpp
@@ -9334,11 +9334,13 @@ DaemonCore::HandleDC_SERVICEWAITPIDS(int)
 			// queue is empty, just return cuz nothing more to do
 			return TRUE;
 		}
-		wait_entry = WaitpidQueue.front();
-		WaitpidQueue.pop_front();
 
+		wait_entry = WaitpidQueue.front();
 		// we pulled something off the queue, handle it
 		HandleProcessExit(wait_entry.child_pid, wait_entry.exit_status);
+		// Remove wait_entry from the queue _after_ invoking the callback
+		// so that the callback can tell that the process is gone.
+		WaitpidQueue.pop_front();
 
 		iReapsCnt--;
 	}

--- a/src/condor_shadow.V6.1/remoteresource.cpp
+++ b/src/condor_shadow.V6.1/remoteresource.cpp
@@ -606,6 +606,8 @@ RemoteResource::closeClaimSock( void )
 void
 RemoteResource::disconnectClaimSock(const char *err_msg)
 {
+	abortFileTransfer();
+
 	if (!claim_sock) {
 		return;
 	}

--- a/src/condor_shadow.V6.1/remoteresource.h
+++ b/src/condor_shadow.V6.1/remoteresource.h
@@ -497,6 +497,8 @@ class RemoteResource : public Service {
         time_t TerminationTime;
     } activation;
 
+	void abortFileTransfer();
+
 private:
 
 		/// Private helper methods for trying to reconnect
@@ -545,7 +547,6 @@ private:
 	void startCheckingProxy();
 	void attemptShutdownTimeout();
 	void attemptShutdown();
-	void abortFileTransfer();
 	int transferStatusUpdateCallback(FileTransfer *transobject);
 };
 

--- a/src/condor_shadow.V6.1/shadow.cpp
+++ b/src/condor_shadow.V6.1/shadow.cpp
@@ -412,6 +412,11 @@ UniShadow::resourceDisconnected( RemoteResource* rr )
 {
 	ASSERT( rr == remRes );
 
+
+	// All of our children should be gone already, but let's be sure.
+	daemonCore->kill_immediate_children();
+
+
 	const char* txt = "Socket between submit and execute hosts "
 		"closed unexpectedly";
 	logDisconnectedEvent( txt );

--- a/src/condor_shadow.V6.1/shadow_v61_main.cpp
+++ b/src/condor_shadow.V6.1/shadow_v61_main.cpp
@@ -61,6 +61,7 @@ int
 ExceptCleanup(int, int, const char *buf)
 {
   BaseShadow::log_except(buf);
+  daemonCore->kill_immediate_children();
   return 0;
 }
 

--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -5855,6 +5855,11 @@ description=Where should condor_adstash place JSON files if using the jsonfile i
 type=path
 default=$(LOG)
 
+[DEFAULT_KILL_CHILDREN_ON_EXIT]
+description=Hidden knob.  If true, all daemon core daemons will kill all of their children on exit.
+type=bool
+default=true
+
 ######
 ## add metaknobs below this banner
 ##


### PR DESCRIPTION
  Daemon core now kills its immediate children in DC_Exit().  The shadow now kills its immediate children on EXCEPT().  The daemon core reaper caller now leaves the wait entry in the queue until after the callback finishes, so that the starter can tell if the job proc(s) need to be killed on the way out the door.

Also, the shadow now aborts file transfers on disconnects.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
