### PR TITLE
HTCONDOR-1821: LVM leaking sandboxes on EP

### DIFF
--- a/src/condor_startd.V6/ResMgr.cpp
+++ b/src/condor_startd.V6/ResMgr.cpp
@@ -472,7 +472,10 @@ ResMgr::init_resources( void )
 	m_execution_xfm.config("JOB_EXECUTION");
 
 #ifdef LINUX
-	m_volume_mgr.reset(new VolumeManager());
+	if (!param_boolean("STARTD_ENFORCE_DISK_LIMITS", false)) {
+		dprintf(D_STATUS, "Startd will not enforce disk limits via logical volume management.\n");
+		m_volume_mgr.reset(nullptr);
+	} else { m_volume_mgr.reset(new VolumeManager()); }
 #endif // LINUX
 
     stats.Init();

--- a/src/condor_startd.V6/Starter.cpp
+++ b/src/condor_startd.V6/Starter.cpp
@@ -574,20 +574,18 @@ Starter::exited(Claim * claim, int status) // Claim may be NULL.
 #ifdef LINUX
 	if (claim && claim->rip() && claim->rip()->getVolumeManager()) {
 		auto &slot_name = claim->rip()->r_id_str;
-		dprintf(D_ALWAYS,"Starter::exited for %s. Attempting to cleanup LVM partition.\n",slot_name);
+		dprintf(D_ALWAYS,"Starter::Exited for %s. Attempting to cleanup LVM partition.\n",slot_name);
 		CondorError err;
 		if (!claim->rip()->getVolumeManager()->CleanupSlot(slot_name, err)) {
-			if (abnormal_exit) {
+			std::string msg = err.getFullText();
+			if (abnormal_exit && msg.find("Failed to find logical volume") == std::string::npos) {
 				dprintf(D_ALWAYS, "Failed to cleanup slot %s logical volume: %s",
-					slot_name, err.getFullText().c_str());
+					slot_name, msg.c_str());
 			}
 		}
-	} else {
-		cleanup_execute_dir( s_pid, executeDir(), s_created_execute_dir, abnormal_exit );
 	}
-#else
-	cleanup_execute_dir( s_pid, executeDir(), s_created_execute_dir, abnormal_exit );
 #endif // LINUX
+	cleanup_execute_dir( s_pid, executeDir(), s_created_execute_dir, abnormal_exit );
 
 }
 

--- a/src/condor_startd.V6/Starter.cpp
+++ b/src/condor_startd.V6/Starter.cpp
@@ -576,12 +576,26 @@ Starter::exited(Claim * claim, int status) // Claim may be NULL.
 		auto &slot_name = claim->rip()->r_id_str;
 		dprintf(D_ALWAYS,"Starter::Exited for %s. Attempting to cleanup LVM partition.\n",slot_name);
 		CondorError err;
-		if (!claim->rip()->getVolumeManager()->CleanupSlot(slot_name, err)) {
-			std::string msg = err.getFullText();
-			if (abnormal_exit && msg.find("Failed to find logical volume") == std::string::npos) {
-				dprintf(D_ALWAYS, "Failed to cleanup slot %s logical volume: %s",
-					slot_name, msg.c_str());
+		// Attempt LV cleanup n times to prevent race condition between
+		// killing of family processes and LV cleanup causing failure
+		int max_attempts = 5;
+		for (int attempt=1; attempt<=max_attempts; attempt++) {
+			// Attempt a cleanup
+			dprintf(D_FULLDEBUG, "LV cleanup attempt %d/%d\n", attempt, max_attempts);
+			if (!claim->rip()->getVolumeManager()->CleanupSlot(slot_name, err)) {
+				std::string msg = err.getFullText();
+				if (!abnormal_exit && msg.find("Failed to find logical volume") != std::string::npos) {
+					break; // If starter exited normally and we failed to find LV assume it is cleaned up
+				} else if (attempt == max_attempts){
+					// We have failed and this was the last attempt so output error message
+					dprintf(D_ALWAYS, "Failed to cleanup slot %s logical volume: %s", slot_name, msg.c_str());
+				}
+				err.clear();
+			} else {
+				dprintf(D_FULLDEBUG, "LVM cleanup succesful.\n");
+				break;
 			}
+			sleep(1);
 		}
 	}
 #endif // LINUX

--- a/src/condor_startd.V6/VolumeManager.cpp
+++ b/src/condor_startd.V6/VolumeManager.cpp
@@ -23,10 +23,6 @@ static std::vector<std::string> ListPoolLVs(const std::string &pool_name, Condor
 VolumeManager::VolumeManager()
     : m_encrypt(param_boolean("STARTD_ENCRYPT_EXECUTE_DISK", false))
 {
-    if (!param_boolean("STARTD_ENFORCE_DISK_LIMITS", false)) {
-        dprintf(D_FULLDEBUG, "Not enforcing disk limits in the startd.\n");
-        return;
-    }
     std::string pool_name; std::string volume_group_name;
     if (!param(pool_name, "THINPOOL_NAME") || !param(volume_group_name, "THINPOOL_VOLUME_GROUP_NAME")) {
         param(m_loopback_filename, "THINPOOL_BACKING_FILE", "$(SPOOL)/startd_disk.img");

--- a/src/condor_starter.V6.1/starter.cpp
+++ b/src/condor_starter.V6.1/starter.cpp
@@ -3760,8 +3760,8 @@ Starter::removeTempExecuteDir( void )
 #ifdef LINUX
 	if (m_volume_mgr) {
 		//LVM managed... reset handle pointer to call destructor for cleanup
-		m_volume_mgr.reset();
-		return true;
+		//We can't determine if the cleanup failed or not, and need to rm the working dir
+		m_volume_mgr.reset(nullptr);
 	}
 #endif /* LINUX */
 


### PR DESCRIPTION
-Changed LVM to cleanup LV then do normal execute dir
 cleanup on both Starter and Startd side
-Moved check for if using startd disk enforcment out of
 VolumeManager constructor to prevent creation of object
 if not using it

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
