### PR TITLE
HTCONDOR-2542 Fix credential cleanup when UID_DOMAIN is changed

### DIFF
--- a/src/condor_schedd.V6/schedd.cpp
+++ b/src/condor_schedd.V6/schedd.cpp
@@ -1704,7 +1704,17 @@ Scheduler::count_jobs()
 	#endif
 		// If this Owner has any jobs in the queue or match records,
 		// we don't want to remove the entry.
-		if (owner_info.num.Hits > 0) continue;
+		if (owner_info.num.Hits > 0) {
+			// CRUFT: Remove these calls once we have proper handling of
+			//   users in different domains
+			if (cred_dir_krb) {
+				credmon_clear_mark(cred_dir_krb, clusterad->ownerinfo->Name());
+			}
+			if (cred_dir_oauth) {
+				credmon_clear_mark(cred_dir_oauth, clusterad->ownerinfo->Name());
+			}
+			continue;
+		}
 
 		// expire and mark for removal Owners that have not had any hits (i.e jobs in the queue)
 		if ( ! owner_info.LastHitTime) {


### PR DESCRIPTION
If a schedd's UID_DOMAIN is changed, users can end up with two user records which differ only in their domain. When there are no more jobs under the old domain's record, the schedd will mark credentials for sweeping even if the user has jobs queued under the new domain's record. As a quick fix, always remove the mark file for a user record that has jobs queued.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
