### PR TITLE
HTCONDOR-2675 Remove incorrect log message about scitokens trailing s…

### DIFF
--- a/src/condor_io/authentication.cpp
+++ b/src/condor_io/authentication.cpp
@@ -652,15 +652,17 @@ void Authentication::map_authentication_name_to_canonical_name(int authenticatio
 		if (mapret && authentication_type == CAUTH_SCITOKENS) {
 			auth_name_to_map += '/';
 			bool withslash_result = global_map_file->GetCanonicalization(method_string, auth_name_to_map, canonical_user);
-			if (param_boolean("SEC_SCITOKENS_ALLOW_EXTRA_SLASH", false)) {
-				// just continue as if everything is fine.  we've now
-				// already updated canonical_user with the result. complain
-				// a little bit though so the admin can notice and fix it.
-				dprintf(D_SECURITY, "MAPFILE: WARNING: The CERTIFICATE_MAPFILE entry for SCITOKENS \"%s\" contains a trailing '/'. This was allowed because SEC_SCITOKENS_ALLOW_EXTRA_SLASH is set to TRUE.\n", authentication_name);
-				mapret = withslash_result;
-			} else {
-				// complain loudly
-				dprintf(D_ALWAYS, "MAPFILE: ERROR: The CERTIFICATE_MAPFILE entry for SCITOKENS \"%s\" contains a trailing '/'. Either correct the mapfile or set SEC_SCITOKENS_ALLOW_EXTRA_SLASH in the configuration.\n", authentication_name);
+			if (!withslash_result) {
+				if (param_boolean("SEC_SCITOKENS_ALLOW_EXTRA_SLASH", false)) {
+					// just continue as if everything is fine.  we've now
+					// already updated canonical_user with the result. complain
+					// a little bit though so the admin can notice and fix it.
+					dprintf(D_SECURITY, "MAPFILE: WARNING: The CERTIFICATE_MAPFILE entry for SCITOKENS \"%s\" contains a trailing '/'. This was allowed because SEC_SCITOKENS_ALLOW_EXTRA_SLASH is set to TRUE.\n", authentication_name);
+					mapret = withslash_result;
+				} else {
+					// complain loudly
+					dprintf(D_ALWAYS, "MAPFILE: ERROR: The CERTIFICATE_MAPFILE entry for SCITOKENS \"%s\" contains a trailing '/'. Either correct the mapfile or set SEC_SCITOKENS_ALLOW_EXTRA_SLASH in the configuration.\n", authentication_name);
+				}
 			}
 		}
 


### PR DESCRIPTION
…lashes

The scary messages about scitokens map entries containing an errant trailing slash should only be printed if adding a slash to the unmapped auth name results in a successful mapping.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
