### PR TITLE
HTCONDOR-1994 remove ancient emacs mode subsettings in some files

### DIFF
--- a/src/condor_utils/read_user_log.cpp
+++ b/src/condor_utils/read_user_log.cpp
@@ -1657,10 +1657,3 @@ ReadUserLogMatch::MatchStr( ReadUserLogMatch::MatchResult value ) const
 	};
 
 }
-
-/*
-### Local Variables: ***
-### mode:c++ ***
-### tab-width:4 ***
-### End: ***
-*/

--- a/src/condor_utils/read_user_log.h
+++ b/src/condor_utils/read_user_log.h
@@ -543,10 +543,3 @@ private:
 };
 
 #endif /* _CONDOR_USER_LOG_CPP_H */
-
-/*
-### Local Variables: ***
-### mode:c++ ***
-### tab-width:4 ***
-### End: ***
-*/

--- a/src/condor_utils/read_user_log_state.cpp
+++ b/src/condor_utils/read_user_log_state.cpp
@@ -1090,10 +1090,3 @@ ReadUserLogStateAccess::getState( const ReadUserLogFileState *&state ) const
 	state = m_state;
 	return true;
 }
-
-/*
-### Local Variables: ***
-### mode:c++ ***
-### tab-width:4 ***
-### End: ***
-*/

--- a/src/condor_utils/read_user_log_state.h
+++ b/src/condor_utils/read_user_log_state.h
@@ -318,10 +318,3 @@ private:
 };
 
 #endif
-
-/*
-### Local Variables: ***
-### mode:c++ ***
-### tab-width:4 ***
-### End: ***
-*/

--- a/src/condor_utils/test_log_reader.cpp
+++ b/src/condor_utils/test_log_reader.cpp
@@ -747,10 +747,3 @@ const char *timestr( time_t time )
 	}
 	return tbuf;
 }
-
-/*
-### Local Variables: ***
-### mode:c++ ***
-### tab-width:4 ***
-### End: ***
-*/

--- a/src/condor_utils/test_log_reader_state.cpp
+++ b/src/condor_utils/test_log_reader_state.cpp
@@ -1060,10 +1060,3 @@ Options::parseValue( const SimpleArg &arg )
 	}
 	return false;
 }
-
-/*
-### Local Variables: ***
-### mode:c++ ***
-### tab-width:4 ***
-### End: ***
-*/

--- a/src/condor_utils/test_log_verify
+++ b/src/condor_utils/test_log_verify
@@ -130,10 +130,3 @@ class Verify ( object ) :
 
 main = Verify( )
 main.VerifyFiles()
-
-### Local Variables: ***
-### py-indent-offset:4 ***
-### python-indent:4 ***
-### python-continuation-offset:4 ***
-### tab-width:4  ***
-### End: ***

--- a/src/condor_utils/test_log_writer.cpp
+++ b/src/condor_utils/test_log_writer.cpp
@@ -1623,9 +1623,3 @@ EventInfo::GetSize( int mult ) const
 		return randint( mult );
 	}
 }
-/*
-### Local Variables: ***
-### mode:c++ ***
-### tab-width:4 ***
-### End: ***
-*/

--- a/src/condor_utils/user_log.c++.h
+++ b/src/condor_utils/user_log.c++.h
@@ -24,9 +24,3 @@
 #include "read_user_log.h"
 
 #endif /* _CONDOR_USER_LOG_CPP_H */
-
-/*
-### Local Variables: ***
-### mode:C++ ***
-### End: **
-*/

--- a/src/condor_utils/write_user_log.cpp
+++ b/src/condor_utils/write_user_log.cpp
@@ -1639,12 +1639,6 @@ WriteUserLog::GenerateGlobalId( std::string &id )
 	formatstr_cat( id, "%s%d.%ld.%ld", GetGlobalIdBase(), m_global_sequence,
 	               (long)now.tv_sec, (long)now.tv_usec );
 }
-/*
-### Local Variables: ***
-### mode:c++ ***
-### tab-width:4 ***
-### End: ***
-*/
 
 FileLockBase *
 WriteUserLog::getLock(CondorError &err) {

--- a/src/condor_utils/write_user_log.h
+++ b/src/condor_utils/write_user_log.h
@@ -383,9 +383,3 @@ private:
 };
 
 #endif /* _CONDOR_USER_LOG_CPP_H */
-
-/*
-### Local Variables: ***
-### mode:C++ ***
-### End: **
-*/

--- a/src/condor_utils/write_user_log_state.h
+++ b/src/condor_utils/write_user_log_state.h
@@ -48,9 +48,3 @@ private:
 };
 
 #endif /* _CONDOR_USER_LOG_CPP_STATE_H */
-
-/*
-### Local Variables: ***
-### mode:C++ ***
-### End: **
-*/


### PR DESCRIPTION
It is odd to only have these in a handful of files, and emacs best practice is not to put these into individual source files. Let's just remove these.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
