### PR TITLE
HTCONDOR-1853-fix-niceuser-test

### DIFF
--- a/src/condor_tests/job_core_niceuser_van.run
+++ b/src/condor_tests/job_core_niceuser_van.run
@@ -34,6 +34,8 @@ my $config = <<CONDOR_TESTREQ_CONFIG;
 CONDOR_TESTREQ_CONFIG
 #endtestreq
 
+CondorTest::runCondorTool("condor_off -negotiator");
+
 my $debuglevel = 2;
 my $pid = $$;
 
@@ -58,6 +60,11 @@ my @vdata =
 my @skiplines = ();
 my $datafile = "$testname$pid.data";
 my $count = 4;
+
+my $SubmitSuccess = sub
+{
+	CondorTest::runCondorTool("condor_on -negotiator");
+};
 
 my $ExitSuccess = sub 
 {
@@ -84,12 +91,14 @@ CreateEmptyFile("$datafile");
 
 SimpleJob::RunCheck(
     runthis=>"x_do_niceuser.pl",
+	# "Duration" means "arguments"
 	duration=>'$(accounting_group) ' . $datafile,
 	should_transfer_files=>"YES",
 	when_to_transfer_output=>"ON_EXIT",
 	transfer_input_files=>"$datafile",
 	transfer_output_files=>"$datafile",
 	on_success=>$ExitSuccess,
+	on_submit=>$SubmitSuccess,
 	queue_sz=>"accounting_group in (nice-user, rude, rude, nice-user)"
 );
 


### PR DESCRIPTION
The test job_core_niceuser_van fails intermittently.  It starts a one slot startd, and in one job cluster, submits two nice user jobs and two non-nice user jobs, and tests that both non-nice user jobs start and run first.

The problem is that when the schedd sends the two submitter ads to the collector, it doesn’t do this atomically.  Rarely, the negotiator will run when the nice user submitter ad is in the collector, but the non-nice submitter ad is not.  In this case, we run the jobs in the “wrong” order.

Ideally, we should have an interface to the collector where we can atomically update multiple ads, but we don’t.  To fix this test, we will turn off the negotiator, submit the jobs, and only after the submit event is written, start up the negotiator again.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
