### PR TITLE
HTCONDOR-1626 make test_condor_now more reliable

### DIFF
--- a/src/condor_tests/test_condor_now.py
+++ b/src/condor_tests/test_condor_now.py
@@ -29,7 +29,7 @@ def max_victim_jobs():
     params={
         # PyTest and HTCondor can both handle spaces in the parameter name,
         # but it's easier debugging in the shell without them.
-        "time_out": ("1", "[now job {0}]: coalesce command timed out, failing"),
+        "time_out": ("1", "Failed to send COALESCE_SLOTS to startd"),
         "transient_failure": (
             "2",
             "[now job {0}]: coalesce failed: FAILURE INJECTION: 2",
@@ -137,7 +137,7 @@ def sched_log_containing_failure(
     assert sched_log.wait(
         # The documentation of DaemonLogMessage looks incomplete, but since
         # this doesn't start with an underscore, I'm assuming it's public.
-        condition=lambda line: line.message == failure_log_message_with_job_id,
+        condition=lambda line: failure_log_message_with_job_id in line.message,
         timeout=60,
     )
 


### PR DESCRIPTION
The test was looking for a message on a timeout failure that was usually printed to the log, but due to a race condition inside daemon core callbacks, this message was sometimes not printed to the log.  Replace looking for this message with a message that it always printed

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
