### PR TITLE
HTCONDOR-1925: Reduce the verbosity of Debian build

### DIFF
--- a/build/packaging/debian/rules.in
+++ b/build/packaging/debian/rules.in
@@ -47,7 +47,7 @@ override_dh_auto_configure:
 
 
 override_dh_auto_build: doc/build
-	dh_auto_build --parallel -- VERBOSE=1
+	dh_auto_build --parallel
 	# The tests don't get built eventhough was asked for them
 	(cd obj-*; make tests)
 	# post-fixing things that have to be done due to changes introduced by

--- a/nmi_tools/glue/build/build_uw_deb.sh
+++ b/nmi_tools/glue/build/build_uw_deb.sh
@@ -47,7 +47,7 @@ cp -pr build/packaging/debian debian
 # set default email address for build
 export DEBEMAIL=${DEBEMAIL-htcondor-admin@cs.wisc.edu}
 # if running in a condor slot, set parallelism to slot size
-export DEB_BUILD_OPTIONS="parallel=${OMP_NUM_THREADS-1}"
+export DEB_BUILD_OPTIONS="parallel=${OMP_NUM_THREADS-1} terse"
 
 # Extract prerelease value from top level CMake file
 PRE_RELEASE=$(grep '^set(PRE_RELEASE' CMakeLists.txt)


### PR DESCRIPTION
So we can actually see the warnings

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
