### PR TITLE
(HTCONDOR-2633)  `htcondor annex` handles misses --gpu flag badly.

### DIFF
--- a/docs/version-history/lts-versions-24-0.rst
+++ b/docs/version-history/lts-versions-24-0.rst
@@ -38,6 +38,11 @@ Bugs Fixed:
   correctly reject values containing newlines.
   :jira:`2616`
 
+- :tool:`htcondor annex` now reports a proper error if you request an annex
+  from a GPU-enabled queue but don't specify how many GPUs per node you
+  want (and the queue does not always allocate whole nodes).
+  :jira:`2633`
+
 - Fixed bug where :tool:`condor_watch_q` would display ``None`` for jobs with
   no :ad-attr:`JobBatchName` instead of the expected :ad-attr:`ClusterId`.
   :jira:`2625`

--- a/src/condor_tools/htcondor_cli/annex_validate.py
+++ b/src/condor_tools/htcondor_cli/annex_validate.py
@@ -748,7 +748,10 @@ def validate_constraints( *,
             if queue['allocation_type'] == 'node':
                 gpus = gpus_per_node
 
-        if gpus <= 0:
+        # `gpus` is a local, so we can't just set it to a sane default
+        # in an else clause above.  We can't set a default in the argument
+        # parser because `None` means "all" for the whole-node queues.
+        if gpus is None or gpus <= 0:
             error_string = f"The '{queue_name}' queue is a GPU queue.  You must specify a number of GPUs (--gpus)."
             raise ValueError(error_string)
 


### PR DESCRIPTION
If the queue has GPUs but isn't a whole-node queue, `htcondor annex` would crash because it didn't have a numeric value set for the number of GPUs if the user didn't supply one.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
