### PR TITLE
HTCONDOR-1988: Fixed bug to allow shadow job hooks to get classad from stdin

### DIFF
--- a/src/condor_shadow.V6.1/ShadowHookMgr.cpp
+++ b/src/condor_shadow.V6.1/ShadowHookMgr.cpp
@@ -109,6 +109,7 @@ ShadowHookMgr::tryHookPrepareJob()
 		dprintf(D_ALWAYS|D_FAILURE, "Shadow does not have a copy of the job ad.\n");
 		return -1;
 	}
+	sPrintAd(hook_stdin, *job_ad);
 
 	auto hook_client = new HookShadowPrepareJobClient(m_hook_prepare_job);
 	auto hook_name = getHookTypeString(hook_client->type());


### PR DESCRIPTION
Fixing the bug where shadow job hooks cannot receive the job classad from stdin.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
