### PR TITLE
HTCONDOR-1771: DAGMan fail job submission with +vars

### DIFF
--- a/docs/version-history/lts-versions-10-0.rst
+++ b/docs/version-history/lts-versions-10-0.rst
@@ -87,6 +87,12 @@ Bugs Fixed:
 - Fixed a missing library import in *condor_credmon_vault*.
   :jira:`1527`
 
+- Fixed a bug where DAGMan job submission would fail when not using
+  direct submission due to setting a custom job classad attribute with
+  the ``+`` syntax in a ``VARS`` command that doesn't append the
+  variables i.e. ``VARS NodeA PREPEND +customAttr="value"``
+  :jira:`1771`
+
 .. _lts-version-history-1003:
 
 Version 10.0.3

--- a/src/condor_dagman/parse.cpp
+++ b/src/condor_dagman/parse.cpp
@@ -1797,6 +1797,9 @@ static bool parse_vars(Dag *dag, const char *filename, int lineNumber)
 			}
 			if ( varName.empty() ) {
 				break;
+			} else if (varName[0] == '+') {
+				//convert + syntax vars to 'My.' syntax
+				varName = "My." + varName.substr(1);
 			}
 
 			job->AddVar(varName.c_str(), varValue.c_str(), filename, lineNumber, prepend);

--- a/src/condor_tests/job_dagman_vars_prepend.run
+++ b/src/condor_tests/job_dagman_vars_prepend.run
@@ -66,7 +66,8 @@ $dagfile=
 JOB test job_dagman_vars_prepend.cmd
 VARS test PREPEND pass_var1=\"Passed Prepend\"
 VARS test APPEND test_var2=\"Passed Append\"
-VARS test test_var3=\"Outer\"";
+VARS test test_var3=\"Outer\"
+VARS test PREPEND +ThisShouldNotBreakShellSubmission=\"asdf\"";
 
 $submitfile=
 "executable = \$CHOICE(isWindows, /bin/echo, ..\\appendmsg.exe)


### PR DESCRIPTION
-Changed DAGMan VARS parsing to automatically replace
 '+' to 'My.' for custom variables i.e. +attr -> My.attr
-Updated test to add a custom + attr that isn't appended
 to check for breakage

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
