### PR TITLE
HTCONDOR-2235: Fix extenstions error 404 with deep paths

### DIFF
--- a/bindings/python/htcondor2/_submit.py
+++ b/bindings/python/htcondor2/_submit.py
@@ -305,7 +305,7 @@ class Submit(MutableMapping):
         short description from *condor_submit_dag*'s ``-help`` output.
 
         This function is useful if you don't have an installed copy of
-        *condor_submit_dag* or if this module and that command-line
+        :tool:`condor_submit_dag` or if this module and that command-line
         tool could be from different versions.
 
         FIXME: Unimplemented.

--- a/docs/extensions/ad-attr.py
+++ b/docs/extensions/ad-attr.py
@@ -6,7 +6,7 @@ from docutils.parsers.rst import Directive
 from sphinx import addnodes
 from sphinx.errors import SphinxError
 from sphinx.util.nodes import split_explicit_title, process_index_entry, set_role_source_info
-from htc_helpers import custom_ext_parser, make_ref_and_index_nodes, extra_info_parser
+from htc_helpers import *
 # Remove once Centos7 support is dropped (Requires Sphinx V2.0.0)
 try:
     from sphinx.util import logging
@@ -60,6 +60,7 @@ def warn(msg: str):
         logger.warning(msg)
 
 def classad_attr_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    root_dir = get_rel_path_to_root_dir(inliner)[:-1]
     attr_name, attr_info = custom_ext_parser(text)
     details = extra_info_parser(attr_info) if attr_info != "" else None
 
@@ -76,7 +77,7 @@ def classad_attr_role(name, rawtext, text, lineno, inliner, options={}, content=
             if len(ATTRIBUTE_FILES[attr_name]) > 1:
                 warn(f"Classad Attribute '{attr_name}' is defined in multiple files. Defaulting to {filename}")
 
-    ref_link = f"href=\"../classad-attributes/{filename}#{attr_name}\""
+    ref_link = f"href=\"{root_dir}/classad-attributes/{filename}#{attr_name}\""
     return make_ref_and_index_nodes(name, attr_name, attr_index,
                                     ref_link, rawtext, inliner, lineno, options)
 

--- a/docs/extensions/htc_helpers.py
+++ b/docs/extensions/htc_helpers.py
@@ -16,6 +16,11 @@ from sphinx import addnodes
 from sphinx.errors import SphinxError
 from sphinx.util.nodes import split_explicit_title, process_index_entry, set_role_source_info
 
+def get_rel_path_to_root_dir(inliner):
+    env = inliner.document.settings.env
+    doc = env.docname
+    return "../" * len(env.doc2path(doc, False).split("/"))
+
 def make_headerlink_node(attribute_name, options):
     ref = '#' + attribute_name
     node = nodes.reference('', '¶', refuri=ref, reftitle="Permalink to this headline", classes=['headerlink'], **options)

--- a/docs/extensions/macro.py
+++ b/docs/extensions/macro.py
@@ -6,15 +6,16 @@ from docutils.parsers.rst import Directive
 from sphinx import addnodes
 from sphinx.errors import SphinxError
 from sphinx.util.nodes import split_explicit_title, process_index_entry, set_role_source_info
-from htc_helpers import custom_ext_parser, make_ref_and_index_nodes
+from htc_helpers import *
 
 def dump(obj):
     for attr in dir(obj):
         print("obj.%s = %r" % (attr, getattr(obj, attr)))
 
 def macro_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    root_dir = get_rel_path_to_root_dir(inliner)[:-1]
     macro_name, macro_index = custom_ext_parser(text)
-    ref_link = "href=\"../admin-manual/configuration-macros.html#" + str(macro_name) + "\""
+    ref_link = f"href=\"{root_dir}/admin-manual/configuration-macros.html#" + str(macro_name) + "\""
     return make_ref_and_index_nodes(name, macro_name, macro_index,
                                     ref_link, rawtext, inliner, lineno, options)
 

--- a/docs/extensions/subcom.py
+++ b/docs/extensions/subcom.py
@@ -6,15 +6,16 @@ from docutils.parsers.rst import Directive
 from sphinx import addnodes
 from sphinx.errors import SphinxError
 from sphinx.util.nodes import split_explicit_title, process_index_entry, set_role_source_info
-from htc_helpers import custom_ext_parser, make_ref_and_index_nodes
+from htc_helpers import *
 
 def dump(obj):
     for attr in dir(obj):
         print("obj.%s = %r" % (attr, getattr(obj, attr)))
 
 def subcom_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    root_dir = root_dir = get_rel_path_to_root_dir(inliner)[:-1]
     subcom_name, subcom_index = custom_ext_parser(text)
-    ref_link = "href=\"../man-pages/condor_submit.html#" + str(subcom_name) + "\""
+    ref_link = f"href=\"{root_dir}/man-pages/condor_submit.html#" + str(subcom_name) + "\""
     return make_ref_and_index_nodes(name, subcom_name, subcom_index,
                                     ref_link, rawtext, inliner, lineno, options)
 

--- a/docs/extensions/tool.py
+++ b/docs/extensions/tool.py
@@ -6,16 +6,17 @@ from docutils.parsers.rst import Directive
 from sphinx import addnodes
 from sphinx.errors import SphinxError
 from sphinx.util.nodes import split_explicit_title, process_index_entry, set_role_source_info
-from htc_helpers import custom_ext_parser, make_ref_and_index_nodes
+from htc_helpers import *
 
 def dump(obj):
     for attr in dir(obj):
         print("obj.%s = %r" % (attr, getattr(obj, attr)))
 
 def tool_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    root_dir = get_rel_path_to_root_dir(inliner)[:-1]
     original_name, program_index = custom_ext_parser(text)
     program_name = original_name if original_name[:8] != "htcondor" else "htcondor"
-    ref_link = f"href=\"../man-pages/{program_name}.html\""
+    ref_link = f"href=\"{root_dir}/man-pages/{program_name}.html\""
     return make_ref_and_index_nodes(name, original_name, program_index,
                                     ref_link, rawtext, inliner, lineno, options)
 


### PR DESCRIPTION
-Before this change the custom extentions expected the root
 html directory to be one ../ up. This would result in error 404
 page not found when attempt to use custom reference roles in files
 that where deeper in the directory tree. Fix is to dynamically
 create the relative path up to the html root directory

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
