### PR TITLE
HTCONDOR-1769-fix-cmd-drain-scavenging-test

### DIFF
--- a/src/condor_tests/cmd_drain_scavenging.run
+++ b/src/condor_tests/cmd_drain_scavenging.run
@@ -487,14 +487,23 @@ sub checkTiming {
 		 ${secondsMatch}\ slot1_\7${jidm}:\ max\ vacate\ time\ expired.\ \ Escalating\ to\ a\ fast\ shutdown\ of\ the\ job
 		 /sx) {
 			my $finalDrainStartTime = $1;
-			if ($finalDrainStartTime != $4) {
-				die( "slot1_$7 did not start retiring immediately, aborting.\n" );
+			# Ugh. We print the log time as the message is printed, so each line will have a different timestamp
+			# if we start at second XX.99something, we will likely wrap to (XX + 1).something, so need to have some 
+			# slop.  If this happens at 59 seconds, also need to accept 00 seconds as the "after" time.
+			if (($4 - $finalDrainStartTime) > 2) {
+				if ($4 != 0) {
+					die( "slot1_$7 did not start retiring immediately, aborting.\n" );
+				}
 			}
-			if ($finalDrainStartTime != $8) {
-				die( "MaxJobRetirementTime was not 0, aborting.\n" );
+			if (($8 - $finalDrainStartTime) > 2) {
+				if ($8 != 0) {
+					die( "MaxJobRetirementTime was not 0, aborting.\n" );
+				}
 			}
-			if ($finalDrainStartTime != $11) {
-				die( "slot1_$7 did not immediately switch from retiring to preempting.\n" );
+			if (($11 - $finalDrainStartTime) > 2) {
+				if ($11 != 0) {
+					die( "slot1_$7 did not immediately switch from retiring to preempting.\n" );
+				}
 			}
 			# Especially with sub-second reporting, allow the startd some time to work.
 			if( (($finalDrainStartTime + 4) % 60) != $14 && (($finalDrainStartTime + 5) % 60) != $14 && (($finalDrainStartTime + 6) % 60) != $14 ) {


### PR DESCRIPTION
This test scrapes the StartLog, and verifies that the drain, evict and other events happen at the same time if however, the first log message happens near the end of a second, and the second rolls over, we get a false negative

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
