### PR TITLE
HTCONDOR-2675: Fix DAGMan idle proc warnings with service nodes

### DIFF
--- a/src/condor_dagman/dag.cpp
+++ b/src/condor_dagman/dag.cpp
@@ -1129,7 +1129,7 @@ Dag::ProcessIsIdleEvent(Node *node, int proc) {
 	}
 
 	// Do some consistency checks here.
-	if (_numIdleJobProcs > 0 && NumNodesSubmitted() < 1) {
+	if (_numIdleJobProcs > 0 && TotalSubmittedNodes() < 1) {
 		debug_printf(DEBUG_NORMAL,
 		            "Warning:  DAGMan thinks there are %d idle job procs, even though there are no nodes in the queue!  Setting idle count to 0 so DAG continues.\n",
 		            _numIdleJobProcs );
@@ -1158,7 +1158,7 @@ Dag::ProcessNotIdleEvent(Node *node, int proc) {
 		             _numIdleJobProcs );
 	}
 
-	if (_numIdleJobProcs > 0 && NumNodesSubmitted() < 1) {
+	if (_numIdleJobProcs > 0 && TotalSubmittedNodes() < 1) {
 		debug_printf(DEBUG_NORMAL,
 		             "Warning:  DAGMan thinks there are %d idle job procs, even though there are no nodes in the queue!  Setting idle count to 0 so DAG continues.\n",
 		             _numIdleJobProcs);
@@ -3886,7 +3886,7 @@ void
 Dag::UpdateNodeCounts(Node *node, int change)
 {
 	// Service nodes are separate from normal nodes
-	if (node->GetType() == NodeType::SERVICE) { return; }
+	if (node->GetType() == NodeType::SERVICE) { _numServiceNodesSubmitted += change; return; }
 	_numNodesSubmitted += change;
 	ASSERT(_numNodesSubmitted >= 0);
 

--- a/src/condor_dagman/dag.h
+++ b/src/condor_dagman/dag.h
@@ -208,6 +208,8 @@ public:
 		return (NumNodes(includeFinal) - (NumNodesDone(includeFinal) + PreRunNodeCount() + NumNodesSubmitted() +
 		        PostRunNodeCount() + NumNodesReady() + NumNodesFailed() + NumNodesFutile()));
 	}
+	// Count of all nodes w/ submitted jobs regardless of type
+	inline int TotalSubmittedNodes() const { return _numServiceNodesSubmitted + _numNodesSubmitted; }
 
 	inline int NumPreScriptsRunning() const {
 		ASSERT(_isSplice == false);
@@ -470,6 +472,7 @@ private:
 	int _numNodesFailed{0}; // Number of nodes that have failed (list of jobs/PRE/POST failed)
 	int _numNodesFutile{0}; // Number of nodes that can't run due to ancestor failing
 	int _numNodesSubmitted{0}; // Number of batch system jobs currently submitted
+	int _numServiceNodesSubmitted{0}; // Number of service nodes with jobs submitted in the queue
 	int _maxJobHolds{0}; // Maximum times a job can go on hold before being declared Faile (0=infinite)
 
 	int _totalJobsSubmitted{0}; // Total number of batch system jobs submitted


### PR DESCRIPTION
-DAGMan will occasionally output warnings about having idle jobs
 in the queue despite not submitted nodes. This is due to the
 separation of service nodes.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
