### PR TITLE
HTCONDOR-1992 fix unitialized read in getcap syscall

### DIFF
--- a/src/condor_sysapi/process_capabilities.cpp
+++ b/src/condor_sysapi/process_capabilities.cpp
@@ -33,13 +33,15 @@ uint64_t sysapi_get_process_caps_mask(int pid, LinuxCapsMaskType type) {
 	struct __user_cap_header_struct hs;
 	struct __user_cap_data_struct ds[2];
 	TemporaryPrivSentry sentry(PRIV_ROOT);
+	//Set the process id
+	hs.pid = pid;
+	hs.version = 0;
+
 	//syscall to get the machines linux_capabilty_version
 	if (syscall(SYS_capget,&hs,NULL)) {
 		dprintf(D_ERROR,"Error: Linux system call for capget failed to initialize linux_capability_version.\n");
 		return UINT64_MAX;
 	}
-	//Set the process id
-	hs.pid = pid;
 	
 	//Get capability masks (Returns Permitted, Inheritable, and Effective in structure)
 	if (syscall(SYS_capget,&hs,ds)) {


### PR DESCRIPTION
ubsan complains that we are passing these syscall parameters into the kernel unitialiazed.  I'm not sure it is reading them all, but let's set them just to be sure.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
