### PR TITLE
(HTCONDOR-2377)  Allow CUDA devices to be autodectected again.

### DIFF
--- a/src/gpu/condor_gpu_discovery.cpp
+++ b/src/gpu/condor_gpu_discovery.cpp
@@ -677,14 +677,22 @@ main( int argc, const char** argv)
 	std::map< std::string, int > cudaDevices;
 	std::vector< BasicProps > nvmlDevices;
 	std::vector< BasicProps > enumeratedDevices;
+
+	bool enumeratedCUDADevices = false;
 	if(! opt_opencl) {
-		if (cuDeviceGetCount && ! enumerateCUDADevices(enumeratedDevices)) {
+		if (cuDeviceGetCount && enumerateCUDADevices(enumeratedDevices)) {
+			enumeratedCUDADevices = true;
+		}
+	}
+
+	if(! enumeratedCUDADevices) {
+		if( opt_cuda_only ) {
 			const char * problem = "Failed to enumerate GPU devices";
 			fprintf( stderr, "# %s, aborting.\n", problem );
 			fprintf( stdout, "condor_gpu_discovery_error = \"%s\"\n", problem );
 			return 1;
 		}
-
+	} else {
 		//
 		// We have to report NVML devices, because enabling MIG on any
 		// GPU prevents CUDA from reporting any MIG-capable GPU, even


### PR DESCRIPTION
Introducing MIG device detection accidentally broke our condor_gpu_discovery's auto mode, where it would print OpenCL devices if it couldn't find any CUDA ones.  This PR (hopefully) corrects that broken logic.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
