### PR TITLE
(HTCONDOR-2631)  Fix `htcondor2.Schedd.submit()`...

### DIFF
--- a/bindings/python/htcondor2/_schedd.py
+++ b/bindings/python/htcondor2/_schedd.py
@@ -415,6 +415,8 @@ class Schedd():
             unit separator character (``\\x1F``).  Keys, if specified, must be
             valid submit-language variable names.
         '''
+        if not isinstance(description, Submit):
+            raise TypeError( "description must be an htcondor2.Submit object")
 
         submit_file = ''
         for key, value in description.items():

--- a/docs/version-history/lts-versions-24-0.rst
+++ b/docs/version-history/lts-versions-24-0.rst
@@ -38,6 +38,10 @@ Bugs Fixed:
   correctly reject values containing newlines.
   :jira:`2616`
 
-- Fixed bug where :tool:`condor_watch_q` would display ``None`` for jobs with
+- Fixed a bug where :tool:`condor_watch_q` would display ``None`` for jobs with
   no :ad-attr:`JobBatchName` instead of the expected :ad-attr:`ClusterId`.
   :jira:`2625`
+
+- :meth:`htcondor2.Schedd.submit` now correctly raises a :obj:`TypeError`
+  when passed a description that is not a :obj:`htcondor2.Submit` object.
+  :jira:`2631`


### PR DESCRIPTION
... so that it no longer fails (with an `AttributeError`) when passed a dictionary; it should instead raise a `TypeError` and remind the programmer that _description_ must be a `Submit` object.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
