### PR TITLE
HTCONDOR-1895: LVM with Docker container bug

### DIFF
--- a/docs/version-history/feature-versions-10-x.rst
+++ b/docs/version-history/feature-versions-10-x.rst
@@ -31,6 +31,12 @@ Bugs Fixed:
   EP when using Startd disk enforcement.
   :jira:`1821`
 
+- When using Startd disk enforcement, if a *condor_starter* running a container
+  or VM universe job is abrubtly killed (like SIGABRT) then the *condor_startd*
+  would fail to cleanup the running docker container or VM and underlying logical
+  volume.
+  :jira:`1895`
+
 Version 10.6.0
 --------------
 

--- a/src/condor_startd.V6/Starter.cpp
+++ b/src/condor_startd.V6/Starter.cpp
@@ -573,6 +573,12 @@ Starter::exited(Claim * claim, int status) // Claim may be NULL.
 
 #ifdef LINUX
 	if (claim && claim->rip() && claim->rip()->getVolumeManager()) {
+		// Attempt to cleanup of recovery files/directories used by docker/vm universe
+		std::string pid_dir, pid_dir_path;
+		formatstr(pid_dir, "dir_%d", s_pid);
+		formatstr(pid_dir_path, "%s/%s", executeDir(), pid_dir.c_str());
+		check_recovery_file(pid_dir_path.c_str(), abnormal_exit);
+		// Attempt LV cleanup
 		auto &slot_name = claim->rip()->r_id_str;
 		dprintf(D_ALWAYS,"Starter::Exited for %s. Attempting to cleanup LVM partition.\n",slot_name);
 		CondorError err;

--- a/src/condor_startd.V6/util.h
+++ b/src/condor_startd.V6/util.h
@@ -31,6 +31,7 @@ class StringList;
 void	cleanup_execute_dir(int pid, char const *exec_path, bool remove_exec_path, bool abnormal_exit);
 void	cleanup_execute_dirs( StringList &list );
 void	check_execute_dir_perms( StringList &list );
+void	check_recovery_file( const char *sandbox_dir, bool abnormal_exit );
 
 bool	reply( Stream*, int );
 bool	refuse( Stream* );


### PR DESCRIPTION
-Duplicated the check/removal of VM & Docker universe
 recovery files to occur prior to LVM cleanup to prevent
 rogue docker containers and VMs. This is also an issue
 because these parts continually running prevent the LVM
 from being cleanedup due to the filesystems being in use

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
