### PR TITLE
First implementation of the Docker entrypoint override.

### DIFF
--- a/docs/man-pages/condor_submit.rst
+++ b/docs/man-pages/condor_submit.rst
@@ -2246,6 +2246,17 @@ COMMANDS FOR THE DOCKER UNIVERSE
     which contains the port number on the host forwarding to the corresponding
     service.
 
+ :subcom-def:`docker_override_entrypoint` = <True | False>
+    If docker_override_entrypoint is set to True and **executable** is not empty,
+    the image entrypoint is replaced with the executable.
+    The default value (False) follows the same logic as the docker engine uses with images
+    (see `docker run <https://docs.docker.com/engine/reference/run/#default-command-and-options>`_):
+
+        * Without entrypoint, executable runs as main PID
+        * With entrypoint, it is launched with the excutable as first argument
+    
+    Any additional **arguments** will follow the executable.
+
 COMMANDS FOR THE CONTAINER UNIVERSE
 
  :subcom-def:`container_image` = < image-name >

--- a/docs/users-manual/env-of-job.rst
+++ b/docs/users-manual/env-of-job.rst
@@ -353,6 +353,23 @@ If no :subcom:`executable[in docker universe]` is
 specified in the submit description file, it is presumed that the Docker
 container has a default command to run.
 
+If the docker image has an entrypoint defined, and :subcom:`executable[in docker universe]`
+is specified in the submit description file,
+it will be used as first argument for the entrypoint, followed by any :subcom:`arguments`.
+
+It is possible to use as entrypoint the :subcom:`executable[in docker universe]`
+directly, redefining the entrypoint of the image (equivalent to ``--entrypoint`` in
+`docker run <https://docs.docker.com/engine/reference/commandline/container_run>`_)
+
+The entrypoint is replaced by the executable if the submit description file contains the command:
+
+.. code-block:: condor-submit
+
+      docker_override_entrypoint = True
+
+The default value is ``False`` as it is the behaviour that works well with the majority of the
+docker images.
+
 When the job completes, is held, evicted, or is otherwise removed from
 the machine, the container will be removed.
 

--- a/src/condor_includes/condor_attributes.h
+++ b/src/condor_includes/condor_attributes.h
@@ -185,6 +185,7 @@
 #define ATTR_DOCKER_IMAGE "DockerImage"
 #define ATTR_DOCKER_NETWORKS "DockerNetworks"
 #define ATTR_DOCKER_NETWORK_TYPE "DockerNetworkType"
+#define ATTR_DOCKER_OVERRIDE_ENTRYPOINT  "DockerOverrideEntrypoint"
 #define ATTR_DOCKER_PULL_POLICY "DockerPullPolicy"
 #define ATTR_DOCKER_VOLUMES "DockerVolumes"
 #define ATTR_DOCKER_VERSION  "DockerVersion"

