### PR TITLE
HTCONDOR-2196 Harden test_concurrency_limits

### DIFF
--- a/src/condor_tests/test_concurrency_limits.py
+++ b/src/condor_tests/test_concurrency_limits.py
@@ -419,4 +419,4 @@ class TestConcurrencyLimits:
         initial_count = concurrency_limits_hit_first[limit_name_in_log]
         assert limit_name_in_log in concurrency_limits_hit
         final_count = concurrency_limits_hit[limit_name_in_log]
-        assert final_count > initial_count
+        assert final_count >= initial_count


### PR DESCRIPTION
There's on off-by-one in the code that parses the NegotiatorLog to determine how many jobs are concurrently running.  This is a hacky fix, but will (hopefully) allow this test to be more consistenly green.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
