### PR TITLE
HTCONDOR-2312 Fix Python 3.12 warnings in condor_adstash

### DIFF
--- a/docs/version-history/lts-versions-23-0.rst
+++ b/docs/version-history/lts-versions-23-0.rst
@@ -69,6 +69,9 @@ Bugs Fixed:
   log parser.
   :jira:`2305`
 
+- Fixed ``SyntaxWarning`` raised by Python 3.12 in **condor_adstash**.
+  :jira:`2312`
+
 .. _lts-version-history-2305:
 
 Version 23.0.5

--- a/src/condor_scripts/adstash/config.py
+++ b/src/condor_scripts/adstash/config.py
@@ -166,7 +166,7 @@ def get_environment_config(name="ADSTASH"):
 def debug2level(debug):
 
     level = "WARNING"
-    debug_levels = set(re.split("[\s,]+", debug))
+    debug_levels = set(re.split(r"[\s,]+", debug))
     if ("D_FULLDEBUG" in debug_levels) or ("D_ALL" in debug_levels):
         level = "INFO"
     if ("D_FULLDEBUG:2" in debug_levels) or ("D_ALL:2" in debug_levels):
@@ -183,7 +183,7 @@ def debug2fmt(debug=None):
         fmt = " ".join(fmt_list)
         return {"fmt": fmt, "datefmt": datefmt}
 
-    debug_levels = set(re.split("[\s,]+", debug))
+    debug_levels = set(re.split(r"[\s,]+", debug))
 
     if "D_CATEGORY" in debug_levels:
         fmt_list.insert(1, "(%(levelname)s)")


### PR DESCRIPTION
https://opensciencegrid.atlassian.net/browse/HTCONDOR-2312

Pretty simple fix to convert offending strings to raw strings.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
