### PR TITLE
HTCONDOR-2296 Fix starter crash on unix with JobStarterLog

### DIFF
--- a/src/condor_utils/dprintf_config.cpp
+++ b/src/condor_utils/dprintf_config.cpp
@@ -567,8 +567,7 @@ dprintf_config( const char *subsys, struct dprintf_output_settings *p_info /* = 
 			} else {
 				logarg = arg.ptr();
 			}
-			auto_free_ptr logPath(realpath(logarg, nullptr));
-			info.logPath = logPath.ptr();
+			info.logPath = logarg;
 			trim(info.logPath);
 			info.optional_file = true; // for the condor_starter, the directory of this file may not exist at first
 			DebugParams.push_back(info);


### PR DESCRIPTION
When requesting an extra copy of the starter log to transfer to the AP, don't call realpath() on the yet-to-be-created filename. That will fail on unix and using the resulting nullptr crashes the starter.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
