### PR TITLE
HTCONDOR-2389 remove iostream overloads for classad value

### DIFF
--- a/src/classad/classad/value.h
+++ b/src/classad/classad/value.h
@@ -416,8 +416,6 @@ class Value
 
         friend bool operator==(const Value &value1, const Value &value2);
 
-		friend std::ostream& operator<<(std::ostream &stream, Value &value);
-
 	private:
 		void _Clear() {
 			switch( valueType ) {

--- a/src/classad/classad_functional_tester.cpp
+++ b/src/classad/classad_functional_tester.cpp
@@ -720,7 +720,10 @@ void handle_eval(
                 variable = new Variable(variable_name, value);
                 variables[variable_name] = variable;
                 if (parameters.interactive) {
-                    cout << value << endl;
+					classad::ClassAdUnParser unp;
+					std::string s;
+					unp.Unparse(s, value);
+                    cout << s << endl;
                 }
             }
         }
@@ -780,9 +783,14 @@ void handle_same(
             print_error_message("Couldn't evaluate second expressions.\n", state);
         } else if (!value1.SameAs(value2)) {
             if (parameters.debug) {
+				classad::ClassAdUnParser unp;
+				std::string s1;
+				std::string s2;
+				unp.Unparse(s1, value1);
+				unp.Unparse(s2, value2);
                 cout << "They evaluated to: \n";
-                cout << " " << value1 << endl;
-                cout << " " << value2 << endl;
+                cout << " " << s1 << endl;
+                cout << " " << s2 << endl;
             }
             print_error_message("the expressions are different.", state);
         }

--- a/src/classad/value.cpp
+++ b/src/classad/value.cpp
@@ -21,12 +21,10 @@
 #include "classad/operators.h"
 #include "classad/sink.h"
 #include "classad/value.h"
-#include <iostream>
 
 using std::string;
 using std::vector;
 using std::pair;
-using std::ostream;
 
 
 namespace classad {
@@ -471,54 +469,6 @@ SameAs(const Value &otherValue) const
 bool operator==(const Value &value1, const Value &value2)
 {
     return value1.SameAs(value2);
-}
-
-ostream& operator<<(ostream &stream, Value &value)
-{
-	ClassAdUnParser unparser;
-	string          unparsed_text;
-
-	switch (value.valueType) {
-	case Value::NULL_VALUE:
-		stream << "(null)";
-		break;
-	case Value::ERROR_VALUE:
-		stream << "error";
-		break;
-	case Value::UNDEFINED_VALUE:
-		stream << "undefined";
-		break;
-	case Value::BOOLEAN_VALUE:
-		if (value.booleanValue) {
-			stream << "true";
-		} else {
-			stream << "false";
-		}
-		break;
-	case Value::INTEGER_VALUE:
-		stream << value.integerValue;
-		break;
-	case Value::REAL_VALUE:
-		stream << value.realValue;
-		break;
-	case Value::LIST_VALUE:
-	case Value::SLIST_VALUE:
-	case Value::CLASSAD_VALUE:
-	case Value::SCLASSAD_VALUE:
-	case Value::RELATIVE_TIME_VALUE:
-	case Value::ABSOLUTE_TIME_VALUE: {
-		unparser.Unparse(unparsed_text, value);
-		stream << unparsed_text;
-		break;
-	}
-	case Value::STRING_VALUE:
-		stream << *value.strValue;
-		break;
-	default:
-		break;
-	}
-
-	return stream;
 }
 
 bool convertValueToRealValue(const Value value, Value &realValue)

--- a/src/condor_dagman/dagman_submit.cpp
+++ b/src/condor_dagman/dagman_submit.cpp
@@ -26,8 +26,6 @@
 #include "my_username.h"
 #include "../condor_utils/dagman_utils.h"
 
-#include <sstream>
-
 //
 // Local DAGMan includes
 //
@@ -952,7 +950,7 @@ const char *
 getEventMask()
 {
 	static std::string result("");
-	static std::stringstream dmaskstrm("");
+	static std::string dmaskstr("");
 
 	if ( result == "" ) {
 		//
@@ -984,13 +982,13 @@ getEventMask()
 
 		for ( const int *p = &mask[0]; *p != -1; ++p ) {
 			if ( p != &mask[0] ) {
-				dmaskstrm << ",";
+				dmaskstr += ',';
 			}
-			dmaskstrm << *p;
+			dmaskstr += std::to_string(*p);
 		}
 
-		result = dmaskstrm.str();
+		result = dmaskstr;
 	}
 
-	return result.c_str();
+	return result.c_str(); // somewhat safe because result is static.
 }

--- a/src/condor_filetransfer_plugins/multifile_curl_plugin.cpp
+++ b/src/condor_filetransfer_plugins/multifile_curl_plugin.cpp
@@ -7,7 +7,6 @@
 #include "fcloser.h"
 #include <algorithm>
 #include <exception>
-#include <sstream>
 #include <iostream>
 #include <chrono>
 #include <thread>
@@ -121,8 +120,8 @@ GetToken(const std::string & cred_name, std::string & token) {
 	}
 	const char *creddir = getenv("_CONDOR_CREDS");
 	if (!creddir) {
-		std::stringstream ss; ss << "Credential for " << cred_name << " requested by $_CONDOR_CREDS not set";
-		throw std::runtime_error(ss.str());
+		std::string s; s += std::string("Credential for ") + cred_name + " requested by $_CONDOR_CREDS not set";
+		throw std::runtime_error(s);
 	}
 
 	// Cred name (via URL scheme) come in as <provider>[.<handle>]
@@ -135,8 +134,8 @@ GetToken(const std::string & cred_name, std::string & token) {
 	if (-1 == fd) {
 		fprintf( stderr, "Error: Unable to open credential file %s: %s (errno=%d)", cred_path.c_str(),
 			strerror(errno), errno);
-		std::stringstream ss; ss << "Unable to open credential file " << cred_path << ": " << strerror(errno) << " (errno=" << errno << ")";
-		throw std::runtime_error(ss.str());
+		std::string s; s =  std::string("Unable to open credential file ") + cred_path + ": " + strerror(errno) + " (errno=" + std::to_string(errno) + ")";
+		throw std::runtime_error(s);
 	}
 	close(fd);
 	std::ifstream istr(cred_path, std::ios::binary);

--- a/src/condor_gridmanager/proxymanager.cpp
+++ b/src/condor_gridmanager/proxymanager.cpp
@@ -35,7 +35,6 @@
 #include "proxymanager.h"
 #include "gridmanager.h"
 
-#include <sstream>
 #include <algorithm>
 #include <map>
 
@@ -167,9 +166,8 @@ AcquireProxy( const ClassAd *job_ad, std::string &error,
 		std::string iwd;
 		job_ad->LookupString(ATTR_JOB_IWD, iwd);
 		if (!iwd.empty()) {
-			std::stringstream ss;
-			ss << iwd << DIR_DELIM_CHAR << proxy_path;
-			proxy_path = ss.str();
+			std::string s = iwd + DIR_DELIM_CHAR + proxy_path;
+			proxy_path = s;
 		}
 	}
 

--- a/src/condor_had/Utils.cpp
+++ b/src/condor_had/Utils.cpp
@@ -39,8 +39,6 @@
 #include "condor_netdb.h"
 #include "ipv6_hostname.h"
 
-#include <fstream>
-
 // for MD5 blocks computation, and for backward compat leading 0's
 #define MD5_MAC_SIZE   16
 

--- a/src/condor_starter.V6.1/starter.cpp
+++ b/src/condor_starter.V6.1/starter.cpp
@@ -57,8 +57,6 @@
 #endif
 #include "authentication.h"
 
-#include <sstream>
-
 extern void main_shutdown_fast();
 
 const char* JOB_AD_FILENAME = ".job.ad";

--- a/src/condor_tools/config_val.cpp
+++ b/src/condor_tools/config_val.cpp
@@ -57,7 +57,6 @@
 #include "param_info_tables.h"
 #include "condor_version.h"
 
-#include <sstream>
 #include <algorithm> // for std::sort
 
 const char * MyName;
@@ -461,9 +460,10 @@ char* EvaluatedValue(char const* value, ClassAd const* ad) {
     ClassAd empty;
     bool rc = (ad) ? ad->EvaluateExpr(value, res) : empty.EvaluateExpr(value, res);
     if (!rc) return NULL;
-    std::stringstream ss;
-    ss << res;
-    return strdup(ss.str().c_str());
+    std::string s;
+	classad::ClassAdUnParser unp;
+	unp.Unparse(s, res);
+    return strdup(s.c_str());
 }
 
 // consume the next command line argument, otherwise return an error

--- a/src/condor_tools/config_val.cpp
+++ b/src/condor_tools/config_val.cpp
@@ -461,8 +461,8 @@ char* EvaluatedValue(char const* value, ClassAd const* ad) {
     bool rc = (ad) ? ad->EvaluateExpr(value, res) : empty.EvaluateExpr(value, res);
     if (!rc) return NULL;
     std::string s;
-	classad::ClassAdUnParser unp;
-	unp.Unparse(s, res);
+    classad::ClassAdUnParser unp;
+    unp.Unparse(s, res);
     return strdup(s.c_str());
 }
 

--- a/src/condor_tools/token_list.cpp
+++ b/src/condor_tools/token_list.cpp
@@ -68,7 +68,6 @@ GCC_DIAG_OFF(cast-qual)
 GCC_DIAG_ON(float-equal)
 GCC_DIAG_ON(cast-qual)
 
-#include <fstream>
 #include <stdio.h>
 
 namespace {

--- a/src/condor_utils/CondorError.cpp
+++ b/src/condor_utils/CondorError.cpp
@@ -21,8 +21,8 @@
 #include "CondorError.h"
 #include "condor_snutils.h"
 #include "condor_debug.h"
+#include "stl_string_utils.h"
 
-#include <sstream>
 
 CondorError::CondorError(const CondorError& copy) {
 	init();
@@ -115,28 +115,26 @@ void CondorError::pushf( const char* the_subsys, int the_code, const char* the_f
 std::string
 CondorError::getFullText( bool want_newline ) const
 {
-	std::stringstream err_ss;
+	std::string err_ss;
 	bool printed_one = false;
 
 	CondorError* walk = _next;
 	while (walk) {
 		if( printed_one ) {
 			if( want_newline ) {
-				err_ss << '\n';
+				err_ss += '\n';
 			} else {
-				err_ss << '|';
+				err_ss += '|';
 			}
 		} else {
 			printed_one = true;
 		}
-		if (walk->_subsys) err_ss << walk->_subsys;
-		err_ss << ':';
-		err_ss << walk->_code;
-		err_ss << ':';
-		if (walk->_message) err_ss << walk->_message;
+		if (walk->_subsys) err_ss += walk->_subsys;
+		formatstr_cat(err_ss, ":%d:", walk->_code);
+		if (walk->_message) err_ss += walk->_message;
 		walk = walk->_next;
 	}
-	return err_ss.str();
+	return err_ss;
 }
 
 const char*

--- a/src/condor_utils/dprintf.cpp
+++ b/src/condor_utils/dprintf.cpp
@@ -69,8 +69,6 @@
 # include <time.h>
 #endif
 
-#include <sstream>
-
 // call when you want to insure that dprintfs are thread safe on Linux regardless of
 // wether daemon core threads are enabled. thread safety cannot be disabled once enabled
 #ifdef WIN32

--- a/src/condor_utils/file_transfer.cpp
+++ b/src/condor_utils/file_transfer.cpp
@@ -56,10 +56,8 @@
 #include "shortfile.h"
 #include "fcloser.h"
 
-#include <fstream>
 #include <algorithm>
 #include <numeric>
-#include <sstream>
 #include <string>
 #include <unordered_set>
 #include <unordered_map>
@@ -833,8 +831,7 @@ FileTransfer::IsDataflowJob( ClassAd *job_ad ) {
 
 	// Parse the list of input files
 	job_ad->LookupString( ATTR_TRANSFER_INPUT_FILES, input_files );
-	std::stringstream is( input_files );
-	while ( getline( is, token, ',' ) ) {
+	for (const auto &token: StringTokenIterator(input_files, ",")) {
 		// Skip any file path that looks like a URL or transfer plugin related
 		if ( token.find( "://" ) == std::string::npos ) {
 			// Stat each file. Paths can be relative or absolute.
@@ -876,8 +873,7 @@ FileTransfer::IsDataflowJob( ClassAd *job_ad ) {
 
 	// Parse the list of output files
 	job_ad->LookupString( ATTR_TRANSFER_OUTPUT_FILES, output_files );
-	std::stringstream os( output_files );
-	while ( getline( os, token, ',' ) ) {
+	for (const auto &token: StringTokenIterator(output_files, ",")) {
 		// Stat each file. Add the last-modified timestamp to set of timestamps.
 		std::string output_filename;
 		if ( token.find_last_of( DIR_DELIM_CHAR ) != std::string::npos ) {

--- a/src/condor_utils/manifest.cpp
+++ b/src/condor_utils/manifest.cpp
@@ -25,7 +25,6 @@
 #include <string.h>
 #include <string>
 #include <map>
-#include <fstream>
 #include <filesystem>
 
 #include <openssl/hmac.h>

--- a/src/gangliad/statsd.cpp
+++ b/src/gangliad/statsd.cpp
@@ -27,7 +27,6 @@
 
 #include <memory>
 #include <fstream>
-#include <sstream>
 
 #define ATTR_REGEX  "Regex"
 #define ATTR_VERBOSITY "Verbosity"
@@ -538,10 +537,10 @@ Metric::getValueString(std::string &result) const {
 			break;
 		}
 	}
-	std::stringstream value_str;
-	classad::Value v = value;
-	value_str << v;
-	dprintf(D_ALWAYS,"Invalid value %s=%s\n",name.c_str(),value_str.str().c_str());
+	std::string str;
+	classad::ClassAdUnParser unp;
+	unp.Unparse(str, value);
+	dprintf(D_ALWAYS,"Invalid value %s=%s\n",name.c_str(),str.c_str());
 	return false;
 }
 


### PR DESCRIPTION
This formats a bit different than unparse, which seems like a footgun. Just use unparse everywhere.  As long as we are doing this, let's remove some other stringstreams along the way.  Also, one fewer switch-on-type in classads.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
