### PR TITLE
HTCONDOR-1768-job-periodic-hold-test

### DIFF
--- a/src/condor_tests/job_core_perhold_local.run
+++ b/src/condor_tests/job_core_perhold_local.run
@@ -73,14 +73,6 @@ $held = sub {
 		RegisterResult(0,"test_name", "testname");
 		return(1);
 	} else { # perhold TRUE case hold handling`
-		##
-		## Make sure we weren't here earlier
-		##
-		if ( $gotHold ) {
-			CondorTest::debug("Bad - Job $cluster.$job was put on hold twice.\n",1);
-			RegisterResult(0,"test_name", "$testname");
-		}
-	
 		CondorTest::debug("Good - Job $cluster.$job was put on hold.\n",1);
 
 		##


### PR DESCRIPTION
It shouldn't error if there is more than one hold event for a job.  That's an expected, but rare condition

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
