### PR TITLE
HTCONDOR-2517 Don't clear cache after auto-requested token is approved

### DIFF
--- a/docs/version-history/lts-versions-23-0.rst
+++ b/docs/version-history/lts-versions-23-0.rst
@@ -46,6 +46,10 @@ Bugs Fixed:
 - Fixed a bug where *condor_annex* could segfault on start-up.
   :jira:`2502`
 
+- Fixed a bug where some daemons would crash after an IDTOKEN they
+  requested from the *condor_collector* was approved.
+  :jira:`2517`
+
 .. _lts-version-history-23012:
 
 Version 23.0.12

--- a/src/condor_daemon_core.V6/daemon_core_main.cpp
+++ b/src/condor_daemon_core.V6/daemon_core_main.cpp
@@ -500,6 +500,11 @@ private:
 				dprintf(D_ALWAYS, "Token request approved.\n");
 					// Flush the cached result of the token search.
 				Condor_Auth_Passwd::retry_token_search();
+					// Don't flush any security sessions. It's highly unlikely
+					// there are any relevant ones, and flushing the
+					// non-negotiated sessions will cause problems
+					// (like crashing when we want to use the family session).
+				#if 0
 					// Flush out the security sessions; will need to force a re-auth.
 				auto sec_man = daemonCore->getSecMan();
 				sec_man->reconfig();
@@ -511,6 +516,7 @@ private:
 				} else {
 					sec_man->invalidateAllCache();
 				}
+				#endif
 					// Invoke the daemon-provided callback to do daemon-specific cleanups.
 				(*req.m_callback_fn)(true, req.m_callback_data);
 			}


### PR DESCRIPTION
The session cache is highly unlikely to contain any sessions that would authenticate differently if the new token were available. And the cache has many (non-negotiated) sessions that should not be cleared. In particular, removal of the condor@(parent|child|family) sessions will ASSERT()s and other issues.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
