### PR TITLE
HTCONDOR-2173 Speed up ctest runs

### DIFF
--- a/src/condor_tests/ctest_driver
+++ b/src/condor_tests/ctest_driver
@@ -27,6 +27,11 @@ MAIL=/bin/true
 SENDMAIL=/bin/true
 LOCAL_CONFIG_FILE={pwd}/condor_config.local
 DOCKER_PERFORM_TEST=false
+# The default FILETRANSFER_PLUGINS contains support for box,onedrive,
+# and gdrive.  On startup, the startd runs each of these with the -classad
+# option to probe.  However, this is somewhat slow, as they are each implemented
+# in python, and we test none of them.  Ideally, I'd like to just be able to
+# remove those from the default, but we don't have a good way to do that.
 FILETRANSFER_PLUGINS = $(LIBEXEC)/curl_plugin
 
 # ctest allows tests to run for up to 1500 seconds; after that, we are

--- a/src/condor_tests/ctest_driver
+++ b/src/condor_tests/ctest_driver
@@ -27,6 +27,7 @@ MAIL=/bin/true
 SENDMAIL=/bin/true
 LOCAL_CONFIG_FILE={pwd}/condor_config.local
 DOCKER_PERFORM_TEST=false
+FILETRANSFER_PLUGINS = $(LIBEXEC)/curl_plugin
 
 # ctest allows tests to run for up to 1500 seconds; after that, we are
 # potentially a runaway personal condor instance.


### PR DESCRIPTION
ps shows that when I run ctest -j 40, there's usually a dozen python processes running box|gdrive|onedrive plugin -classad.

Testing standalone shows that just getting python off the ground takes about .2 of a second, and when we do three of these for each startd, it adds up.  We have no tests that test these plugins, and I'm not sure we have any users, so I'm just going to disable them in ctest.

Ideally, I'd like the equivalent of "-=" in config language, but for now, we'll hard code the transfer plugin list to just include the curl plugin, which we do test, and is in native condor code, so it is fast to run -classad.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
