### PR TITLE
HTCONDOR-1668: htcondor-test contains binaries

### DIFF
--- a/build/packaging/debian/control.in
+++ b/build/packaging/debian/control.in
@@ -241,7 +241,7 @@ Description: distributed workload management system - single node configuration
  This package provides files needed to create a stand-alone HTCondor tarball.
 
 Package: htcondor-test
-Architecture: all
+Architecture: any
 Section: science
 Depends: htcondor (= ${binary:Version}),
          ${misc:Depends}


### PR DESCRIPTION
This came up as I was releasing. I noticed the ppc64le htcondor-test package was not allowed into the repository, because it was incorrectly tagged as noarch. It does contain some binaries for testing. Since we only support using this package BaTLab, we can fix this up after release.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
