### PR TITLE
HTCONDOR-1754 turn off cgroup v2 when we don't have root

### DIFF
--- a/src/condor_starter.V6.1/vanilla_proc.cpp
+++ b/src/condor_starter.V6.1/vanilla_proc.cpp
@@ -215,7 +215,7 @@ static bool cgroup_v1_is_writeable(const std::string &relative_cgroup) {
 }
 
 static bool cgroup_v2_is_writeable(const std::string &relative_cgroup) {
-	return cgroup_controller_is_writeable("", relative_cgroup);
+	return can_switch_ids() && cgroup_controller_is_writeable("", relative_cgroup);
 }
 
 static bool cgroup_is_writeable(const std::string &relative_cgroup) {


### PR DESCRIPTION
The unprivileged cgroup v2 code isn't working in batlab where we run in a docker container without root.  We can make new cgroups, but the root cgroup doesn't have cgroup.subtree_controllers settable, so we can't
move processes into the cgroups we create.

For now, turn off the ability to use cgroup v2 when we don't have root.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
