### PR TITLE
Fix LoadAvg values, so that they better reflect the number of CPUs of a slot

### DIFF
--- a/src/condor_startd.V6/ResMgr.cpp
+++ b/src/condor_startd.V6/ResMgr.cpp
@@ -1659,15 +1659,16 @@ void ResMgr::assign_load_and_idle()
 	// even if the value was greater than 1.0, but other than that this algorithm is
 	// the same as before.  This algorithm doesn't make a lot of sense for multi-core slots
 	// but it's the way it has always worked so...
-	for (Resource* rip : active) {
-		if (total_owner_load < 1.0) {
-			rip->set_owner_load(total_owner_load);
-			total_owner_load = 0;
-		} else {
-			rip->set_owner_load(1.0);
-			total_owner_load -= 1.0;
-		}
-	}
+        for (Resource* rip : active) {
+                long long cpus = rip->r_attr->num_cpus();
+                if (total_owner_load < cpus) {
+                        rip->set_owner_load(total_owner_load);
+                        total_owner_load = 0;
+                } else {
+                        rip->set_owner_load(cpus);
+                        total_owner_load -= cpus;
+                }
+        }
 
 	// assign keyboard and console idle
 	time_t console = m_attr->console_idle();


### PR DESCRIPTION
Following the discussion in the htcondor-users thread (https://www-auth.cs.wisc.edu/lists/htcondor-users/2024-March/msg00049.shtml), this PR calculates the LoadAvg for multi-core slots in a more sensible way: instead of capping the owner_load of a slot to 1.0, it will be the number of cpus in the slot.

In my case, I also wanted to have Condor EPs that are able to treat multi-core jobs somehow similarly to single-core jobs, so that multi-core jobs are able to start executing as far as the load of the machine is less than the total number of CPUs, so I also modified the configuration file to the following, overriding the POLICY:DESKTOP values, though I do not include this in the PR itself, since this is a configuration issue that probably not all sites want to have.

```
NumCPUsIdle = Cpus - LoadAvg
START=((KeyboardIdle > $(StartIdleTime)) && (  $(NumCPUsIdle) > TARGET.RequestCpus || (State != "Unclaimed" && State != "Owner")) )

```

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
