### PR TITLE
HTCONDOR-2236 fix bug in user log reader with short reads.

### DIFF
--- a/docs/version-history/lts-versions-23-0.rst
+++ b/docs/version-history/lts-versions-23-0.rst
@@ -32,7 +32,11 @@ New Features:
 
 Bugs Fixed:
 
-- None.
+- Fixed bug in the event log reader that would rarely cause DAGMan
+  to lose track of a job, and wait forever for a job that had
+  really finished, with dagman not realizing that said job had
+  indeed finished.
+  :jira:`2236`
 
 .. _lts-version-history-2304:
 

--- a/src/condor_utils/read_user_log.cpp
+++ b/src/condor_utils/read_user_log.cpp
@@ -1097,7 +1097,8 @@ ReadUserLog::readEventClassad( ULogEvent *& event, int log_type, FileLockBase *l
 /*
  *  This is the heart of the user log reader.  The precondition on entry is
  *  that the fp in the class is pointing at the very start of a "native" user
- *  log event, or at end of file.  The writers must guarantee that events are
+ *  log event, or at end of file (assuming the end of file is immediately after
+ *  a completely written event).  The writers must guarantee that events are
  *  not interleaved.  They do this by gathering up all the bytes in a single
  *  event, and writing them in one write(2) call, to an fd opened in O_APPEND
  *  mode.  If somehow the fp is pointing in the middle of an event, we don't go


### PR DESCRIPTION
In the test suites, we (rarely) see dagman hanging, having lost track of a job it submitted.  Turns out that the user log read code is to blame. There are cases where even though the user log writer is writing the entire event in one write(2) call, on an FD opened with O_APPEND, posix only guarantees that a reader will see every byte of that write at once if the read is started after the write returns to userspace. We make no attempts to do so.

In a couple of places in the log reader code, we fseek back to the beginning  when we detect a short read, but not all cases.  This PR adds fseek’ing back to the remaining cases.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
