### PR TITLE
(HTCONDOR-1991)  Make Ornithology docs buildable at RTD again.

### DIFF
--- a/src/condor_tests/ornithology-docs/.readthedocs.yaml
+++ b/src/condor_tests/ornithology-docs/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: src/condor_tests/ornithology-docs/source/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: src/condor_tests/requirements.txt

--- a/src/condor_tests/ornithology-docs/.readthedocs.yaml
+++ b/src/condor_tests/ornithology-docs/.readthedocs.yaml
@@ -19,4 +19,4 @@ sphinx:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
-    - requirements: src/condor_tests/requirements.txt
+    - requirements: src/condor_tests/ornithology-docs/requirements.txt

--- a/src/condor_tests/ornithology-docs/requirements.txt
+++ b/src/condor_tests/ornithology-docs/requirements.txt
@@ -2,4 +2,4 @@ htcondor
 pytest
 pytest-httpserver
 sphinx-autodoc-typehints
-sphinx-rtd-thme
+sphinx-rtd-theme

--- a/src/condor_tests/ornithology-docs/requirements.txt
+++ b/src/condor_tests/ornithology-docs/requirements.txt
@@ -2,3 +2,4 @@ htcondor
 pytest
 pytest-httpserver
 sphinx-autodoc-typehints
+sphinx-rtd-thme

--- a/src/condor_tests/ornithology-docs/requirements.txt
+++ b/src/condor_tests/ornithology-docs/requirements.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-httpserver
+htcondor
+sphinx-rtd-theme

--- a/src/condor_tests/ornithology-docs/requirements.txt
+++ b/src/condor_tests/ornithology-docs/requirements.txt
@@ -1,4 +1,5 @@
+htcondor
 pytest
 pytest-httpserver
-htcondor
+sphinx-autodoc-typehints
 sphinx-rtd-theme

--- a/src/condor_tests/ornithology-docs/requirements.txt
+++ b/src/condor_tests/ornithology-docs/requirements.txt
@@ -1,5 +1,5 @@
-htcondor
 pytest
 pytest-httpserver
 sphinx-autodoc-typehints
-sphinx-rtd-theme
+sphinx-rtd-theme >= 1.2.2
+htcondor

--- a/src/condor_tests/ornithology-docs/requirements.txt
+++ b/src/condor_tests/ornithology-docs/requirements.txt
@@ -2,4 +2,3 @@ htcondor
 pytest
 pytest-httpserver
 sphinx-autodoc-typehints
-sphinx-rtd-theme

--- a/src/condor_tests/ornithology-docs/source/conf.py
+++ b/src/condor_tests/ornithology-docs/source/conf.py
@@ -52,10 +52,10 @@ pygments_style = "colorful"
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-import sphinx_rtd_theme
+# import sphinx_rtd_theme
 
-html_theme = "sphinx_rtd_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# html_theme = "sphinx_rtd_theme"
+# html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -67,5 +67,5 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 autoclass_content = "both"
 
 intersphinx_mapping = {
-    "https://docs.python.org/3/": None,
+    'python': ("https://docs.python.org/3/": None),
 }

--- a/src/condor_tests/ornithology-docs/source/conf.py
+++ b/src/condor_tests/ornithology-docs/source/conf.py
@@ -67,5 +67,5 @@ pygments_style = "colorful"
 autoclass_content = "both"
 
 intersphinx_mapping = {
-    'python': ("https://docs.python.org/3/": None),
+    'python': ("https://docs.python.org/3/", None),
 }

--- a/src/condor_tests/ornithology-docs/source/conf.py
+++ b/src/condor_tests/ornithology-docs/source/conf.py
@@ -15,22 +15,6 @@ import sys
 
 sys.path.insert(0, os.path.abspath("../.."))
 
-
-ON_RTD = os.environ.get("READTHEDOCS") == "True"
-if ON_RTD:
-    print("ON RTD, THEREFORE INSTALLING HTCONDOR PACKAGE")
-    cmd = "{} -m pip install 'htcondor'".format(sys.executable)
-    print("EXECUTING COMMAND: {}".format(cmd))
-    os.system(cmd)
-    print("INSTALLED HTCONDOR PACKAGE")
-
-    print("ON RTD, THEREFORE INSTALLING TEST STUFF")
-    dev_reqs = os.path.abspath("../../requirements.txt")
-    cmd = "{} -m pip install -r {}".format(sys.executable, dev_reqs)
-    print("EXECUTING COMMAND: {}".format(cmd))
-    os.system(cmd)
-    print("INSTALLED TEST STUFF")
-
 # -- Project information -----------------------------------------------------
 
 project = "Ornithology"
@@ -67,7 +51,7 @@ pygments_style = "colorful"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
+
 import sphinx_rtd_theme
 
 html_theme = "sphinx_rtd_theme"


### PR DESCRIPTION
Bunch of tweaks to make the Ornithology docs buildable at RTD again.  Should probably be a squash merge.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
