### PR TITLE
HTCONDOR-1992 If we change the default slot_type_id for partitionable

### DIFF
--- a/src/condor_schedd.V6/dedicated_scheduler.cpp
+++ b/src/condor_schedd.V6/dedicated_scheduler.cpp
@@ -3308,18 +3308,17 @@ DedicatedScheduler::AddMrec(
     // not to store just one 'dynamic' slot per host into all_matches 
     // and leave behind all extra created dynamic slots 
     // we need to use/fill pending_matches. Try checking for
-    // SlotTypeID == PARTITIONABLE_SLOT, as this is left unchanged by
+    // SlotType == "Static", as this is left unchanged by
     // ScheddNegotiate::fixupPartitionableSlot.
-    // if (is_partitionable(match_ad)) {
-    int slot_type_id = 0;
-    match_ad->LookupInteger(ATTR_SLOT_TYPE_ID, slot_type_id);
-    if (slot_type_id == 1) { // Cannot include Resource.h from here.
+	std::string slot_type;
+    match_ad->LookupString(ATTR_SLOT_TYPE, slot_type);
+    if (slot_type == "Static") {
+        ASSERT( all_matches->insert(slot_name, mrec) == 0 );
+        ASSERT( all_matches_by_id->insert(mrec->claim_id.claimId(), mrec) == 0 );
+    } else {
         update_negotiator_attrs_for_partitionable_slots(mrec->my_match_ad);
         pending_matches[claim_id] = mrec;
         pending_claims[mrec->claim_id.publicClaimId()] = claim_id;
-    } else {
-        ASSERT( all_matches->insert(slot_name, mrec) == 0 );
-        ASSERT( all_matches_by_id->insert(mrec->claim_id.claimId(), mrec) == 0 );
     }
 
 	removeRequest( job_id );


### PR DESCRIPTION
slots

this would break the dedicated_scheduler with partitionable slots. Change the way we detect what kind of slots are which to be stable in the face of this change

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
