### PR TITLE
HTCONDOR-1993: Remove extraneous 'to to's

### DIFF
--- a/docs/admin-manual/configuration-templates.rst
+++ b/docs/admin-manual/configuration-templates.rst
@@ -373,7 +373,7 @@ incorporates.
 
     -  ``Startd_Publish_CpusUsage``
 
-       Publish the number of CPU cores being used by the job into to
+       Publish the number of CPU cores being used by the job into the
        slot ad as attribute ``CpusUsage``. This value will be the
        average number of cores used by the job over the past minute,
        sampling every 5 seconds.

--- a/docs/admin-manual/setting-up-special-environments.rst
+++ b/docs/admin-manual/setting-up-special-environments.rst
@@ -68,7 +68,7 @@ Platform-Specific Configuration File Settings
 The configuration variables that are truly platform-specific are:
 
 :macro:`RELEASE_DIR`
-    Full path to to the installed HTCondor binaries. While the
+    Full path to the installed HTCondor binaries. While the
     configuration files may be shared among different platforms, the
     binaries certainly cannot. Therefore, maintain separate release
     directories for each platform in the pool.

--- a/docs/man-pages/condor_q.rst
+++ b/docs/man-pages/condor_q.rst
@@ -657,7 +657,7 @@ some situations such as when several submitters are contending for
 resources, or if the pool is rapidly changing state which cannot be
 accurately diagnosed.
 
-It is possible to to hold jobs that are in the X state. To avoid this it
+It is possible to hold jobs that are in the X state. To avoid this it
 is best to construct a **-constraint** *expression* that option
 contains ``JobStatus != 3`` if the user wishes to avoid this condition.
 

--- a/docs/users-manual/quick-start-guide.rst
+++ b/docs/users-manual/quick-start-guide.rst
@@ -193,7 +193,7 @@ units are megabytes and disk kilobytes.
     request_disk            = 1G
 
 
-If this script/batch file were to to be invoked from the command line, and
+If this script/batch file were to be invoked from the command line, and
 outside of HTCondor, its single line of output
 
 .. code-block:: text