--- a/src/condor_scripts/adstash/convert.py
+++ b/src/condor_scripts/adstash/convert.py
@@ -357,6 +357,7 @@ BOOL_ATTRS = {
     "BufferFiles",
     "CurrentStatusUnknown",
     "DataflowJobSkipped",
+    "DockerOverrideEntrypoint",
     "EncryptExecuteDirectory",
     "EraseOutputAndErrorOnRestart",
     "ExitBySignal",

--- a/src/condor_tests/cmd_submit_regress_dry.expect
+++ b/src/condor_tests/cmd_submit_regress_dry.expect
@@ -138,6 +138,15 @@ TransferExecutable=false
 WantDocker=true
 ProcId=0
 
+==docker-entrypoint.sub
+DockerImage="ubuntu"
+Requirements=/TARGET\.HasDocker/
+WantDocker=true
+Cmd=/^".*basic.cmd"$/
+DockerOverrideEntrypoint=true
+JobStatus=1
+ProcId=0
+
 ==grid_azure.sub
 Arguments=""
 AzureAdminKey="/Users/jfrey/.ssh/azure_rsa.pub"
@@ -206,8 +215,8 @@ Requirements=/TARGET\.HasFileTransfer.+"FTP",TARGET\.HasFileTransferPluginMethod
 TransferInput="FTP://foo/bar"
 
 ==xfer1.sub
-Err=/"\d+xfer1\.17\.err"/
-Out=/"\d+xfer1\.17\.out"/
+Err=/"\d+xfer1\.18\.err"/
+Out=/"\d+xfer1\.18\.out"/
 Requirements=/TARGET\.HasFileTransfer/
 ShouldTransferFiles="YES"
 StreamErr=false

--- a/src/condor_tests/cmd_submit_regress_dry.subs
+++ b/src/condor_tests/cmd_submit_regress_dry.subs
@@ -126,6 +126,13 @@ universe=docker
 docker_image=ubuntu
 queue 3
 
+==docker-entrypoint.sub
+universe=docker
+docker_image=ubuntu
+executable=$Fp(SUBMIT_FILE)basic.cmd
+DockerOverrideEntrypoint=TRUE
+queue 1
+
 ==grid_azure.sub
 universe = grid
 grid_resource = azure 4843bf93-0ebe-422e-b6ef-c877f6740099

--- a/src/condor_utils/submit_utils.cpp
+++ b/src/condor_utils/submit_utils.cpp
@@ -4414,6 +4414,7 @@ static const SimpleSubmitKeyword prunable_keywords[] = {
 	{SUBMIT_KEY_JobMaterializeMaxIdleAlt, ATTR_JOB_MATERIALIZE_MAX_IDLE, SimpleSubmitKeyword::f_as_expr | SimpleSubmitKeyword::f_alt_name},
 	{SUBMIT_KEY_DockerNetworkType, ATTR_DOCKER_NETWORK_TYPE, SimpleSubmitKeyword::f_as_string},
 	{SUBMIT_KEY_DockerPullPolicy, ATTR_DOCKER_PULL_POLICY, SimpleSubmitKeyword::f_as_string},
+	{SUBMIT_KEY_DockerOverrideEntrypoint, ATTR_DOCKER_OVERRIDE_ENTRYPOINT, SimpleSubmitKeyword::f_as_bool},
 	{SUBMIT_KEY_ContainerTargetDir, ATTR_CONTAINER_TARGET_DIR, SimpleSubmitKeyword::f_as_string | SimpleSubmitKeyword::f_strip_quotes},
 	{SUBMIT_KEY_TransferContainer, ATTR_TRANSFER_CONTAINER, SimpleSubmitKeyword::f_as_bool},
 	{SUBMIT_KEY_TransferPlugins, ATTR_TRANSFER_PLUGINS, SimpleSubmitKeyword::f_as_string},

--- a/src/condor_utils/submit_utils.h
+++ b/src/condor_utils/submit_utils.h
@@ -267,6 +267,7 @@
 #define SUBMIT_KEY_DockerImage "docker_image"
 #define SUBMIT_KEY_DockerNetworkType "docker_network_type"
 #define SUBMIT_KEY_DockerPullPolicy "docker_pull_policy"
+#define SUBMIT_KEY_DockerOverrideEntrypoint "docker_override_entrypoint"
 
 #define SUBMIT_KEY_ContainerImage "container_image"
 #define SUBMIT_KEY_ContainerServiceNames "container_service_names"


### PR DESCRIPTION
Add the possibility to the docker universe to use the executable as argument for the `--entrypoint` of docker create.

This is useful when the default entrypoint is not able to run the executable, for example when it does not interpret the first argument as the command to run.

This flags selects between two different behaviours of `docker run` as described in the [documentation](https://docs.docker.com/engine/reference/run/#default-command-and-options) in a not really obvious way.
Essentially if the docker image has an entrypoint defined:
```Dockerfile
# ...
ENTRYPOINT ["/opt/entrypoint.sh"]
# ...
```
The run command will always use it, with all the arguments passed to the entrypoint.
This means that a command like:
```shell
docker run image:latest  /usr/local/command.sh arg1 arg2
```
Is really equivalent to:
```shell
/opt/entrypoint.sh  /usr/local/command.sh arg1 arg2
```
And not:
```shell
/usr/local/command.sh arg1 arg2
```

Commonly this is not an issue because almost all of the images either do not have an entrypoint or the entrypoint is essentially the proper interpreter and will evaluate the first argument as a binary.
However there are occasions where the entrypoint is not prepared to do this or it is desirable to skip it.
In docker this is done with:
```shell
docker run --entrypoint /usr/local/command.sh image:latest  arg1 arg2
```

This patch brings the possibility to a condor job to have also  this possibility by defining the `docker_override_entrypoint` to true in the submit, so the `executable` is used as entrypoint.

Original mail thread with some more details: [HTCondor Users](https://www-auth.cs.wisc.edu/lists/htcondor-users/2024-February/msg00005.shtml)


# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
