### PR TITLE
HTCONDOR-1909: Fix service nodes blowing up DAGMan

### DIFF
--- a/docs/version-history/lts-versions-10-0.rst
+++ b/docs/version-history/lts-versions-10-0.rst
@@ -24,7 +24,9 @@ New Features:
 
 Bugs Fixed:
 
-- None.
+- Fixed a bug in DAGMan where service nodes that finish before the DAGs
+  end would result in DAGMan crashing due to an assertion failure.
+  :jira:`1909`
 
 .. _lts-version-history-1007:
 

--- a/src/condor_dagman/dag.cpp
+++ b/src/condor_dagman/dag.cpp
@@ -4251,9 +4251,8 @@ Dag::ProcessSuccessfulSubmit( Job *node, const CondorID &condorID )
 		// we see the submit events so that we don't accidentally exceed
 		// maxjobs (now really maxnodes) if it takes a while to see
 		// the submit events.  wenger 2006-02-10.
-	if ( node->GetType() != NodeType::SERVICE ) {
-		UpdateJobCounts( node, 1 );
-	}
+	UpdateJobCounts( node, 1 );
+
 
         // stash the job ID reported by the submit command, to compare
         // with what we see in the userlog later as a sanity-check
@@ -4361,6 +4360,8 @@ Dag::DecrementProcCount( Job *node )
 void
 Dag::UpdateJobCounts( Job *node, int change )
 {
+	// Service nodes are separate from normal jobs
+	if ( node->GetType() == NodeType::SERVICE ) { return; }
 	_numJobsSubmitted += change;
 	ASSERT( _numJobsSubmitted >= 0 );
 

--- a/src/condor_dagman/dag.h
+++ b/src/condor_dagman/dag.h
@@ -363,14 +363,23 @@ class Dag {
 	*/
 	inline int TotalJobsCompleted() const { return _totalJobsCompleted; }
 
-    /** @return the number of nodes ready to submit job to batch system
-     */
-    inline int NumNodesReady() const { return _readyQ->Number(); }
+	/** @return the number of nodes ready to submit job to batch system
+	*/
+	inline int NumNodesReady() const { return _readyQ->Number() - NumReadyServiceNodes(); }
 
-    /** @param whether to include final node, if any, in the count
-	    @return the number of nodes not ready to submit to batch system
+	/* Return the number of service nodes in the ready state
+	*/
+	inline int NumReadyServiceNodes() const {
+		int num = 0;
+		for (auto node : _service_nodes)
+			if (node->GetStatus() == Job::STATUS_READY) { ++num; }
+		return num;
+	}
+
+	/** @param whether to include final node, if any, in the count
+	@return the number of nodes not ready to submit to batch system
 	 */
-    inline int NumNodesUnready( bool includeFinal ) const {
+	inline int NumNodesUnready( bool includeFinal ) const {
 				return ( NumNodes( includeFinal )  -
 				( NumNodesDone( includeFinal ) + PreRunNodeCount() +
 				NumJobsSubmitted() + PostRunNodeCount() +
@@ -1098,7 +1107,7 @@ private:
 
 	bool _provisioner_ready = false;
 
-	std::list<Job*> _service_nodes{};
+	std::vector<Job*> _service_nodes{};
 
 	std::map<std::string, Job *>	_nodeNameHash;
 

--- a/src/condor_tests/CMakeLists.txt
+++ b/src/condor_tests/CMakeLists.txt
@@ -215,6 +215,7 @@ endif ()
 			condor_pl_test(test_drain_policies "Test job policy and backfill/draining interactions" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 			condor_pl_test(test_dagman_inline_submit "Test the DAGMan inline submit description feature" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 			condor_pl_test(test_dagman_submit_description "Test the DAGMan SUBMIT-DESCRIPTION command" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
+			condor_pl_test(test_dagman_service_nodes "Test the DAGMan service nodes" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 			condor_pl_test(test_scheduler_priority "Test that job priority is respected in scheduler universe" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 			condor_pl_test(test_parallel_uni "Test parallel uni" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 
@@ -234,7 +235,6 @@ endif ()
 			condor_pl_test(test_jobsets "Test jobsets" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 
 			condor_pl_test(test_htcondor_submit_constructor "Test htcondor.Submit()" "quick;ctest"	CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
-
 			condor_pl_test(test_job_submit_method_recording "Test recording of JobSubmitMethod job attribute" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 
 			# These tests require Python 3.6 or later.

--- a/src/condor_tests/test_dagman_service_nodes.py
+++ b/src/condor_tests/test_dagman_service_nodes.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env pytest
+
+#   test_dagman_service_nodes.py
+#
+#   This test makes sure that service nodes dont blow up DAGMan
+#   because of improper counting.
+#
+#   Author: Cole Bollig - 2023/07/21
+
+from ornithology import *
+import htcondor
+import os
+
+@action
+def echo_job(test_dir):
+    path = os.path.join(str(test_dir), "echo.sub")
+    with open(path, "w") as f:
+        f.write("""# Simple echo job
+executable = /bin/echo
+arguments  = 'Condor is King'
+log        = echo.log
+output     = echo.out
+error      = echo.err
+queue
+""")
+    return path
+
+@action
+def sleep_job(test_dir, path_to_sleep):
+    path = os.path.join(str(test_dir), "sleep.sub")
+    with open(path, "w") as f:
+        f.write(f"""# Simple sleep job
+executable = {path_to_sleep}
+arguments  = 10
+log        = sleep.log
+queue
+""")
+    return path
+
+@action
+def submit_dag(default_condor, test_dir, echo_job, sleep_job):
+    contents = f"""JOB SLEEP {sleep_job}
+SERVICE FAST {echo_job}
+"""
+    filename = os.path.join(str(test_dir), "test.dag")
+    with open(filename, "w") as f:
+        f.write(contents)
+    dag = htcondor.Submit.from_dag(filename)
+    job = default_condor.submit(dag)
+    assert job.wait(condition=ClusterState.all_complete,timeout=40)
+    return filename + ".dagman.out"
+
+class TestDAGManServiceNodes:
+    def test_short_service_doesnt_blow_up_dag(self, submit_dag):
+        with open(submit_dag, "r") as f:
+            for line in f:
+                assert "Assertion ERROR on (_numJobsSubmitted >= 0)" not in line
+


### PR DESCRIPTION
-Resolved an issue with the counting of submitted nodes to DAGMan.
 Where service nodes were supposed to be separate, but were only
 implemented partially separate. This would cause DAGMan to blowup
 at an assertion check if a service node finished before the entire
 DAG
-Added an ornithology test

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
