### PR TITLE
HTCONDOR-1925 fix Fedora warnings

### DIFF
--- a/src/condor_includes/sockCache.h
+++ b/src/condor_includes/sockCache.h
@@ -52,10 +52,10 @@ class SocketCache
 {
 public:
 		// ctor/dtor
-	SocketCache( int size = DEFAULT_SOCKET_CACHE_SIZE );
+	SocketCache( size_t size = DEFAULT_SOCKET_CACHE_SIZE );
 	~SocketCache();
 
-	void resize( int size );
+	void resize( size_t size );
 
 	void clearCache( void );
 	void invalidateSock( const char* );
@@ -85,7 +85,7 @@ private:
 
 	int			timeStamp;
 	sockEntry 	*sockCache;
-	int			cacheSize;
+	size_t			cacheSize;
 };
 			
 		

--- a/src/condor_io/sockCache.cpp
+++ b/src/condor_io/sockCache.cpp
@@ -21,7 +21,7 @@
 #include "condor_debug.h"
 #include "condor_io.h"
 
-SocketCache::SocketCache( int cSize )
+SocketCache::SocketCache( size_t cSize )
 {
 	cacheSize = cSize;
 	timeStamp = 0;
@@ -29,7 +29,7 @@ SocketCache::SocketCache( int cSize )
 	if( !sockCache ) {
 		EXCEPT( "SocketCache: Out of memory" );
 	}
-	for( int i = 0; i < cSize; i++ ) {
+	for( size_t i = 0; i < cSize; i++ ) {
 		initEntry( &(sockCache[i]) );
 	}
 }
@@ -43,7 +43,7 @@ SocketCache::~SocketCache()
 
 
 void
-SocketCache::resize( int newSize )
+SocketCache::resize( size_t newSize )
 {
 	if( newSize == cacheSize ) {
 			// nothing to do!
@@ -58,11 +58,10 @@ SocketCache::resize( int newSize )
 				 "ERROR: Cannot shrink a SocketCache with resize()\n" );
 		return;
 	}
-	dprintf( D_FULLDEBUG, "Resizing SocketCache - old: %d new: %d\n",
+	dprintf( D_FULLDEBUG, "Resizing SocketCache - old: %zu new: %zu\n",
 			 cacheSize, newSize ); 
-	sockEntry* new_cache = new sockEntry[newSize];
-	int i;
-	for( i=0; i<newSize; i++ ) {
+	sockEntry* new_cache = new sockEntry[(unsigned int)newSize];
+	for( size_t i=0; i<newSize; i++ ) {
 		if( i<cacheSize && sockCache[i].valid ) {
 			new_cache[i].valid = true;
 			new_cache[i].sock = sockCache[i].sock;
@@ -81,7 +80,7 @@ SocketCache::resize( int newSize )
 void
 SocketCache::clearCache()
 {
-	for( int i = 0; i < cacheSize; i++ ) {
+	for( size_t i = 0; i < cacheSize; i++ ) {
 		invalidateEntry( i );
 	}
 }
@@ -90,7 +89,7 @@ SocketCache::clearCache()
 void
 SocketCache::invalidateSock( const char* addr )
 {
-	for( int i = 0; i < cacheSize; i++ ) {
+	for( size_t i = 0; i < cacheSize; i++ ) {
 		if( sockCache[i].valid && addr == sockCache[i].addr ) {
 			invalidateEntry(i);
 		}
@@ -101,7 +100,7 @@ SocketCache::invalidateSock( const char* addr )
 ReliSock* 
 SocketCache::findReliSock( const char *addr )
 {
-    for( int i = 0; i < cacheSize; i++ ) {
+    for( size_t i = 0; i < cacheSize; i++ ) {
         if( sockCache[i].valid && addr == sockCache[i].addr ) {
 			return sockCache[i].sock;
 		}
@@ -124,7 +123,7 @@ SocketCache::addReliSock( const char* addr, ReliSock* rsock )
 bool
 SocketCache::isFull( void )
 {
-	for( int i = 0; i < cacheSize; i++ ) {
+	for( size_t i = 0; i < cacheSize; i++ ) {
 		if( ! sockCache[i].valid ) {
 			return false;
 		}
@@ -145,17 +144,16 @@ SocketCache::getCacheSlot()
 {
 	int time	= INT_MAX;
 	int	oldest  = -1;
-	int	i;
 
 	// increment time stamp
 	timeStamp++;
 
 	// find empty entry, or oldest entry
-	for (i = 0; i < cacheSize; i++)
+	for (size_t i = 0; i < cacheSize; i++)
 	{
 		if (!sockCache[i].valid)
 		{
-			dprintf (D_FULLDEBUG, "SocketCache:  Found unused slot %d\n", i);
+			dprintf (D_FULLDEBUG, "SocketCache:  Found unused slot %zu\n", i);
 			return i;
 		}
 

--- a/src/condor_schedd.V6/qmgmt.cpp
+++ b/src/condor_schedd.V6/qmgmt.cpp
@@ -3097,7 +3097,7 @@ grow_prio_recs( int newsize )
 
 	dprintf(D_FULLDEBUG,"Dynamically growing PrioRec to %d\n",newsize);
 
-	tmp = new prio_rec[newsize];
+	tmp = new prio_rec[(unsigned int)newsize];
 	if ( tmp == NULL ) {
 		EXCEPT( "grow_prio_recs: out of memory" );
 	}

--- a/src/condor_utils/ad_printmask.cpp
+++ b/src/condor_utils/ad_printmask.cpp
@@ -461,7 +461,7 @@ MyRowOfValues::~MyRowOfValues()
 int MyRowOfValues::SetMaxCols(int max_cols)
 {
 	if (max_cols > cmax) {
-		classad::Value * pd = new classad::Value[max_cols];
+		classad::Value * pd = new classad::Value[(unsigned int)max_cols];
 		unsigned char * pv = new unsigned char[max_cols];
 		memset(pv, '\0', max_cols);
 

--- a/src/condor_utils/ad_printmask.h
+++ b/src/condor_utils/ad_printmask.h
@@ -218,7 +218,7 @@ public:
 		memset( pvalid, '\0', cmax );
 
 		if( pdata != NULL ) { delete pdata; }
-		pdata = new classad::Value[cmax];
+		pdata = new classad::Value[(unsigned int)cmax];
 		for( int i = 0; i < cmax; ++i ) {
 			pdata[i] = rhs.pdata[i];
 			pvalid[i] = rhs.pvalid[i];

--- a/src/condor_utils/compat_classad_util.cpp
+++ b/src/condor_utils/compat_classad_util.cpp
@@ -869,8 +869,8 @@ static std::vector<ClassAd*> *matched_ads = NULL;
 bool ParallelIsAMatch(ClassAd *ad1, std::vector<ClassAd*> &candidates, std::vector<ClassAd*> &matches, int threads, bool halfMatch)
 {
 	int adCount = candidates.size();
-	static int cpu_count = 0;
-	int current_cpu_count = threads;
+	static size_t cpu_count = 0;
+	size_t current_cpu_count = threads;
 	int iterations = 0;
 	size_t matched = 0;
 
@@ -904,7 +904,7 @@ bool ParallelIsAMatch(ClassAd *ad1, std::vector<ClassAd*> &candidates, std::vect
 	if(!candidates.size())
 		return false;
 
-	for(int index = 0; index < cpu_count; index++)
+	for(size_t index = 0; index < cpu_count; index++)
 	{
 		target_pool[index].CopyFrom(*ad1);
 		match_pool[index].ReplaceLeftAd(&(target_pool[index]));
@@ -970,7 +970,7 @@ bool ParallelIsAMatch(ClassAd *ad1, std::vector<ClassAd*> &candidates, std::vect
 		}
 	}
 
-	for(int index = 0; index < cpu_count; index++)
+	for(size_t index = 0; index < cpu_count; index++)
 	{
 		match_pool[index].RemoveLeftAd();
 		matched += matched_ads[index].size();
@@ -979,7 +979,7 @@ bool ParallelIsAMatch(ClassAd *ad1, std::vector<ClassAd*> &candidates, std::vect
 	if(matches.capacity() < matched)
 		matches.reserve(matched);
 
-	for(int index = 0; index < cpu_count; index++)
+	for(size_t index = 0; index < cpu_count; index++)
 	{
 		if(matched_ads[index].size())
 			matches.insert(matches.end(), matched_ads[index].begin(), matched_ads[index].end());


### PR DESCRIPTION
There's a new warning in the fedora compiler where operator new[] takes a size_t as the size, and if passed a (signed) int, it gets promoted to a unsigned quantity, which if it was negative, (unlikely), gets changes to a very large integer, which triggers a warning

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
