### PR TITLE
HTCONDOR-232 Delay enforcement of token file permissions

### DIFF
--- a/docs/version-history/feature-versions-23-x.rst
+++ b/docs/version-history/feature-versions-23-x.rst
@@ -19,10 +19,6 @@ Release Notes:
 
 New Features:
 
-- ``IDTOKEN`` files whose access permissions are not restricted to the file
-  owner are now ignored.
-  :jira:`232`
-
 - Allow the *condor_startd* to force a job that doesn't ask to run inside a
   docker or apptainer container inside one with new parameters
   :macro:`USE_DEFAULT_CONTAINER` and :macro:`DEFAULT_CONTAINER_IMAGE`

--- a/src/condor_io/condor_auth_passwd.cpp
+++ b/src/condor_io/condor_auth_passwd.cpp
@@ -154,7 +154,8 @@ bool findToken(const std::string &tokenfilename,
 	bool rv = false;
 	char* data = nullptr;
 	size_t len = 0;
-	if (!read_secure_file(tokenfilename.c_str(), (void**)&data, &len, true)) {
+	// TODO Change this to SECURE_FILE_VERIFY_ALL in 23.8.x
+	if (!read_secure_file(tokenfilename.c_str(), (void**)&data, &len, true, SECURE_FILE_VERIFY_NONE)) {
 		return false;
 	}
 	for (auto& line: StringTokenIterator(data, len, "\n", true)) {

--- a/src/condor_utils/secure_file.h
+++ b/src/condor_utils/secure_file.h
@@ -34,6 +34,7 @@ bool write_secure_file(const char* path, const void* data, size_t len, bool as_r
 //   tmpext - appended to path to create the temp filename
 bool replace_secure_file(const char* path, const char * tmpext, const void* data, size_t len, bool as_root, bool group_readable = false);
 
+#define SECURE_FILE_VERIFY_NONE      0x00
 #define SECURE_FILE_VERIFY_OWNER     0x01
 #define SECURE_FILE_VERIFY_ACCESS    0x02
 #define SECURE_FILE_VERIFY_ALL       0xFF


### PR DESCRIPTION
This is a disruptive change for our installed base, so delay the file access checks until a future version (23.8.x).

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
