### PR TITLE
HTCONDOR-2514: Add UserRuntimes, FsyncRuntimes, ReaperRuntimes maps

### DIFF
--- a/src/condor_daemon_core.V6/condor_daemon_core.h
+++ b/src/condor_daemon_core.V6/condor_daemon_core.h
@@ -1735,6 +1735,8 @@ class DaemonCore : public Service
 	   stats_entry_recent<double> TimerRuntime;   //  total time spent handling timers
 	   stats_entry_recent<double> SocketRuntime;  //  total time spent handling socket messages
 	   stats_entry_recent<double> PipeRuntime;    //  total time spent handling pipe messages
+       std::map<std::string, stats_entry_probe<double>> UserRuntimes; // map for user command runtimes (keyed by user_cmd)
+       std::map<std::string, stats_entry_probe<double>> ReaperRuntimes; // map for reaper runtimes
 
 	   stats_entry_recent<int> Signals;        //  number of signals handlers called
 	   stats_entry_abs<int> TimersFired;    //  number of timer handlers called

--- a/src/condor_schedd.V6/schedd.cpp
+++ b/src/condor_schedd.V6/schedd.cpp
@@ -2158,6 +2158,16 @@ int Scheduler::make_ad_list(
    // publish scheduler generic statistics
    stats.Publish(*cad, stats_config.c_str());
 
+   // publish user statistics
+   for(auto const& [key, probe]: daemonCore->dc_stats.UserRuntimes)
+		cad->Assign("DIAG_CCS" + key, probe.Total());
+   // publish reaper statistics
+   for(auto const& [reaper, probe]: daemonCore->dc_stats.ReaperRuntimes)
+		cad->Assign("DIAG_CRS" + reaper, probe.Total());
+   // publish fsync statistics
+   for(auto const& [user, value]: this->FsyncRuntimes)
+		cad->Assign("DIAG_CFS" + user, value.Total());
+
    m_xfer_queue_mgr.publish(cad, stats_config.c_str());
 
    // publish daemon core stats
@@ -5060,7 +5070,9 @@ Scheduler::WriteSubmitToUserLog( JobQueueJob* job, bool do_fsync, const char * w
 
 	bool status = false;
 	if (do_fsync) {
+		double startTime = _condor_debug_get_time_double();
 		status = ULog->writeEvent(&event, job);
+		this->FsyncRuntimes[job->ownerinfo->Name()] += _condor_debug_get_time_double() - startTime;
 	} else {
 		status = ULog->writeEventNoFsync(&event, job);
 	}

--- a/src/condor_schedd.V6/scheduler.h
+++ b/src/condor_schedd.V6/scheduler.h
@@ -717,6 +717,10 @@ class Scheduler : public Service
 	// live counters for running/held/idle jobs
 	LiveJobCounters liveJobCounts; // job counts that are always up-to-date with the committed job state
 
+	// fsync tracking by user
+	std::map<std::string, stats_entry_probe<double>> FsyncRuntimes;
+	
+
 	// the significant attributes that the schedd belives are absolutely required.
 	// This is NOT the effective set of sig attrs we get after we talk to negotiators
 	// it is the basic set needed for correct operation of the Schedd: Requirements,Rank,


### PR DESCRIPTION
This adds some maps in schedd and daemoncore code that track the runtimes of user commands, fsyncs, and reapers respectively. These statistics are then published in stats queries to the schedd.

Sidenote: some of the formatting looks weird on GitHub but I've made sure everything is spaced appropriately.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
