### PR TITLE
HTCONDOR-2523: System ID in release string for Debian and Ubuntu

### DIFF
--- a/nmi_tools/glue/build/build_uw_deb.sh
+++ b/nmi_tools/glue/build/build_uw_deb.sh
@@ -74,25 +74,31 @@ if [ "$PRE_RELEASE" = 'OFF' ]; then
     dch --release --distribution $dist ignored
 else
     # Generate a changelog entry
-    dch --distribution $dist --newversion "$condor_version-0.$condor_build_id" "Automated build"
+    dch --distribution $dist --newversion "$condor_version-0.$condor_build_id+SYS99" "Automated build"
 fi
 
 . /etc/os-release
 if [ "$VERSION_CODENAME" = 'bullseye' ]; then
-    true
+    SYS99='deb11'
 elif [ "$VERSION_CODENAME" = 'bookworm' ]; then
-    dch --distribution $dist --nmu 'place holder entry'
+    SYS99='deb12'
 elif [ "$VERSION_CODENAME" = 'focal' ]; then
-    true
+    SYS99='ubu20'
 elif [ "$VERSION_CODENAME" = 'jammy' ]; then
-    dch --distribution $dist --nmu 'place holder entry'
+    SYS99='ubu22'
 elif [ "$VERSION_CODENAME" = 'noble' ]; then
-    dch --distribution $dist --nmu 'place holder entry'
-    dch --distribution $dist --nmu 'place holder entry'
+    SYS99='ubu24'
 elif [ "$VERSION_CODENAME" = 'chimaera' ]; then
-    true
+    SYS99='dev04'
 else
     echo ERROR: Unknown codename "${VERSION_CODENAME}"
+    exit 1
+fi
+
+if grep -q SYS99 debian/changelog; then
+    sed -i s/SYS99/$SYS99/ debian/changelog
+else
+    echo ERROR: SYS99 not present in changelog
     exit 1
 fi
 

--- a/nmi_tools/glue/build/make-tarball-from-debs
+++ b/nmi_tools/glue/build/make-tarball-from-debs
@@ -47,7 +47,7 @@ for file in $debdir/*.deb; do
         # Skip debug information
         echo Skipping $file
     else
-        eval $(perl -e "(\$package, \$version, \$release, \$arch) = '$file' =~ m:^.*/(.*)_([0-9][0-9.]*)-([0-9][0-9.]*)_([^.]+)\.deb$:; print \"package=\$package version=\$version release=\$release arch=\$arch\";")
+        eval $(perl -e "(\$package, \$version, \$release, \$arch) = '$file' =~ m:^.*/(.*)_([0-9][0-9.]*)-([0-9][^_]*)_([^.]+)\.deb$:; print \"package=\$package version=\$version release=\$release arch=\$arch\";")
         echo ======= ${package}_$version-${release}_$arch.deb =======
         extract_deb $debdir/${package}_$version-${release}_$arch.deb tarball
         echo ${package}_$version-${release}_$arch.deb >> tarball/Manifest.txt


### PR DESCRIPTION
Previously we just incremented the build ID or added .1 or .2 to the release id. This was confusing to end users and frankly a lie when incrementing the build ID.
So, we just add a system identifier to the package release string.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
