### PR TITLE
HTCONDOR-1925 robustify cmd_status-compact test

### DIFF
--- a/src/condor_tests/cmd_status-compact.run
+++ b/src/condor_tests/cmd_status-compact.run
@@ -147,7 +147,6 @@ open(FH,">$rules_file") || print "FAILED opening file $rules_file\n";
 print FH $rules_content;
 close(FH);
 
-`condor_submit $submitfile`;
 my $counter = 100;
 while ($counter ne 0){
 	if ($counter == 0){
@@ -185,6 +184,7 @@ if (check_heading('status_compact_machine',\%table1) && check_heading('status_su
 unlink($new_ads);
 unlink($orig_ads);
 print "############################################################################\n";
+`condor_submit $submitfile`;
 $option = "run";
 $counter = 100;
 while ($counter ne 0){


### PR DESCRIPTION
By ensuring that when we run condor_transform_ads, the partionable slot doesn't have a claimed/idle dslot under it.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
