### PR TITLE
HTCONDOR-2644 Add timeout to vm-gahp test mode invocation

### DIFF
--- a/src/condor_includes/condor_uid.h
+++ b/src/condor_includes/condor_uid.h
@@ -179,6 +179,8 @@ public:
 		}
 	}
 
+	priv_state orig_priv() const {return m_orig_state;}
+
 private:
 	// non-copyable.
 	TemporaryPrivSentry(const TemporaryPrivSentry&);

--- a/src/condor_startd.V6/vmuniverse_mgr.cpp
+++ b/src/condor_startd.V6/vmuniverse_mgr.cpp
@@ -420,36 +420,39 @@ VMUniverseMgr::testVMGahp(const char* gahppath, const char* vmtype)
 	}
 #endif
 
-	priv_state prev_priv;
+	TemporaryPrivSentry sentry;
 	if( (strcasecmp(vmtype, CONDOR_VM_UNIVERSE_XEN) == MATCH) || (strcasecmp(vmtype, CONDOR_VM_UNIVERSE_KVM) == MATCH) ) {
 		// Xen requires root privilege
-		prev_priv = set_root_priv();
+		set_root_priv();
 	}else {
-		prev_priv = set_condor_priv();
+		set_condor_priv();
 
 	}
-	FILE* fp = NULL;
-	fp = my_popen(systemcmd, "r", FALSE );
-	set_priv(prev_priv);
-
-	if( !fp ) {
+	MyPopenTimer gahp_test;
+	if (gahp_test.start_program(systemcmd, MyPopenTimer::WITHOUT_STDERR, nullptr, MyPopenTimer::KEEP_PRIVS) < 0) {
 		dprintf( D_ALWAYS, "Failed to execute %s, ignoring\n", gahppath );
 		return false;
 	}
 
+	int exit_code = 0;
+	if (!gahp_test.wait_for_exit(5, &exit_code)) {
+		dprintf(D_ALWAYS, "Failed to get output from %s, ignoring\n", gahppath);
+		return false;
+	}
+	set_priv(sentry.orig_priv());
+
 	bool read_something = false;
-	char buf[2048];
+	std::string buf;
 
 	m_vmgahp_info.Clear();
-	while( fgets(buf, 2048, fp) ) {
+	while (readLine(buf, gahp_test.output(), false)) {
 		if( !m_vmgahp_info.Insert(buf) ) {
 			dprintf( D_ALWAYS, "Failed to insert \"%s\" into VMInfo, "
-					 "ignoring invalid parameter\n", buf );
+			         "ignoring invalid parameter\n", buf.c_str() );
 			continue;
 		}
 		read_something = true;
 	}
-	my_pclose( fp );
 	if( !read_something ) {
 		std::string args_string;
 		systemcmd.GetArgsStringForDisplay(args_string,0);


### PR DESCRIPTION
We've seen the vm-gahp block forever attempting to connect to libvirtd. The startd should timeout and kill it if that happens.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
