### PR TITLE
HTCONDOR-1992 remove unused set_new_handler

### DIFF
--- a/src/condor_daemon_core.V6/daemon_core_main.cpp
+++ b/src/condor_daemon_core.V6/daemon_core_main.cpp
@@ -3369,34 +3369,6 @@ handle_dc_sigquit(int )
 	return TRUE;
 }
 
-const size_t OOM_RESERVE = 2048;
-static char *oom_reserve_buf;
-static void OutOfMemoryHandler()
-{
-	std::set_new_handler(NULL);
-
-		// free up some memory to improve our chances of
-		// successfully logging
-	delete [] oom_reserve_buf;
-
-	int monitor_age = 0;
-	unsigned long vsize = 0;
-	unsigned long rss = 0;
-
-	if( daemonCore && daemonCore->monitor_data.last_sample_time != -1 ) {
-		monitor_age = (int)(time(NULL)-daemonCore->monitor_data.last_sample_time);
-		vsize = daemonCore->monitor_data.image_size;
-		rss = daemonCore->monitor_data.rs_size;
-	}
-
-	dprintf_dump_stack();
-
-	EXCEPT("Out of memory!  %ds ago: vsize=%lu KB, rss=%lu KB",
-		   monitor_age,
-		   vsize,
-		   rss);
-}
-
 #ifndef WIN32
 // if we fork into the background, this is the write pipe in the child
 // and the read pipe for the parent (i.e. the current process)

--- a/src/condor_daemon_core.V6/daemon_core_main.cpp
+++ b/src/condor_daemon_core.V6/daemon_core_main.cpp
@@ -3397,16 +3397,6 @@ static void OutOfMemoryHandler()
 		   rss);
 }
 
-static void InstallOutOfMemoryHandler()
-{
-	if( !oom_reserve_buf ) {
-		oom_reserve_buf = new char[OOM_RESERVE];
-		memset(oom_reserve_buf,0,OOM_RESERVE);
-	}
-
-	std::set_new_handler(OutOfMemoryHandler);
-}
-
 #ifndef WIN32
 // if we fork into the background, this is the write pipe in the child
 // and the read pipe for the parent (i.e. the current process)
@@ -4462,11 +4452,6 @@ int dc_main( int argc, char** argv )
 	// now re-set the identity so that any children we spawn will have it
 	// in their environment
 	SetEnv( envName, daemonCore->sec_man->my_unique_id() );
-
-	// create a database connection object
-	//DBObj = createConnection();
-
-	InstallOutOfMemoryHandler();
 
 	// call the daemon's main_init()
 	dc_main_init( argc, argv );


### PR DESCRIPTION
In modern C++, new throws std::bad_alloc, and never calls the new handler.  And it usually doesn't even do that -- the OOM killer will probably get the program first, so let's just remove this unused code.

Oh, and also, we never initialize the static `oom_reserve_buf`, so this code probably never runs to begin with.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
