### PR TITLE
(HTCONDOR-2305) Don't pass newlines from the job wrapper into the error message;

### DIFF
--- a/docs/version-history/lts-versions-23-0.rst
+++ b/docs/version-history/lts-versions-23-0.rst
@@ -64,6 +64,11 @@ Bugs Fixed:
   ``C:\Program Files``
   :jira:`2302`
 
+- Fixed a bug where the :macro:`USER_JOB_WRAPPER` was allowed to create job
+  event log information events with newlines in them, which broke the event
+  log parser.
+  :jira:`2305`
+
 .. _lts-version-history-2305:
 
 Version 23.0.5

--- a/src/condor_starter.V6.1/user_proc.cpp
+++ b/src/condor_starter.V6.1/user_proc.cpp
@@ -29,6 +29,8 @@
 #include "stream_handler.h"
 #include "subsystem_info.h"
 
+#include <algorithm>
+
 extern Starter *Starter;
 
 const char* JOB_WRAPPER_FAILURE_FILE = ".job_wrapper_failure";

--- a/src/condor_starter.V6.1/user_proc.cpp
+++ b/src/condor_starter.V6.1/user_proc.cpp
@@ -145,6 +145,12 @@ UserProc::JobReaper(int pid, int status)
 			fclose(fp);
 		}
 		trim(error_txt);
+		// Do NOT pass newlines into this exception, since it ends up
+		// in corrupting the job event log.
+		std::replace(
+		    error_txt.begin(), error_txt.end(),
+		    '\n', ' '
+		);
 		EXCEPT("The job wrapper failed to execute the job: %s", error_txt.c_str());
 	}
 


### PR DESCRIPTION
doing so causes the event log parser to become confused.

See #2226.  This PR corrects targets `V23_0-branch`, as that PR should have.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
