### PR TITLE
HTCONDOR-1626: Increase timeout for DAGMan save files test

### DIFF
--- a/src/condor_tests/test_dagman_save_files.py
+++ b/src/condor_tests/test_dagman_save_files.py
@@ -145,7 +145,7 @@ def run_params(runTests):
     return runTests[2]
 @action
 def run_wait(run_handle):
-    assert run_handle.wait(condition=ClusterState.all_complete,timeout=30)
+    assert run_handle.wait(condition=ClusterState.all_complete,timeout=60)
     return run_handle
 
 #-----------------------------------------------------------------------------------------------
@@ -186,7 +186,7 @@ def rerun_params(rerunTests):
     return rerunTests[2]
 @action
 def rerun_wait(rerun_handle):
-    assert rerun_handle.wait(condition=ClusterState.all_complete,timeout=30)
+    assert rerun_handle.wait(condition=ClusterState.all_complete,timeout=60)
     return rerun_handle
 
 #===============================================================================================


### PR DESCRIPTION
-The DAGMan save files test periodically times out on aarch64 AlmaLinux8
 which runs a bit slower. Looking at the various test outputs the DAG job
 is running successfully, but the wait handle is timing out. So, we are
 increasing the wait timeout number to not fail.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
