### PR TITLE
HTCONDOR-2523 Remove duplicate string::c_str calls in dagman

### DIFF
--- a/src/condor_dagman/parse.cpp
+++ b/src/condor_dagman/parse.cpp
@@ -286,13 +286,13 @@ bool parse(const Dagman& dm, Dag *dag, const char * filename, bool incrementDagN
 					// If a duplicate exists, std::map.insert() will not throw any
 					// errors but it also won't overwrite the existing value.
 					// In this case, throw a warning and proceed as normal.
-					if(dag->SubmitDescriptions.find(nodename.c_str()) != dag->SubmitDescriptions.end()) {
+					if(dag->SubmitDescriptions.find(nodename) != dag->SubmitDescriptions.end()) {
 						debug_printf(DEBUG_NORMAL, "Warning: a submit description "
 							"already exists with name %s, will not be overwritten."
 							"\n", nodename.c_str());
 					}
-					dag->SubmitDescriptions.insert(std::make_pair(std::string(nodename.c_str()), new SubmitHash()));
-					SubmitHash* submitDesc = dag->SubmitDescriptions.at(std::string(nodename.c_str()));
+					dag->SubmitDescriptions.insert(std::make_pair(std::string(nodename), new SubmitHash()));
+					SubmitHash* submitDesc = dag->SubmitDescriptions.at(std::string(nodename));
 					submitDesc->init(JSM_DAGMAN);
 					submitDesc->setDisableFileChecks(true);
 					std::string errmsg;
@@ -346,13 +346,13 @@ bool parse(const Dagman& dm, Dag *dag, const char * filename, bool incrementDagN
 					// If a duplicate exists, std::map.insert() will not throw any
 					// errors but it also won't overwrite the existing value.
 					// In this case, throw a warning and proceed as normal.
-					if(dag->SubmitDescriptions.find(nodename.c_str()) != dag->SubmitDescriptions.end()) {
+					if(dag->SubmitDescriptions.find(nodename) != dag->SubmitDescriptions.end()) {
 						debug_printf(DEBUG_NORMAL, "Warning: a submit description "
 							"already exists with name %s, will not be overwritten."
 							"\n", nodename.c_str());
 					}
-					dag->SubmitDescriptions.insert(std::make_pair(std::string(nodename.c_str()), new SubmitHash()));
-					SubmitHash* submitDesc = dag->SubmitDescriptions.at(std::string(nodename.c_str()));
+					dag->SubmitDescriptions.insert(std::make_pair(std::string(nodename), new SubmitHash()));
+					SubmitHash* submitDesc = dag->SubmitDescriptions.at(std::string(nodename));
 					submitDesc->init(JSM_DAGMAN);
 					submitDesc->setDisableFileChecks(true);
 					std::string errmsg;
@@ -423,13 +423,13 @@ bool parse(const Dagman& dm, Dag *dag, const char * filename, bool incrementDagN
 					// If a duplicate exists, std::map.insert() will not throw any
 					// errors but it also won't overwrite the existing value.
 					// In this case, throw a warning and proceed as normal.
-					if(dag->SubmitDescriptions.find(descName.c_str()) != dag->SubmitDescriptions.end()) {
+					if(dag->SubmitDescriptions.find(descName) != dag->SubmitDescriptions.end()) {
 						debug_printf(DEBUG_NORMAL, "Warning: a submit description "
 							"already exists with name %s, will not be overwritten."
 							"\n", descName.c_str());
 					}
-					dag->SubmitDescriptions.insert(std::make_pair(std::string(descName.c_str()), new SubmitHash()));
-					SubmitHash* submitDesc = dag->SubmitDescriptions.at(descName.c_str());
+					dag->SubmitDescriptions.insert(std::make_pair(std::string(descName), new SubmitHash()));
+					SubmitHash* submitDesc = dag->SubmitDescriptions.at(descName);
 					submitDesc->init(JSM_DAGMAN);
 					submitDesc->setDisableFileChecks(true);
 					std::string errmsg;
@@ -2230,7 +2230,7 @@ parse_splice(
 	}
 
 	// munge the splice name
-	spliceName = munge_node_name(spliceName.c_str()).c_str();
+	spliceName = munge_node_name(spliceName.c_str());
 
 	// XXX I'm not sure this goes here quite yet....
 	debug_printf(DEBUG_DEBUG_1, "Splice scope is: %s\n", 


### PR DESCRIPTION
<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
