### PR TITLE
HTCONDOR-2610 Fix path to 'true' on macOS

### DIFF
--- a/bindings/python/htcondor/personal.py
+++ b/bindings/python/htcondor/personal.py
@@ -21,6 +21,7 @@ import os
 import shlex
 import signal
 import subprocess
+import sys
 import textwrap
 import time
 from pathlib import Path
@@ -384,8 +385,8 @@ class PersonalPool:
             "SEC_PASSWORD_DIRECTORY": self.passwords_dir.as_posix(),
             "SEC_TOKEN_DIRECTORY": self.tokens_dir.as_posix(),
             "SEC_TOKEN_SYSTEM_DIRECTORY": self.system_tokens_dir.as_posix(),
-            "MAIL": "/bin/true",
-            "SENDMAIL": "/bin/true",
+            "MAIL": "/usr/bin/true" if sys.platform == "darwin" else "/bin/true",
+            "SENDMAIL": "/usr/bin/true" if sys.platform == "darwin" else "/bin/true",
         }
 
         param_lines += ["# BASE PARAMS"]

--- a/src/condor_tests/ctest_driver
+++ b/src/condor_tests/ctest_driver
@@ -4,6 +4,7 @@ import os
 import shutil
 import errno
 import argparse
+import sys
 
 
 BASE_CONFIG_TEMPLATE = """
@@ -23,8 +24,8 @@ NEGOTIATOR_MIN_INTERVAL=1
 SCHEDD_INTERVAL=1
 SCHEDD_MIN_INTERVAL=1
 DAGMAN_USER_LOG_SCAN_INTERVAL = 1
-MAIL=/bin/true
-SENDMAIL=/bin/true
+MAIL={true_path}
+SENDMAIL={true_path}
 LOCAL_CONFIG_FILE={pwd}/condor_config.local
 DOCKER_PERFORM_TEST=false
 # The default FILETRANSFER_PLUGINS contains support for box,onedrive,
@@ -91,7 +92,8 @@ def write_base_config(prefix_path, java=False):
     with open("base_config", "w") as fp:
         fp.write(
             BASE_CONFIG_TEMPLATE.format(
-                pwd=pwd, prefix_path=prefix_path, extra_args=extra_args
+                pwd=pwd, prefix_path=prefix_path, extra_args=extra_args,
+                true_path="/usr/bin/true" if sys.platform == "darwin" else "/bin/true"
             )
         )
 

--- a/src/condor_tests/job_core_time-deferral.run
+++ b/src/condor_tests/job_core_time-deferral.run
@@ -29,6 +29,11 @@ use Check::SimpleJob;
 
 my $testname = "job_core_time-deferral";
 
+my $true_path = "/bin/true";
+if ($^O == "darwin") {
+    $true_path = "/usr/bin/true";
+}
+
 #testreq: personal
 my $config = <<CONDOR_TESTREQ_CONFIG;
 	DAEMON_LIST = MASTER,SCHEDD,COLLECTOR,NEGOTIATOR,STARTD
@@ -39,8 +44,8 @@ my $config = <<CONDOR_TESTREQ_CONFIG;
 	SCHEDD_INTERVAL=1
 	SCHEDD_MIN_INTERVAL=1
 	RUNBENCHMARKS=false
-	MAIL=/bin/true
-	SENDMAIL=/bin/true
+	MAIL=$true_path
+	SENDMAIL=$true_path
 CONDOR_TESTREQ_CONFIG
 #endtestreq
 

--- a/src/condor_tests/job_dagman_splice-scaling-splice.cmd
+++ b/src/condor_tests/job_dagman_splice-scaling-splice.cmd
@@ -1,5 +1,5 @@
 universe     = scheduler
-executable   = /bin/true
+executable   = /bin/date
 log          = submit-splice-scaling.log
 Notification = NEVER
 queue

--- a/src/condor_tests/ornithology/condor.py
+++ b/src/condor_tests/ornithology/condor.py
@@ -25,6 +25,7 @@ import shlex
 import re
 import textwrap
 import os
+import sys
 
 import htcondor
 
@@ -41,8 +42,8 @@ DEFAULT_PARAMS = {
     "MASTER_ADDRESS_FILE": "$(LOG)/.master_address",
     "COLLECTOR_ADDRESS_FILE": "$(LOG)/.collector_address",
     "SCHEDD_ADDRESS_FILE": "$(LOG)/.schedd_address",
-    "MAIL": "/bin/true",
-    "SENDMAIL": "/bin/true",
+    "MAIL": "/usr/bin/true" if sys.platform == "darwin" else "/bin/true",
+    "SENDMAIL": "/usr/bin/true" if sys.platform == "darwin" else "/bin/true",
     "UPDATE_INTERVAL": "2",
     "POLLING_INTERVAL": "2",
     "NEGOTIATOR_INTERVAL": "2",


### PR DESCRIPTION
On macOS, 'true' is in /usr/bin, not /bin.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
