### PR TITLE
Draft: cgroup-v2: fix memory attribution of cached pages to job

### DIFF
--- a/src/condor_utils/proc_family_direct_cgroup_v2.cpp
+++ b/src/condor_utils/proc_family_direct_cgroup_v2.cpp
@@ -663,6 +663,7 @@ ProcFamilyDirectCgroupV2::get_usage(pid_t pid, ProcFamilyUsage& usage, bool /*fu
 
 	stdfs::path memory_current = leaf / "memory.current";
 	stdfs::path memory_peak    = leaf / "memory.peak";
+	stdfs::path memory_stat    = leaf / "memory.stat";
 
 	f = fopen(memory_current.c_str(), "r");
 	if (!f) {
@@ -677,6 +678,31 @@ ProcFamilyDirectCgroupV2::get_usage(pid_t pid, ProcFamilyUsage& usage, bool /*fu
 		return false;
 	}
 	fclose(f);
+
+	f = fopen(memory_stat.c_str(), "r");
+	if (!f) {
+		dprintf(D_ALWAYS, "ProcFamilyDirectCgroupV2::get_usage cannot open %s: %d %s\n", memory_stat.c_str(), errno, strerror(errno));
+		return false;
+	}
+
+	uint64_t memory_inactive_anon_value = 0;
+	uint64_t memory_inactive_file_value = 0;
+	char line[256];
+	size_t total_read = 0;
+	while (fgets(line, 256, f)) {
+		total_read += sscanf(line, "inactive_file %ld", &memory_inactive_file_value);
+		total_read += sscanf(line, "inactive_anon %ld", &memory_inactive_anon_value);
+		if (total_read == 2) {
+			break;
+		}
+	}
+	fclose(f);
+	if (total_read != 2) {
+		dprintf(D_ALWAYS, "ProcFamilyDirectCgroupV2::get_usage cannot read inactive_file or inactive_anon from %s: %d %s\n", memory_stat.c_str(), errno, strerror(errno));
+		fclose(f);
+		return false;
+	}
+	memory_current_value -= memory_inactive_anon_value + memory_inactive_file_value;
 
 	uint64_t memory_peak_value = 0;
 


### PR DESCRIPTION
Jobs running under cgroup-v2 get OOM't if they accumulate lots of cached pages, including inode/dentry caches from reading files, since memory.current includes page caches.
Subtract inactive_anon and inactive_file to not include droppable caches in the OOM considerations.

Note: this is completely untested. I wrote this patch as a user, I don't have the possibility of actually running this code on a worker.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
