### PR TITLE
HTCONDOR-1925-supress-clang-alignment-warnings

### DIFF
--- a/src/condor_utils/CMakeLists.txt
+++ b/src/condor_utils/CMakeLists.txt
@@ -556,6 +556,12 @@ add_custom_target (utils_genparams ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/param
 
 if(UNIX)
 	set_source_files_properties(param_info.cpp PROPERTIES COMPILE_FLAGS -Wno-unused-parameter)
+	# The inotify system call is basically impossible to use without triggering casting to larger
+	# alignment warnings.  So just turn that off for this file
+	set_source_files_properties(file_modified_trigger.cpp PROPERTIES COMPILE_FLAGS -Wno-cast-align)
+
+	# ditto for this file
+	set_source_files_properties(ipv6_hostname.cpp PROPERTIES COMPILE_FLAGS -Wno-cast-align)
 endif(UNIX)
 
 ############ end generate params


### PR DESCRIPTION
In particular, the inotify and some of the ipv6 routines are fundamentally hard to supress warnings about alignment restrictions.  Just turn off the warnings in those files.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
