### PR TITLE
HTCONDOR-2046: Filter out non-specified clusters for condor_watch_q

### DIFF
--- a/docs/man-pages/condor_watch_q.rst
+++ b/docs/man-pages/condor_watch_q.rst
@@ -124,6 +124,11 @@ and how it discovers them.
     Which cluster IDs to track jobs for.
     One or more cluster ids may be passed.
 
+ **-larger-than CLUSTER_ID**
+    Track jobs for all cluster IDs greater than
+    or equal to the specified *CLUSTER_ID*.
+    Note: This option does not discover how to track jobs.
+
  **-files FILE [FILE ...]**
     Which job event log files (i.e., the ``log`` file from ``condor_submit``)
     to track jobs from.

--- a/docs/version-history/feature-versions-23-x.rst
+++ b/docs/version-history/feature-versions-23-x.rst
@@ -23,6 +23,17 @@ New Features:
   *condor_remote_cluster*.
   :jira:`2002`
 
+- Improved *condor_watch_q* to filter tracked jobs based on cluster IDs
+  either provided by the ``-clusters`` option or found in association
+  to batch names provided by the ``-batches`` option. This helps limit
+  the amount of output lines when using an aggregate/shared log file.
+  :jira:`2046`
+
+- Added new ``-larger-than`` flag to *condor_watch_q* that filters tracked
+  jobs to only include jobs with cluster IDs greater than or equal to the
+  provided cluster ID.
+  :jira:`2046`
+
 Bugs Fixed:
 
 - None.

