### PR TITLE
HTCONDOR-2523 Stop #undef'ing getline before including system headers

### DIFF
--- a/src/condor_includes/condor_sys_bsd.h
+++ b/src/condor_includes/condor_sys_bsd.h
@@ -28,10 +28,8 @@
 
 /* BSD also declares a dprintf, wonder of wonders */
 #   define dprintf _hide_dprintf
-#   define getline _hide_getline
 #include <stdio.h>
 #   undef dprintf
-#   undef getline
 
 
 /* There is no <sys/select.h> on HPUX, select() and friends are 

--- a/src/condor_includes/condor_sys_linux.h
+++ b/src/condor_includes/condor_sys_linux.h
@@ -36,12 +36,10 @@
    we've got hide since we've got our own. */
 #if defined(__GLIBC__)
 #	define dprintf _hide_dprintf
-#	define getline _hide_getline
 #endif
 #include <stdio.h>
 #if defined(__GLIBC__)
 #	undef dprintf
-#	undef getline
 #endif
 
 #define SignalHandler _hide_SignalHandler

--- a/src/python-bindings/condor_python.h
+++ b/src/python-bindings/condor_python.h
@@ -27,7 +27,6 @@
 #if defined(__FreeBSD__)
     #define profil _hide_profil
     #define dprintf _hide_dprintf
-    #define getline _hide_getline
 
     #undef _CONDOR_COMMON_FIRST
 #endif /* __FreeBSD__ */
@@ -68,7 +67,6 @@
 #if defined(__FreeBSD__)
     #undef profil
     #undef dprintf
-    #undef getline
 
     #include "condor_common.h"
 #endif /* __FreeBSD__ */

--- a/src/python-bindings/python_bindings_common.h
+++ b/src/python-bindings/python_bindings_common.h
@@ -17,13 +17,10 @@
   // undef HAVE_SSIZE_T to force pyport.h to typedef Py_ssize_t from Py_intptr_t instead of ssize_t
   #undef HAVE_SSIZE_T
  #endif // __APPLE__
- //Redefining dprintf and getline prevents a collision with the definitions in stdio.h
+ //Redefining dprintf prevents a collision with the definitions in stdio.h
  //which python headers will include, and the condor definitions
  #define dprintf _hide_dprintf
  #define profil _hide_profil
- #if defined(__FreeBSD__)
-  #define getline _hide_getline
- #endif
 #endif
 
 #ifdef __GNUC__
@@ -68,9 +65,6 @@
 #else
  #undef dprintf
  #undef profil
- #if defined(__FreeBSD__)
-  #undef getline
- #endif
  // On Debian 7, pyconfig.h sets this macro. Globus assumes it refers
  // to the Windows-only <io.h>.
  #undef HAVE_IO_H


### PR DESCRIPTION
We renamed our getline to getline_trim a long time ago, so let's stop doing this foolishness.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
