### PR TITLE
(HTCONDOR-2657)  Implement dc::AwaitableDeadlineSocket.

### DIFF
--- a/build/packaging/debian/condor-test.install.in
+++ b/build/packaging/debian/condor-test.install.in
@@ -4,3 +4,5 @@ usr/lib/condor/condor_tests-*.tar.gz
 usr/libexec/condor/condor_sinful
 usr/libexec/condor/condor_testingd
 usr/libexec/condor/test_user_mapping
+usr/libexec/condor/test_awaitable_deadline_socketd
+usr/libexec/condor/test_awaitable_deadline_socket_client

--- a/build/packaging/rpm/condor.spec
+++ b/build/packaging/rpm/condor.spec
@@ -1342,6 +1342,8 @@ rm -rf %{buildroot}
 %_libexecdir/condor/condor_sinful
 %_libexecdir/condor/condor_testingd
 %_libexecdir/condor/test_user_mapping
+%_libexecdir/condor/test_awaitable_deadline_socketd
+%_libexecdir/condor/test_awaitable_deadline_socket_client
 %if %uw_build
 %_libdir/condor/condor_tests-%{version}.tar.gz
 %endif

--- a/src/condor_tests/CMakeLists.txt
+++ b/src/condor_tests/CMakeLists.txt
@@ -81,6 +81,19 @@ if (BUILD_TESTING)
 		file( REMOVE ${RMV_FIRST} )
 	endif()
 
+    condor_exe( test_awaitable_deadline_socketd
+        "test_awaitable_deadline_socketd.cpp"
+        "${C_LIBEXEC}"
+        "${CONDOR_LIBS}"
+        OFF
+    )
+    condor_exe( test_awaitable_deadline_socket_client
+        "test_awaitable_deadline_socket_client.cpp"
+        "${C_LIBEXEC}"
+        "${CONDOR_LIBS}"
+        OFF
+    )
+
 	APPEND_VAR(CONDOR_TEST_HELPER_SCRIPTS "Condor.pm;CondorTest.pm;CondorPersonal.pm;CondorUtils.pm;run_test.pl;condor_credmon_oauth_dummy")
 
 	##########################################################
