### PR TITLE
HTCONDOR-2610 We see random crashes on shutdown, perhaps caused by

### DIFF
--- a/src/condor_utils/compat_classad.cpp
+++ b/src/condor_utils/compat_classad.cpp
@@ -154,7 +154,7 @@ std::string JoinAttrNames(const classad::References &names, const char* delim)
 	return str;
 }
 
-static classad::MatchClassAd the_match_ad;
+static classad::MatchClassAd *the_match_ad = nullptr;
 static bool the_match_ad_in_use = false;
 classad::MatchClassAd *getTheMatchAd( classad::ClassAd *source,
                                       classad::ClassAd *target,
@@ -163,22 +163,25 @@ classad::MatchClassAd *getTheMatchAd( classad::ClassAd *source,
 {
 	ASSERT( !the_match_ad_in_use );
 	the_match_ad_in_use = true;
+	if (!the_match_ad) {
+		the_match_ad = new classad::MatchClassAd();
+	}
 
-	the_match_ad.ReplaceLeftAd( source );
-	the_match_ad.ReplaceRightAd( target );
+	the_match_ad->ReplaceLeftAd( source );
+	the_match_ad->ReplaceRightAd( target );
 
-	the_match_ad.SetLeftAlias( source_alias );
-	the_match_ad.SetRightAlias( target_alias );
+	the_match_ad->SetLeftAlias( source_alias );
+	the_match_ad->SetRightAlias( target_alias );
 
-	return &the_match_ad;
+	return the_match_ad;
 }
 
 void releaseTheMatchAd()
 {
 	ASSERT( the_match_ad_in_use );
 
-	the_match_ad.RemoveLeftAd();
-	the_match_ad.RemoveRightAd();
+	the_match_ad->RemoveLeftAd();
+	the_match_ad->RemoveRightAd();
 
 	the_match_ad_in_use = false;
 }


### PR DESCRIPTION
dtors for global scope objects being destructed in undefined order. To fix one instance of this, let's not keep global the_match_ad by value in compat_classad.cpp.  Instead, keep a pointer globally, and new it up on first use.

We will leak it, but better than a crash.

Note this crash isn't just an annoyance, we have seen crashes in condor_submit after exit that confuse dagman.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
