### PR TITLE
(HTCONDOR-2632)  Minimize some htcondor2 API silliness.

### DIFF
--- a/bindings/python/htcondor2/_submit.py
+++ b/bindings/python/htcondor2/_submit.py
@@ -45,6 +45,7 @@ class Submit(MutableMapping):
     # This is exceedingly clumsy, but matches the semantics from version 1.
     def __init__(self,
         input : Union[Dict[str, str], str] = None,
+        queue : str = None,
         ** kwargs
     ):
         '''
@@ -111,6 +112,12 @@ class Submit(MutableMapping):
             raise TypeError("input must be a dictionary mapping string to strings, a string, or None")
 
         self.update(kwargs)
+
+        if queue is not None:
+            if isinstance(queue, str):
+                self.setQArgs(queue)
+            else:
+                raise TypeError("queue must be a string")
 
 
     def __getitem__(self, key):

--- a/bindings/python/htcondor2/_submit.py
+++ b/bindings/python/htcondor2/_submit.py
@@ -73,6 +73,8 @@ class Submit(MutableMapping):
             for key,value in input.items():
                 if not isinstance(key, str):
                     raise TypeError("key must be a string")
+                if key.casefold() == "queue".casefold():
+                    raise ValueError("the queue statement can not be specified in a dictionary")
                 # This was an undocumented feature in version 1, and it's
                 # likely to be useless.  This implementation assumes that
                 # str(classad.ExprTree) is always valid in a submit-file.

--- a/bindings/python/htcondor2/_submit.py
+++ b/bindings/python/htcondor2/_submit.py
@@ -258,6 +258,12 @@ class Submit(MutableMapping):
         '''
         if not isinstance(args, str):
             raise TypeError("args must be a string")
+
+        queue = args[0:5]
+        if queue.casefold() == "queue".casefold():
+            if args[5] == ' ':
+                args = args[6:]
+
         _submit_setqargs(self, self._handle, args)
 
 


### PR DESCRIPTION
Discovered by AndrewO
* Don't allow `queue` as a key in the dictionary used to construct a `Submit` object.  This presently doesn't work, so raise a `ValueError` until and if we decide that it should.
* `Submit.setQArgs()` is documented to take complete queue statements (those starting with "queue "), and now does.
* Add a `queue` named parameter to the `Submit` object to allow the queue statement to specified directly if constructing from a dictionary.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
