### PR TITLE
HTCONDOR-2051: DAGMan service nodes failing assertion check

### DIFF
--- a/docs/version-history/lts-versions-23-0.rst
+++ b/docs/version-history/lts-versions-23-0.rst
@@ -36,6 +36,10 @@ Bugs Fixed:
   error if they returned an exit code with high bits set
   :jira:`2061`
 
+- Fixed a bug in DAGMan where ``Service`` nodes that failed caused the DAGMan process to fail
+  an assertion check and crash.
+  :jira:`2051`
+
 - Fixed a bug where jobs put on hold internally by the shadow were not writing their ad to the
   job epoch history file.
   :jira:`2060`


### PR DESCRIPTION
-Similar to the issue/fix in HTCONDOR-1909, DAGMan was failing an
 assertion check due to service nodes being counted when they were
 not supposed to be. This was during a node failure. The fix was
 to not include service nodes in the total count of failed nodes
-Updated test to check that failed service nodes worked correctly

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
