### PR TITLE
HTCONDOR-2389 Remove support for copy-on-write std::strings in

### DIFF
--- a/src/classad/classad.cpp
+++ b/src/classad/classad.cpp
@@ -492,7 +492,7 @@ bool ClassAd::Insert(const std::string& serialized_nvp);
 
 // Parse and insert an attribute value via cache if the cache is enabled
 //
-bool ClassAd::InsertViaCache( std::string& name, const std::string & rhs, bool lazy /*=false*/)
+bool ClassAd::InsertViaCache(const std::string& name, const std::string & rhs, bool lazy /*=false*/)
 {
 	if (name.empty()) return false;
 

--- a/src/classad/classad/classad.h
+++ b/src/classad/classad/classad.h
@@ -111,7 +111,7 @@ class ClassAd : public ExprTree
 
 		// insert through cache if cache is enabled, otherwise just parse and insert
 		// parsing of the rhs expression is done use old ClassAds syntax
-		bool InsertViaCache( std::string& attrName, const std::string & rhs, bool lazy=false);
+		bool InsertViaCache(const std::string& attrName, const std::string & rhs, bool lazy=false);
 
 		/** Insert an attribute/value into the ClassAd
 		 *  @param str A string of the form "Attribute = Value"

--- a/src/classad/classad/classadCache.h
+++ b/src/classad/classad/classadCache.h
@@ -62,18 +62,13 @@ public:
 	 * cache () - will cache a copy of the pTree and return 
 	 * an indirect envelope
 	 */
-#ifdef HAVE_COW_STRING
-	static ExprTree * cache ( std::string & pName, ExprTree * pTree, const std::string & szValue );
-	static ExprTree * cache_lazy ( std::string & pName, const std::string & szValue );
-#else
 	static ExprTree * cache (const std::string & pName, ExprTree * pTree, const std::string & szValue );
 	static ExprTree * cache_lazy (const std::string & pName, const std::string & szValue );
-#endif
 
 	/**
 	 * will check to see if we hit or not and return the value.
 	 */ 
-	static CachedExprEnvelope * check_hit (std::string & szName, const std::string & szValue);
+	static CachedExprEnvelope * check_hit (const std::string & szName, const std::string & szValue);
 
 	/**
 	 * will dump the cache contents to a file.

--- a/src/classad/classad/classad_containers.h
+++ b/src/classad/classad/classad_containers.h
@@ -35,15 +35,4 @@
 #define classad_map   std::map 
 #define classad_slist std::list
 
-// G++ uses a shared copy-on-write (COW) std::string on older versions
-// classads will force a copy from the cache for COW strings, but
-// newer gccs and all other compilers use the small string optimization
-// for their std::strings, and this copy just slows things down
-
-#if defined(__GNUC__) && (__GNUC__ < 5)
-#define HAVE_COW_STRING
-#else
-#undef HAVE_COW_STRING
-#endif
-
 #endif /* __CLASSAD_CLASSAD_CONTAINERS_H__ */

--- a/src/classad/classadCache.cpp
+++ b/src/classad/classadCache.cpp
@@ -70,11 +70,7 @@ public:
 	
 	virtual ~ClassAdCache(){ m_destroyed = true; };
 
-#ifdef HAVE_COW_STRING
-	pCacheData cache( std::string & szName, ExprTree * pVal)
-#else
 	pCacheData cache(const std::string & szName, ExprTree * pVal)
-#endif
 	{
 		std::string szValue;
 		if (pVal) {
@@ -87,11 +83,7 @@ public:
 	}
 
 	///< cache's a local attribute->ExpTree
-#ifdef HAVE_COW_STRING
-	pCacheData cache( std::string & szName, const std::string & szValue , ExprTree * pVal)
-#else
 	pCacheData cache(const std::string & szName, const std::string & szValue , ExprTree * pVal)
-#endif
 	{
 		pCacheData pRet;
 
@@ -101,9 +93,6 @@ public:
 		if (itr != m_Cache.end()) {
 			bValidName = true;
 			value_iterator vtr = itr->second.find(szValue);
-#ifdef HAVE_COW_STRING
-			szName = itr->first;
-#endif
 
 			// check the value cache
 			if (vtr != itr->second.end()) {
@@ -140,11 +129,7 @@ public:
 		return pRet;
 	}
 
-#ifdef HAVE_COW_STRING
-	pCacheData insert_lazy( std::string & szName, const std::string & szValue)
-#else
 	pCacheData insert_lazy(const std::string & szName, const std::string & szValue)
-#endif
 	{
 		pCacheData pRet;
 
@@ -154,9 +139,6 @@ public:
 		if (itr != m_Cache.end()) {
 			bValidName = true;
 			value_iterator vtr = itr->second.find(szValue);
-#ifdef HAVE_COW_STRING
-			szName = itr->first;
-#endif
 
 			// check the value cache
 			if (vtr != itr->second.end()) {
@@ -349,11 +331,7 @@ CacheEntry::~CacheEntry()
 }
 
 
-#ifdef HAVE_COW_STRING
-ExprTree * CachedExprEnvelope::cache (std::string & pName, ExprTree * pTree, const std::string & szValue)
-#else
 ExprTree * CachedExprEnvelope::cache (const std::string & pName, ExprTree * pTree, const std::string & szValue)
-#endif
 {
 	ExprTree * pRet = pTree;
 	CachedExprEnvelope * pNewEnv = NULL;
@@ -367,10 +345,6 @@ ExprTree * CachedExprEnvelope::cache (const std::string & pName, ExprTree * pTre
 
 	case EXPR_LIST_NODE:
 	case CLASSAD_NODE:
-#ifdef HAVE_COW_STRING
-		// for classads the values are already cached but we still should string space the name
-		check_hit (pName, szValue);
-#endif
 		break;
 
 	default:
@@ -384,11 +358,7 @@ ExprTree * CachedExprEnvelope::cache (const std::string & pName, ExprTree * pTre
 	return pRet;
 }
 
-#ifdef HAVE_COW_STRING
-ExprTree * CachedExprEnvelope::cache_lazy (std::string & pName, const std::string & szValue)
-#else
 ExprTree * CachedExprEnvelope::cache_lazy (const std::string & pName, const std::string & szValue)
-#endif
 {
 	if ( ! _cache) { _cache.reset( new ClassAdCache() ); }
 	CachedExprEnvelope *pEnv = new CachedExprEnvelope();
@@ -414,7 +384,7 @@ void CachedExprEnvelope::_debug_print_stats(FILE* fp)
   if (_cache) _cache->print_stats(fp);
 }
 
-CachedExprEnvelope * CachedExprEnvelope::check_hit (string & szName, const string& szValue)
+CachedExprEnvelope * CachedExprEnvelope::check_hit(const string & szName, const string& szValue)
 {
    CachedExprEnvelope * pRet = 0; 
 


### PR DESCRIPTION
classads.  None of our compilers do this anymore (and C++ 11 forbids it).  This change promotes a more perfect const-ness, which is a stepping stone to allowing cons-free string_view accessors to classads.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