--- a/src/condor_scripts/condor_watch_q
+++ b/src/condor_scripts/condor_watch_q
@@ -86,12 +86,12 @@ def parse_args():
         "-clusters", nargs="+", metavar="CLUSTER_ID", help="Which cluster IDs to track."
     )
     parser.add_argument(
-        "-since",
+        "-larger-than",
         type=int,
-        nargs=1,
+        dest='since',
         default=None,
         metavar="CLUSTER_ID",
-        help="Track all clusters since specified cluster ID."
+        help="Track all jobs with cluster IDs greater than or equal to the specifiec CLUSTER_ID."
     )
     parser.add_argument(
         "-files", nargs="+", metavar="FILE", help="Which event logs to track."
@@ -903,7 +903,7 @@ class JobStateTracker:
                 if self.filter_ids is not None and event.cluster not in self.filter_ids:
                     continue
 
-                if self.since is not None and event.cluster < self.since[0]:
+                if self.since is not None and event.cluster < self.since:
                     continue
 
                 new_status = JOB_EVENT_STATUS_TRANSITIONS.get(event.type, None)

--- a/src/condor_scripts/condor_watch_q
+++ b/src/condor_scripts/condor_watch_q
@@ -365,7 +365,7 @@ def cli():
     args = parse_args()
 
     if args.clusters is not None and args.since is not None:
-        error("Use of both -clusters and -since flag is prohibited.")
+        error("Use of both -clusters and -larger-than flag is prohibited.")
         sys.exit(1)
 
     if args.debug:

--- a/src/condor_scripts/condor_watch_q
+++ b/src/condor_scripts/condor_watch_q
@@ -86,6 +86,14 @@ def parse_args():
         "-clusters", nargs="+", metavar="CLUSTER_ID", help="Which cluster IDs to track."
     )
     parser.add_argument(
+        "-since",
+        type=int,
+        nargs=1,
+        default=None,
+        metavar="CLUSTER_ID",
+        help="Track all clusters since specified cluster ID."
+    )
+    parser.add_argument(
         "-files", nargs="+", metavar="FILE", help="Which event logs to track."
     )
     parser.add_argument(
@@ -356,6 +364,10 @@ class NegateAction(argparse.Action):
 def cli():
     args = parse_args()
 
+    if args.clusters is not None and args.since is not None:
+        error("Use of both -clusters and -since flag is prohibited.")
+        sys.exit(1)
+
     if args.debug:
         warning("Debug mode enabled...")
         htcondor.enable_debug()
@@ -364,6 +376,7 @@ def cli():
         return watch_q(
             users=args.users,
             cluster_ids=args.clusters,
+            since_cid=args.since,
             event_logs=args.files,
             batches=args.batches,
             collector=args.collector,
@@ -417,6 +430,7 @@ GROUPBY_AD_KEY_TO_ATTRIBUTE = {v: k for k, v in GROUPBY_ATTRIBUTE_TO_AD_KEY.item
 def watch_q(
     users=None,
     cluster_ids=None,
+    since_cid=None,
     event_logs=None,
     batches=None,
     collector=None,
@@ -433,6 +447,7 @@ def watch_q(
     refresh=True,
     abbreviate_path_components=False,
 ):
+    filter_ids = None if cluster_ids is None else [int(cid) for cid in cluster_ids]
     if users is None and cluster_ids is None and event_logs is None and batches is None:
         users = [getpass.getuser()]
     if exit_conditions is None:
@@ -447,13 +462,19 @@ def watch_q(
         constraint,
         event_logs,
         batch_names,
+        batch_filter_ids,
         dagman_clusters_to_paths,
         dagman_job_cluster_ids,
     ) = find_job_event_logs(
         users, cluster_ids, event_logs, batches, collector=collector, schedd=schedd,
     )
 
-    tracker = JobStateTracker(event_logs, batch_names)
+    if filter_ids is None:
+        filter_ids = batch_filter_ids if len(batch_filter_ids) > 0 else None
+    else:
+        filter_ids.extend(batch_filter_ids)
+
+    tracker = JobStateTracker(event_logs, batch_names, filter_ids, since_cid)
     if len(event_logs) == 0:
         warning("No jobs found, exiting...")
         sys.exit(0)
@@ -699,13 +720,14 @@ def find_job_event_logs(
         itertools.chain(
             ("Owner == {}".format(classad.quote(u)) for u in users),
             ("ClusterId == {}".format(cid) for cid in cluster_ids),
-            ("JobBatchName == {}".format(b) for b in batches),
+            ('JobBatchName == "{}"'.format(b) for b in batches),
         )
     )
 
     clusters = set()
     event_logs = set()
     batch_names = {}
+    batch_filter_ids = []
     already_warned_missing_log = set()
     dagman_job_cluster_id_to_log_path = {}
     dagman_job_cluster_ids = set()
@@ -718,6 +740,9 @@ def find_job_event_logs(
         clusters.add(cluster_id)
 
         batch_names[cluster_id] = ad.get("JobBatchName")
+
+        if len(batches) > 0:
+            batch_filter_ids.append(int(cluster_id))
 
         if "DAGManNodesLog" in ad:
             log_path = dagman_job_cluster_id_to_log_path[cluster_id] = ad[
@@ -749,6 +774,7 @@ def find_job_event_logs(
         constraint,
         event_logs,
         batch_names,
+        batch_filter_ids,
         dagman_job_cluster_id_to_log_path,
         dagman_job_cluster_ids,
     )
@@ -830,7 +856,7 @@ class JobStateTracker:
     (available as the state attribute).
     """
 
-    def __init__(self, event_log_paths, batch_names):
+    def __init__(self, event_log_paths, batch_names, filter_ids, since_cid):
         event_readers = {}
         for event_log_path in event_log_paths:
             try:
@@ -847,6 +873,8 @@ class JobStateTracker:
         self.state = collections.defaultdict(lambda: collections.defaultdict(dict))
 
         self.batch_names = batch_names
+        self.filter_ids = filter_ids
+        self.since = since_cid
 
         self.cluster_id_to_cluster = {}
 
@@ -870,6 +898,12 @@ class JobStateTracker:
                             )
                         )
                     )
+                    continue
+
+                if self.filter_ids is not None and event.cluster not in self.filter_ids:
+                    continue
+
+                if self.since is not None and event.cluster < self.since[0]:
                     continue
 
                 new_status = JOB_EVENT_STATUS_TRANSITIONS.get(event.type, None)


### PR DESCRIPTION
- Made it so -clusters shows only those specified clusters when using an old and large log file
- Added similar filtering for jobs found in queue via -batches
- Fixed bug where -batches wasn't working due to written constraint -Added new -since flag to display information of all clusters since a specified ID (inclusively)

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [x] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
