### PR TITLE
HTCONDOR-1785: Fix restd startup crash due to bad locale in minicondor container

### DIFF
--- a/build/docker/services/mini/condor_restd.sh
+++ b/build/docker/services/mini/condor_restd.sh
@@ -1,7 +1,28 @@
 #!/bin/bash
+# Flask needs a UTF locale; if one is not set, find one.
+# Prefer C, then en_US, then just pick one.
+# Depending on distro, a locale may have a ".utf8" or a ".UTF-8" suffix.
+if [[ $LANG != *[Uu][Tt][Ff]* ]]; then
+    utf_locales=$(locale -a | grep -i utf)
+    c_utf_locale=$(printf "%s\n" "$utf_locales" | grep '^C\.' | head -n 1)
+    en_us_utf_locale=$(printf "%s\n" "$utf_locales" | grep '^en_US\.' | head -n 1)
+    last_resort_utf_locale=$(printf "%s\n" "$utf_locales" | head -n 1)
 
-export LANG=en_US.UTF-8
-export LC_ALL=en_US.UTF-8
+    if [[ $c_utf_locale ]]; then
+        LANG=$c_utf_locale
+    elif [[ $en_us_utf_locale ]]; then
+        LANG=$en_us_utf_locale
+    elif [[ $last_resort_utf_locale ]]; then
+        LANG=$last_resort_utf_locale
+    else
+        echo 1>&2 "No UTF locale found - bailing."
+        exit 1
+    fi
+fi
+LC_ALL=$LANG
+
+export LC_ALL LANG
+
 export FLASK_APP=condor_restd
 export FLASK_ENV=dev
 

--- a/build/docker/services/mini/condor_restd.sh
+++ b/build/docker/services/mini/condor_restd.sh
@@ -26,4 +26,16 @@ export LC_ALL LANG
 export FLASK_APP=condor_restd
 export FLASK_ENV=dev
 
-exec /usr/bin/flask-3 run -h 0.0.0.0 -p 8080
+# The location and name of the flask executable is also distro-dependent
+for flask in {/usr/bin,/usr/local/bin}/{flask,flask-3} NOTFOUND; do
+    if [[ -x $flask ]]; then
+        break
+    fi
+done
+
+if [[ $flask == NOTFOUND ]]; then
+    echo 1>&2 "No flask executable found - bailing"
+    exit 127
+fi
+
+exec "$flask" run -h 0.0.0.0 -p 8080


### PR DESCRIPTION
Some fixups needed to make the condor_restd Flask app start up correctly on containers from various distros:

- Flask needs a UTF-8 locale; the available ones are different between EL7, EL8, and ubuntu 20.04
- The location of the Flask executable also varies

The build-images script does not yet support EL9 and Ubuntu 22.04, so this hasn't been tested on those platforms.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