--- a/src/annex/annex-setup.cpp
+++ b/src/annex/annex-setup.cpp
@@ -165,7 +165,7 @@ check_setup( const char * cloudFormationURL, const char * serviceURL ) {
 			ReliSock * sock = (ReliSock *) daemon->makeConnectedSocket(
 				Stream::reli_sock, 0, 0, & errorStack );
 			if( sock == NULL ) {
-				fprintf( stderr, "Failed to connect to to collector at '%s'.  Make sure COLLECTOR_HOST is set correctly.  If it is, ask your administrator about firewalls.", daemon->addr() );
+				fprintf( stderr, "Failed to connect to collector at '%s'.  Make sure COLLECTOR_HOST is set correctly.  If it is, ask your administrator about firewalls.", daemon->addr() );
 				fprintf( stderr, "  Because firewalls are machine-specific, we will continue to check your set-up.  However, if your instances fail to report to your pool, you may want to address this problem and try again.\n" );
 				fprintf( stderr, "\n" );
 			} else {

--- a/src/condor_examples/condor_config.annotated
+++ b/src/condor_examples/condor_config.annotated
@@ -1885,7 +1885,7 @@ CREDD_ADDRESS_FILE	= $(LOG)/.credd_address
 #CREDD_HOST  = $(CONDOR_HOST):$(CREDD_PORT)
 
 ## CredD startup arguments
-## Start the CredD on a well-known port.  Uncomment to to simplify
+## Start the CredD on a well-known port.  Uncomment to simplify
 ## connecting to a remote CredD.  Note: that this interface may change
 ## in a future release.
 CREDD_PORT			= 9620

--- a/src/condor_io/reli_sock.cpp
+++ b/src/condor_io/reli_sock.cpp
@@ -835,7 +835,7 @@ int ReliSock::RcvMsg::rcv_packet( char const *peer_description, SOCKET _sock, in
 
 	// Block on short reads for the header.  Since the header is very short (typically, 5 bytes),
 	// we don't care to gracefully handle the case where it has been fragmented over multiple
-	// TCP packets.  If in non-blocking mode, we want to limit the wait to to a maximum of 1 second.
+	// TCP packets.  If in non-blocking mode, we want to limit the wait to a maximum of 1 second.
 	// This is larger than the contractual delay of 'never block' but we need that header to proceeed.
 	if ( (retval > 0) && (retval != header_size) ) {
 

--- a/src/condor_master.V6/masterDaemon.cpp
+++ b/src/condor_master.V6/masterDaemon.cpp
@@ -2696,7 +2696,7 @@ Daemons::DoPeacefulShutdown(
 {
 	int messages = SetPeacefulShutdown(timeout);
 
-	// if we sent any messages, set a timer to to do the StopPeaceful call.
+	// if we sent any messages, set a timer to do the StopPeaceful call.
 	// to give the messages a chance to arrive.
 	bool fTimer = false;
 	if (messages > 0) {

--- a/src/condor_schedd.V6/schedd.cpp
+++ b/src/condor_schedd.V6/schedd.cpp
@@ -3689,7 +3689,7 @@ count_a_job(JobQueueBase* ad, const JOB_ID_KEY& /*jid*/, void*)
 bool
 service_this_universe(int universe, ClassAd* job)
 {
-	// "service" seems to to really mean find a matching resource or not...
+	// "service" seems to really mean find a matching resource or not...
 
 	/*  If a non-grid job is externally managed, it's been grabbed by
 		the schedd-on-the-side and we don't want to touch it.

--- a/src/condor_startd.V6/command.cpp
+++ b/src/condor_startd.V6/command.cpp
@@ -1138,7 +1138,7 @@ request_claim( Resource* rip, Claim *claim, char* id, Stream* stream )
 
 	if (claim_pslot && rip->r_has_cp) {
 		// TODO refuse claim entirely, or accept claim of single dslot or
-		//   sending to to WorkingCM?
+		//   sending to WorkingCM?
 		rip->dprintf(D_FULLDEBUG, "Refusing claim of pslot with consumption policy\n");
 		refuse(stream);
 		ABORT;

--- a/src/condor_tests/x_conditional_params.cpp
+++ b/src/condor_tests/x_conditional_params.cpp
@@ -218,7 +218,7 @@ static const struct _test_set {
 };
 
 
-// copy the incoming condition, changing %x to to one of the fields of condor version
+// copy the incoming condition, changing %x to one of the fields of condor version
 // where x is D, S or M for first second and third digit of the version
 // and x may be the next or previous letter to indicate ver-1 or ver+1
 // For instance, if the condor_version is 8.3.5  then %D.%T.%L translates as 8.4.4

--- a/src/condor_utils/condor_config.cpp
+++ b/src/condor_utils/condor_config.cpp
@@ -87,7 +87,7 @@
 #include <algorithm> // for std::sort
 #include "CondorError.h"
 
-// define this to keep param who's values match defaults from going into to runtime param table.
+// define this to keep param who's values match defaults from going into the runtime param table.
 #define DISCARD_CONFIG_MATCHING_DEFAULT
 // define this to parse for #opt:newcomment/#opt:oldcomment to decide commenting rules
 #define PARSE_CONFIG_TO_DECIDE_COMMENT_RULES

--- a/src/condor_utils/config.cpp
+++ b/src/condor_utils/config.cpp
@@ -3131,7 +3131,7 @@ const char * lookup_macro(const char * name, MACRO_SET & macro_set, MACRO_EVAL_C
 
 // given the body text of a config macro, and the macro id and macro context
 // evaluate the body and return a string. the string may be a literal, or
-// may point into to the buffer returned in tbuf.  The caller will NOT free
+// may point into the buffer returned in tbuf.  The caller will NOT free
 // the return value, but will free tbuf if it is not NULL with the understanding
 // that the return value may be freed as a result.
 static const char * evaluate_macro_func (
@@ -3881,7 +3881,7 @@ typedef struct _config_macro_position {
 
 // given the body text of a config macro, and the macro id and macro context
 // evaluate the body and return a string. the string may be a literal, or
-// may point into to the buffer returned in tbuf.  The caller will NOT free
+// may point into the buffer returned in tbuf.  The caller will NOT free
 // the return value, but will free tbuf if it is not NULL with the understanding
 // that the return value may be freed as a result.
 static ptrdiff_t evaluate_macro_func (
@@ -4846,7 +4846,7 @@ protected:
 ** expands the macro whose name is specified in the self argument.
 ** Expand parameter references of the form "left$(self)right".  This
 ** is deceptively simple, but does handle multiple and or nested references.
-** We only expand references to to the parameter specified by self. use expand_macro
+** We only expand references to the parameter specified by self. use expand_macro
 ** to expand all references. 
 */
 char *

--- a/src/condor_utils/file_transfer.cpp
+++ b/src/condor_utils/file_transfer.cpp
@@ -1182,7 +1182,7 @@ FileTransfer::DownloadFiles(bool blocking)
 					 "%s\n", TransSock );
 			Info.success = 0;
 			Info.in_progress = false;
-			formatstr( Info.error_desc, "FileTransfer: Unable to connect to to server %s",
+			formatstr( Info.error_desc, "FileTransfer: Unable to connect to server %s",
 					 TransSock );
 			return FALSE;
 		}
@@ -1581,7 +1581,7 @@ FileTransfer::UploadFiles(bool blocking, bool final_transfer)
 					 "%s\n", TransSock );
 			Info.success = 0;
 			Info.in_progress = false;
-			formatstr( Info.error_desc, "FileTransfer: Unable to connecto to server %s",
+			formatstr( Info.error_desc, "FileTransfer: Unable to connect to server %s",
 					 TransSock );
 			return FALSE;
 		}

--- a/src/condor_utils/metric_units.cpp
+++ b/src/condor_utils/metric_units.cpp
@@ -98,7 +98,7 @@ bool parse_int64_bytes(const char * input, int64_t & value, int base)
 
         val = (int64_t)((val + fract) * mult + base-1) / base;
 
-        // if we to to here and we are at the end of the string
+        // if we to here and we are at the end of the string
         // then the input is valid, return true;
         if (!*p || !p[1]) {
                 value = val;

--- a/src/condor_utils/read_user_log.cpp
+++ b/src/condor_utils/read_user_log.cpp
@@ -1356,7 +1356,7 @@ ReadUserLog::synchronize ( void )
 		return false;
 	}
 
-	const int ixN = sizeof(SynchDelimiter)-2; // back up to to point at the \n (assuming size includes a trailing \0)
+	const int ixN = sizeof(SynchDelimiter)-2; // back up to point at the \n (assuming size includes a trailing \0)
 	const int bufSize = 512;
     char buffer[bufSize];
     while( fgets( buffer, bufSize, m_fp ) != NULL ) {

--- a/src/condor_utils/submit_utils.cpp
+++ b/src/condor_utils/submit_utils.cpp
@@ -8580,7 +8580,7 @@ int SubmitHash::parse_q_args(
 	while (isspace(*pqargs)) ++pqargs;
 
 	// parse the queue arguments, handling the count and finding the in,from & matching keywords
-	// on success pqargs will point to to \0 or to just after the keyword.
+	// on success pqargs will point to \0 or to just after the keyword.
 	rval = o.parse_queue_args(pqargs);
 	if (rval < 0) {
 		errmsg = "invalid Queue statement";

--- a/src/condor_utils/uids.cpp
+++ b/src/condor_utils/uids.cpp
@@ -1607,7 +1607,7 @@ _set_priv(priv_state s, const char *file, int line, int dologging)
 		}
 
 		// We only get here if we are actually switching state. (Not if we
-		// requested to to switch to the current state, or if we requested
+		// requested to switch to the current state, or if we requested
 		// to switch away from a _FINAL state).
 
 #ifdef LINUX

--- a/src/python-bindings/schedd.cpp
+++ b/src/python-bindings/schedd.cpp
@@ -3501,7 +3501,7 @@ public:
 			if (ssi.has_items()) {
 				std::string items_filename;
 				if (SendMaterializeData(cluster, 0, ssi.send_row, &ssi, items_filename, &row_count) < 0 || row_count <= 0) {
-					THROW_EX(HTCondorIOError, "Failed to to send materialize itemdata");
+					THROW_EX(HTCondorIOError, "Failed to send materialize itemdata");
 				}
 
 				// PRAGMA_REMIND("fix this when python submit supports foreach, maybe make this common with condor_submit")
@@ -3662,7 +3662,7 @@ public:
 			int row_count = 1;
 			if (ssi.has_items()) {
 				if (SendMaterializeData(cluster, 0, ssi.send_row, &ssi, ssi.fea().items_filename, &row_count) < 0 || row_count <= 0) {
-					THROW_EX(HTCondorIOError, "Failed to to send materialize itemdata");
+					THROW_EX(HTCondorIOError, "Failed to send materialize itemdata");
 				}
 				num_jobs = row_count * ssi.step_size();
 			}


### PR DESCRIPTION
Upon reviewing HTCONDOR-2010, I noticed that the improved error message duplicated the word to. When I search for the pattern, it was much more prevalant than expected.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
