### PR TITLE
HTCONDOR-2102: Fix bug warning about differring internal held procs count

### DIFF
--- a/docs/version-history/lts-versions-23-0.rst
+++ b/docs/version-history/lts-versions-23-0.rst
@@ -66,6 +66,10 @@ Bugs Fixed:
   *condor_schedd* that's on the same private network.
   :jira:`2115`
 
+- Fixed bug in DAGMan where held jobs that were removed would cause a
+  warning about the internal count of held job procs being incorrect.
+  :jira:`2102`
+
 .. _lts-version-history-2301:
 
 Version 23.0.1

--- a/src/condor_dagman/dag.cpp
+++ b/src/condor_dagman/dag.cpp
@@ -718,8 +718,6 @@ Dag::ProcessAbortEvent(const ULogEvent *event, Job *job,
 
 		job->SetProcEvent( event->proc, ABORT_TERM_MASK );
 
-		DecrementProcCount( job );
-
 			// This code is here because if a held job is removed, we
 			// don't get a released event for that job.  This may not
 			// work exactly right if some procs of a cluster are held
@@ -727,6 +725,8 @@ Dag::ProcessAbortEvent(const ULogEvent *event, Job *job,
 		if ( job->_jobProcsOnHold > 0 ) {
 			job->Release( event->proc );
 		}
+
+		DecrementProcCount( job );
 
 			// Only change the node status, error info,
 			// etc., if we haven't already gotten an error


### PR DESCRIPTION
-DecrementProcCount() calls cleanup() for a node which empties
 the _gotEvents vector for managing job proc events. Because of
 this reset happening prior to a node proc Release(), the proc
 info was non-existant and the internal count decrement passed

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
