### PR TITLE
HTCONDOR-2241 test-token-fixes

### DIFF
--- a/build/packaging/debian/control.in
+++ b/build/packaging/debian/control.in
@@ -61,6 +61,7 @@ Architecture: any
 Depends: adduser,
          libdate-manip-perl,
          python3,
+         python3-cryptography,
          python3-requests,
          lsb-release,
          libcom-err2,

--- a/build/packaging/rpm/condor.spec
+++ b/build/packaging/rpm/condor.spec
@@ -394,6 +394,7 @@ A collection of tests to verify that HTCondor is operating properly.
 Summary: Python bindings for HTCondor
 Group: Applications/System
 Requires: python >= 2.2
+Requires: python2-cryptography
 Requires: %name = %version-%release
 %{?python_provide:%python_provide python2-condor}
 %if 0%{?rhel} >= 7
@@ -426,6 +427,7 @@ Requires: boost-python3
 %endif
 %endif
 Requires: python3
+Requires: python3-cryptography
 
 %description -n python3-condor
 The python bindings allow one to directly invoke the C++ implementations of

--- a/docs/version-history/lts-versions-23-0.rst
+++ b/docs/version-history/lts-versions-23-0.rst
@@ -42,6 +42,10 @@ Bugs Fixed:
   set its descendants to the Futile state if the node job got removed.
   :jira:`2240`
 
+- Fixed *condor_test_token* to access the SciTokens cache as the correct
+  user when run as root.
+  :jira:`2241`
+
 .. _lts-version-history-2304:
 
 Version 23.0.4

--- a/src/condor_scripts/condor_test_token
+++ b/src/condor_scripts/condor_test_token
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import pwd
 import argparse
 import base64
 import binascii
@@ -258,6 +259,10 @@ def parse_args():
 
 
 def main():
+    # For a rootly HTCondor, the SciTokens cache is owned by user condor
+    if os.getuid() == 0:
+        os.seteuid(pwd.getpwnam('condor').pw_uid)
+
     args = parse_args()
     init_ffi()
 


### PR DESCRIPTION
HTCondor daemons access the cache file as user condor. condor_test_token needs to do the same when run as root.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