@@ -212,8 +225,12 @@ endif ()
 			condor_pl_test(test_htcondor_annex_create_constraints "Test annex create constraints" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 			# Note that ctest can NOT find this test if it's named
 			# test_AwaitableDeadlineReaper.  I can't even.
-			condor_pl_test(test_awaitable_deadline_reaper "Test annex create constraints" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py;${CMAKE_BINARY_DIR}/src/condor_tests/test_for_AwaitableDeadlineReaper.exe")
+			condor_pl_test(test_awaitable_deadline_reaper "Test AwaitableDeadlineReaper" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py;${CMAKE_BINARY_DIR}/src/condor_tests/test_for_AwaitableDeadlineReaper.exe")
 			add_dependencies_suffix_hack(test_awaitable_deadline_reaper test_for_AwaitableDeadlineReaper.exe)
+
+            # The dependencies here are a lie, but the immediately preceding
+            # lines make me sad.
+            condor_pl_test(test_awaitable_deadline_socket "Test AwaitableDeadlineSocket" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 		endif()
 
 		# Ornithology - partial merge - Windows and MacOSX problems

--- a/src/condor_tests/test_awaitable_deadline_socket.py
+++ b/src/condor_tests/test_awaitable_deadline_socket.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env pytest
+
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+import time
+from ornithology import *
+
+import htcondor
+
+
+@action
+def the_condor(test_dir):
+    local_dir = test_dir / "condor"
+
+    with Condor(
+        local_dir=local_dir,
+        config={
+            "DAEMON_LIST":
+                "TEST_AWAITABLE_DEADLINE_SOCKETD COLLECTOR",
+            "TEST_AWAITABLE_DEADLINE_SOCKETD":
+                "$(LIBEXEC)/test_awaitable_deadline_socketd",
+            # Ornithology needs this, for some reason.
+            "TEST_AWAITABLE_DEADLINE_SOCKETD_LOG":
+                f"$(LOG)/AwaitableDeadlineSocketLog",
+            "DC_DAEMON_LIST":
+                "+ TEST_AWAITABLE_DEADLINE_SOCKETD",
+        },
+    ) as condor:
+        yield condor
+
+
+@action
+def the_hot_log(the_condor):
+    with the_condor.use_config():
+        libexec = htcondor.param['LIBEXEC']
+    the_log = the_condor._get_daemon_log('TEST_AWAITABLE_DEADLINE_SOCKETD')
+    for line in the_log.open().read():
+        if line.message.startswith('DaemonCore: command socket at '):
+            [prefix, sinful] = line.message.split('DaemonCore: command socket at ')
+            result = the_condor.run_command(
+                [f'{libexec}/test_awaitable_deadline_socket_client', '-hot', sinful]
+            )
+            assert result.returncode == 0
+            return the_log
+    assert False
+
+
+@action
+def the_timeout_log(the_condor):
+    with the_condor.use_config():
+        libexec = htcondor.param['LIBEXEC']
+    the_log = the_condor._get_daemon_log('TEST_AWAITABLE_DEADLINE_SOCKETD')
+    for line in the_log.open().read():
+        if line.message.startswith('DaemonCore: command socket at '):
+            [prefix, sinful] = line.message.split('DaemonCore: command socket at ')
+            result = the_condor.run_command(
+                [f'{libexec}/test_awaitable_deadline_socket_client', '-timeout', sinful]
+            )
+            assert result.returncode == 0
+            return the_log
+    assert False
+
+
+class TestDCStdFunction:
+
+    def test_hot_socket(self, the_condor, the_hot_log):
+        # I'm not at all sure I can just re-open the_hot_log.
+        the_log = the_condor._get_daemon_log('TEST_AWAITABLE_DEADLINE_SOCKETD')
+        for line in the_log.open().read():
+            print(line)
+            if line.message == "[hot] Exchange complete.":
+                return
+        assert False
+
+
+    def test_timeout(self, the_condor, the_timeout_log):
+        # I'm not at all sure I can just re-open the_timeout_log.
+        the_log = the_condor._get_daemon_log('TEST_AWAITABLE_DEADLINE_SOCKETD')
+        for line in the_log.open().read():
+            print(line)
+            if line.message == "[timeout] Timed out waiting for third string.":
+                return
+        assert False

--- a/src/condor_tests/test_awaitable_deadline_socket_client.cpp
+++ b/src/condor_tests/test_awaitable_deadline_socket_client.cpp
@@ -41,7 +41,13 @@ int main( int argc, char ** argv ) {
 
 
     if( starts_with(testID, "timeout") ) {
+#if       defined(WINDOWS)
+        // The Windows sleep() call returns void, because the nap
+        // can't be interrupted by a signal.
+        sleep(25);
+#else
         ASSERT(sleep(25) == 0);
+#endif /* defined(WINDOWS) */
     }
 
 

--- a/src/condor_tests/test_awaitable_deadline_socket_client.cpp
+++ b/src/condor_tests/test_awaitable_deadline_socket_client.cpp
@@ -1,0 +1,54 @@
+#include "condor_common.h"
+#include "condor_config.h"
+#include "condor_debug.h"
+
+#include "condor_daemon_client.h"
+#include "reli_sock.h"
+
+int main( int argc, char ** argv ) {
+    ASSERT( argc == 3 );
+
+    config();
+
+    std::string testID;
+    if(0 == strcmp(argv[1], "-timeout")) {
+        testID = "timeout";
+    } else if(0 == strcmp(argv[1], "-hot")) {
+        testID = "hot";
+    } else {
+        EXCEPT("First parameter must be -hot or -timeout.\n" );
+    }
+
+    std::string sinful = argv[2];
+
+
+    Daemon * d = new Daemon(DT_ANY, sinful.c_str());
+    ASSERT(d);
+    Sock * r = d->startCommand(QUERY_STARTD_ADS, Stream::reli_sock, 0);
+    ASSERT(r);
+
+
+    r->encode();
+    ASSERT(r->put(testID));
+    ASSERT(r->end_of_message());
+
+
+    std::string reply;
+
+    r->decode();
+    ASSERT(r->get(reply))
+    ASSERT(r->end_of_message());
+
+
+    if( starts_with(testID, "timeout") ) {
+        ASSERT(sleep(25) == 0);
+    }
+
+
+    r->encode();
+    ASSERT(r->put("the third string"));
+    ASSERT(r->end_of_message());
+
+
+    return 0;
+}

--- a/src/condor_tests/test_awaitable_deadline_socketd.cpp
+++ b/src/condor_tests/test_awaitable_deadline_socketd.cpp
@@ -1,0 +1,113 @@
+// Require to be a daemon core daemon.
+#include "condor_common.h"
+#include "condor_daemon_core.h"
+#include "subsystem_info.h"
+
+// For dprintf().
+#include "condor_debug.h"
+// For dc::AwaitableDeadlineSocket.
+#include "dc_coroutines.h"
+
+condor::dc::void_coroutine
+test_awaitable_deadline_socket(ReliSock * sock) {
+	std::string testID;
+	std::string buffer;
+
+
+	sock->decode();
+
+	dprintf( D_ALWAYS, "Reading first string...\n" );
+	ASSERT(sock->get(testID));
+	dprintf( D_ALWAYS, "Read first string: '%s'\n", testID.c_str() );
+
+	dprintf( D_ALWAYS, "Reading first EOM...\n" );
+	ASSERT(sock->end_of_message());
+
+	sock->encode();
+
+	dprintf( D_ALWAYS, "Writing second string...\n" );
+	buffer = "first string payload";
+	ASSERT(sock->put(buffer));
+
+	dprintf( D_ALWAYS, "Writing second EOM...\n" );
+	ASSERT(sock->end_of_message());
+
+
+	dprintf( D_ALWAYS, "Waiting for third string.\n" );
+	condor::dc::AwaitableDeadlineSocket hotOrNot;
+	hotOrNot.deadline( sock, 20 );
+	auto [socket, timed_out] = co_await(hotOrNot);
+	ASSERT(socket = sock);
+
+	if( timed_out ) {
+		dprintf( D_ALWAYS, "[%s] Timed out waiting for third string.\n", testID.c_str() );
+		co_return;
+	}
+
+
+	sock->decode();
+
+	dprintf( D_ALWAYS, "Reading third string...\n" );
+	ASSERT(sock->get(buffer));
+	dprintf( D_ALWAYS, "Read third string: '%s'\n", buffer.c_str() );
+
+	dprintf( D_ALWAYS, "Reading third EOM...\n" );
+	ASSERT(sock->end_of_message());
+
+
+	dprintf( D_ALWAYS, "[%s] Exchange complete.\n", testID.c_str() );
+	delete sock;
+
+	co_return;
+}
+
+
+int
+test_awaitable_deadline_socket_f( int i, Stream * s ) {
+	ASSERT(i == QUERY_STARTD_ADS);
+	ReliSock * r = dynamic_cast<ReliSock *>(s);
+	ASSERT(r != NULL );
+	test_awaitable_deadline_socket(r);
+	return KEEP_STREAM;
+}
+
+void
+main_init( int, char ** ) {
+	dprintf( D_ALWAYS, "main_init()\n" );
+
+	bool dont_force_authentication = false;
+	daemonCore->Register_Command(
+		QUERY_STARTD_ADS, "QUERY_STARTD_ADS",
+		test_awaitable_deadline_socket_f, "test_awaitable_deadline_socket_f",
+		READ, dont_force_authentication, STANDARD_COMMAND_PAYLOAD_TIMEOUT
+	);
+}
+
+void
+main_config() {
+	dprintf( D_ALWAYS, "main_config()\n" );
+}
+
+void
+main_shutdown_fast() {
+	dprintf( D_ALWAYS, "main_shutdown_fast()\n" );
+	DC_Exit( 0 );
+}
+
+void
+main_shutdown_graceful() {
+	dprintf( D_ALWAYS, "main_shutdown_graceful()\n" );
+	DC_Exit( 0 );
+}
+
+int
+main( int argc, char * argv [] ) {
+	set_mySubSystem( "AWAITABLE_DEADLINE_SOCKET", true, SUBSYSTEM_TYPE_DAEMON );
+
+	dc_main_init = main_init;
+	dc_main_config = main_config;
+	dc_main_shutdown_fast = main_shutdown_fast;
+	dc_main_shutdown_graceful = main_shutdown_graceful;
+
+	return dc_main( argc, argv );
+}

--- a/src/condor_utils/dc_coroutines.cpp
+++ b/src/condor_utils/dc_coroutines.cpp
@@ -206,6 +206,7 @@ dc::AwaitableDeadlineSocket::socket( Stream * s ) {
 	// Make sure we don't hear from the timer.
 	for( auto [a_timerID, a_sock] : timerIDToSocketMap ) {
 		if( a_sock == sock ) {
+		    daemonCore->Cancel_Socket(a_sock);
 			daemonCore->Cancel_Timer(a_timerID);
 			timerIDToSocketMap.erase(a_timerID);
 			break;

--- a/src/condor_utils/dc_coroutines.cpp
+++ b/src/condor_utils/dc_coroutines.cpp
@@ -16,7 +16,7 @@ dc::AwaitableDeadlineReaper::AwaitableDeadlineReaper() {
 
 dc::AwaitableDeadlineReaper::~AwaitableDeadlineReaper() {
 	// Do NOT destroy() the_coroutine here.  The coroutine may still
-	// needs it state, because the lifetime of this object could be
+	// needs its state, because the lifetime of this object could be
 	// shorter than the lifetime of the coroutine.  (For example, a
 	// coroutine could declare two locals of this type, one of which
 	// has a longer lifetime than the other.)
@@ -128,8 +128,94 @@ spawnCheckpointCleanupProcessWithTimeout( int cluster, int proc, ClassAd * jobAd
 		// This keeps the awaitable deadline reaper alive until the process
 		// we just killed is reaped, which prevents a log message about an
 		// unknown process dying.
-		co_await( logansRun );
+		std::ignore = co_await( logansRun );
 	} else {
 		dprintf( D_TEST, "checkpoint clean-up proc %d returned %d\n", pid, status );
 	}
+}
+
+
+// ---------------------------------------------------------------------------
+
+
+dc::AwaitableDeadlineSocket::AwaitableDeadlineSocket() {
+}
+
+
+dc::AwaitableDeadlineSocket::~AwaitableDeadlineSocket() {
+	// See the commend  in ~AwaitableDeadlineReaper() for why we don't
+	// destroy the_coroutine here.
+
+	// Cancel any timers and any sockets.  (Each holds a pointer to this.)
+	for( auto [timerID, socket] : timerIDToSocketMap ) {
+		daemonCore->Cancel_Timer( timerID );
+		daemonCore->Cancel_Socket( socket );
+	}
+}
+
+
+bool
+dc::AwaitableDeadlineSocket::deadline( Sock * sock, int timeout ) {
+	auto [dummy, inserted] = sockets.insert(sock);
+	if(! inserted) { return false; }
+
+	// Register a timer for this socket.
+	int timerID = daemonCore->Register_Timer(
+		timeout, TIMER_NEVER,
+		(TimerHandlercpp) & AwaitableDeadlineSocket::timer,
+		"AwaitableDeadlineSocket::timer",
+		this
+	);
+	timerIDToSocketMap[timerID] = sock;
+
+    // Register a handler for this socket.
+    daemonCore->Register_Socket( sock, "peer description",
+        (SocketHandlercpp) & dc::AwaitableDeadlineSocket::socket,
+        "AwaitableDeadlineSocket::socket",
+        this
+    );
+
+	return true;
+}
+
+
+void
+dc::AwaitableDeadlineSocket::timer( int timerID ) {
+	ASSERT(timerIDToSocketMap.contains(timerID));
+	Sock * sock = timerIDToSocketMap[timerID];
+	ASSERT(sockets.contains(sock));
+
+	// Remove the socket listener.
+	daemonCore->Cancel_Socket( sock );
+	timerIDToSocketMap.erase(timerID);
+
+	the_socket = sock;
+	timed_out = true;
+	ASSERT(the_coroutine);
+	the_coroutine.resume();
+}
+
+
+int
+dc::AwaitableDeadlineSocket::socket( Stream * s ) {
+    Sock * sock = dynamic_cast<Sock *>(s);
+    ASSERT(sock != NULL);
+
+	ASSERT(sockets.contains(sock));
+
+	// Make sure we don't hear from the timer.
+	for( auto [a_timerID, a_sock] : timerIDToSocketMap ) {
+		if( a_sock == sock ) {
+			daemonCore->Cancel_Timer(a_timerID);
+			timerIDToSocketMap.erase(a_timerID);
+			break;
+		}
+	}
+
+	the_socket = sock;
+	timed_out = false;
+	ASSERT(the_coroutine);
+	the_coroutine.resume();
+
+	return KEEP_STREAM;
 }

--- a/src/condor_utils/dc_coroutines.h
+++ b/src/condor_utils/dc_coroutines.h
@@ -158,6 +158,74 @@ namespace dc {
 		};
 	};
 
+
+	//
+	// An AwaitableDeadlineSocket allows you to co_await for a socket to
+	// become hot or for time out to pass.
+	//
+	class AwaitableDeadlineSocket : public Service {
+
+		public:
+
+			//
+			// The API programmer will use.
+			//
+
+			AwaitableDeadlineSocket();
+
+			// The caller remains responsible for `sock`.
+			bool deadline(Sock * sock, int timeout );
+
+			void destroy() { if( the_coroutine ){ the_coroutine.destroy(); } }
+
+			virtual ~AwaitableDeadlineSocket();
+
+			//
+			// The API for daemon core.
+			//
+			int socket( Stream * s );
+			void timer( int timerID );
+
+
+			//
+			// The API for the compiler.
+			//
+			auto operator co_await() {
+				struct awaiter {
+					dc::AwaitableDeadlineSocket * ads;
+
+					bool await_ready() { return false; }
+
+					void await_suspend( std::coroutine_handle<> h ) {
+						ads->the_coroutine = h;
+					}
+
+					// The value of co_await'ing an AwaitableDeadlineSocket.
+					std::tuple<Sock *, bool> await_resume() {
+						return std::make_tuple(
+							ads->the_socket, ads->timed_out
+						);
+					}
+				};
+
+				return awaiter{this};
+			}
+
+
+		private:
+
+			std::coroutine_handle<> the_coroutine;
+
+            // Bookkeeping.
+			std::set<Sock *> sockets;
+			std::map<int, Sock *> timerIDToSocketMap;
+
+            // The co_await() return values.
+            Sock * the_socket = NULL;
+			bool timed_out = false;
+	};
+
+
 } // end namespace dc
 } // end namespace condor
 

--- a/src/condor_utils/dc_coroutines.h
+++ b/src/condor_utils/dc_coroutines.h
@@ -161,7 +161,7 @@ namespace dc {
 
 	//
 	// An AwaitableDeadlineSocket allows you to co_await for a socket to
-	// become hot or for time out to pass.
+	// become hot or for a time out to pass.
 	//
 	class AwaitableDeadlineSocket : public Service {
 


### PR DESCRIPTION
Implement `dc::AwaitableDeadlineSocket`.  This await()able allows us to write coroutines which return to the event loop and [a]wait for either one (or more) socket(s) to become hot (readable without blocking) or for one (or more) associated timeout(s) to pass.

The first use will be in other code currently under construction, so this PR includes a test that should also serve as an example.

No user-facing documentation or release note is necessary for this strictly-internal improvement.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
