### PR TITLE
HTCONDOR-2022 job-router-user-rec

### DIFF
--- a/src/condor_schedd.V6/qmgmt.cpp
+++ b/src/condor_schedd.V6/qmgmt.cpp
@@ -3315,12 +3315,28 @@ QmgmtSetEffectiveOwner(char const *o)
 	if (o) {
 		urec = scheduler.lookup_owner_const(o);
 		if ( ! urec) {
-			dprintf(D_ALWAYS, "SetEffectiveOwner security violation: No User record named %s\n", o);
-		} else if (urec == real_urec) {
+			if (allow_submit_from_known_users_only || Q_SOCK->getReadOnly()) {
+				dprintf(D_ALWAYS, "SetEffectiveOwner(): fail because no User record for %s\n", o);
+				errno = EACCES;
+				return -1;
+			} else {
+				// create user a user record for a new submitter
+				// the insert_owner_const will make a pending user record
+				// which we then add to the current transaction by calling MakeUserRec
+				urec = scheduler.insert_owner_const(o);
+				if ( ! MakeUserRec(urec, true)) {
+					dprintf(D_ALWAYS, "SetEffectiveOwner(): failed to create new User record for %s\n", o);
+					errno = EACCES;
+					return -1;
+				}
+			}
+		}
+		if (urec == real_urec) {
 			// myself, but without superuser perms. I'll allow it.
 		} else {
+			std::string buf;
 			bool is_super = real_urec && real_urec->IsSuperUser();
-			bool is_allowed_owner = SuperUserAllowedToSetOwnerTo(o);
+			bool is_allowed_owner = SuperUserAllowedToSetOwnerTo(name_of_user(o, buf));
 			if( !is_super || !is_allowed_owner)
 			{
 				if ( ! is_allowed_owner) {


### PR DESCRIPTION
When the job router submits a job, it usually authenticates as condor and calls QmgmtSetEffectiveOwner() to impersonate the job owner. If the job owner doesn't have a user record yet in the schedd, then the schedd needs to create one here; it can't wait until NewCluster().

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
