### PR TITLE
(HTCONDOR-2745) Update `job_spec` in `htcondor2.Schedd` to permit `int` cluster IDs.

### DIFF
--- a/bindings/python/htcondor2/_schedd.py
+++ b/bindings/python/htcondor2/_schedd.py
@@ -147,17 +147,17 @@ class Schedd():
 
     def act(self,
         action : JobAction,
-        job_spec : Union[List[str], str, classad.ExprTree],
+        job_spec : Union[List[str], str, classad.ExprTree, int],
         reason : str = None,
     ) -> classad.ClassAd:
         """
         Change the status of job(s) in the *condor_schedd* daemon.
 
         :param action:  The action to perform.
-        :param job_spec: Which job(s) to act on.  Either a :class:`str`
-             of the form ``clusterID.procID``, a :class:`list` of such
-             strings, or a :class:`classad2.ExprTree` constraint, or
-             the string form of such a constraint.
+        :param job_spec: Which job(s) to act on.  A :class:`str`
+             of the form ``clusterID[.procID]``, a :class:`list` of such
+             strings, a :class:`classad2.ExprTree` constraint, the
+             the string form of such a constraint, or the :class:`int` cluster ID.
         :param reason:  A free-form justification.  Defaults to
             "Python-initiated action".
         :return:  A ClassAd describing the number of jobs changed.  This
@@ -199,7 +199,7 @@ class Schedd():
     # In version 1, edit(ClassAd) and edit_multiple() weren't documented,
     # so they're not implemented in version 2.
     def edit(self,
-        job_spec : Union[List[str], str, classad.ExprTree],
+        job_spec : Union[List[str], str, classad.ExprTree, int],
         attr : str,
         value : Union[str, classad.ExprTree],
         flags : TransactionFlag = TransactionFlag.Default,
@@ -207,10 +207,10 @@ class Schedd():
         """
         Change the value of an attribute in zero or more jobs.
 
-        :param job_spec: Which job(s) to edit.  Either a :class:`str`
-             of the form ``clusterID.procID``, a :class:`list` of such
-             strings, or a :class:`classad2.ExprTree` constraint, or
-             the string form of such a constraint.
+        :param job_spec: Which job(s) to act on.  A :class:`str`
+             of the form ``clusterID[.procID]``, a :class:`list` of such
+             strings, a :class:`classad2.ExprTree` constraint, the
+             the string form of such a constraint, or the :class:`int` cluster ID.
         :param attr:  Which attribute to change.
         :param value:  The new value for the attribute.
         :param flags:  Optional flags specifying alternate transaction behavior.
@@ -492,7 +492,7 @@ class Schedd():
 
 
     def retrieve(self,
-        job_spec : Union[List[str], str, classad.ExprTree],
+        job_spec : Union[List[str], str, classad.ExprTree, int],
     ) -> None:
         #
         # In version 1, this function was documented as accepting either
@@ -506,10 +506,10 @@ class Schedd():
         """
         Retrieve the output files from the job(s) in a given :meth:`submit`.
 
-        :param job_spec: Which job(s) to export.  Either a :class:`str`
-             of the form ``clusterID.procID``, a :class:`list` of such
-             strings, or a :class:`classad2.ExprTree` constraint, or
-             the string form of such a constraint.
+        :param job_spec: Which job(s) to act on.  A :class:`str`
+             of the form ``clusterID[.procID]``, a :class:`list` of such
+             strings, a :class:`classad2.ExprTree` constraint, the
+             the string form of such a constraint, or the :class:`int` cluster ID.
         """
         result = job_spec_hack(self._addr, job_spec,
             _schedd_retrieve_job_ids, _schedd_retrieve_job_constraint,
@@ -543,7 +543,7 @@ class Schedd():
 
 
     def export_jobs(self,
-        job_spec : Union[List[str], str, classad.ExprTree],
+        job_spec : Union[List[str], str, classad.ExprTree, int],
         export_dir : str,
         new_spool_dir : str,
     ) -> classad.ClassAd:
@@ -551,10 +551,10 @@ class Schedd():
         Export one or more job clusters from the queue to put those jobs
         into the externally managed state.
 
-        :param job_spec: Which job(s) to export.  Either a :class:`str`
-             of the form ``clusterID.procID``, a :class:`list` of such
-             strings, or a :class:`classad2.ExprTree` constraint, or
-             the string form of such a constraint.
+        :param job_spec: Which job(s) to act on.  A :class:`str`
+             of the form ``clusterID[.procID]``, a :class:`list` of such
+             strings, a :class:`classad2.ExprTree` constraint, the
+             the string form of such a constraint, or the :class:`int` cluster ID.
         :param export_dir:  Write the exported job(s) into this directory.
         :param new_spool_dir:  The IWD of the export job(s).
         :return:  A ClassAd containing information about the export operation.
@@ -581,16 +581,16 @@ class Schedd():
 
 
     def unexport_jobs(self,
-        job_spec : Union[List[str], str, classad.ExprTree],
+        job_spec : Union[List[str], str, classad.ExprTree, int],
     ) -> classad.ClassAd:
         """
         Unexport one or more job clusters that were previously exported
         from the queue.
 
-        :param job_spec: Which job(s) to unexport.  Either a :class:`str`
-             of the form ``clusterID.procID``, a :class:`list` of such
-             strings, or a :class:`classad2.ExprTree` constraint, or
-             the string form of such a constraint.
+        :param job_spec: Which job(s) to act on.  A :class:`str`
+             of the form ``clusterID[.procID]``, a :class:`list` of such
+             strings, a :class:`classad2.ExprTree` constraint, the
+             the string form of such a constraint, or the :class:`int` cluster ID.
         :return:  A ClassAd containing information about the unexport operation.
             This type of ClassAd is currently undocumented.
         """

--- a/bindings/python/htcondor2/_schedd.py
+++ b/bindings/python/htcondor2/_schedd.py
@@ -57,13 +57,26 @@ def job_spec_hack(
     args : list,
 ):
     if isinstance(job_spec, list):
+        if not all([isinstance(i, str) for i in job_spec]):
+            raise TypeError("All elements of the job_spec list must be strings.")
         job_spec_string = ", ".join(job_spec)
         return f_job_ids(addr, job_spec_string, *args)
-    elif re.fullmatch(r'\d+(\.\d+)?', job_spec):
-        return f_job_ids(addr, job_spec, *args)
+    elif isinstance(job_spec, int):
+        job_spec_string = str(job_spec)
+        return f_job_ids(addr, job_spec_string, *args)
+    elif isinstance(job_spec, classad.ExprTree):
+        job_spec_string = str(job_spec)
+        return f_constraint(addr, job_spec_string, *args)
+    elif isinstance(job_spec, str):
+        if re.fullmatch(r'\d+(\.\d+)?', job_spec):
+            return f_job_ids(addr, job_spec, *args)
+        try:
+            job_spec_expr = classad.ExprTree(job_spec)
+            return f_constraint(addr, job_spec, *args);
+        except ValueError:
+            raise TypeError("The job_spec string must be a clusterID[.jobID] or the string form of an ExprTree.");
     else:
-        job_constraint = str(job_spec)
-        return f_constraint(addr, job_constraint, *args)
+        raise TypeError("The job_spec must be list of strings, a string, an int, or an ExprTree." );
 
 
 class Schedd():

--- a/docs/version-history/feature-versions-24-x.rst
+++ b/docs/version-history/feature-versions-24-x.rst
@@ -53,7 +53,7 @@ New Features:
 
 Bugs Fixed:
 
-- The :tool:`htcondor` tool's ``job submit`` command now issues credentials
+- The :tool:`htcondor job submit` command now issues credentials
   like :tool:`condor_submit`.
   :jira:`2745`
 

--- a/docs/version-history/feature-versions-24-x.rst
+++ b/docs/version-history/feature-versions-24-x.rst
@@ -15,8 +15,16 @@ Release Notes:
 
 - This version includes all the updates from :ref:`lts-version-history-2403`.
 
-New Features:
+- Methods in :class:`htcondor2.Schedd` which take ``job_spec`` arguments now
+  accept :class:`int` cluster IDs.  These functions
+  (:meth:`htcondor2.Schedd.act`, :meth:`htcondor2.Schedd.edit`,
+  :meth:`htcondor2.Schedd.export_jobs`, :meth:`htcondor2.Schedd.retrieve`,
+  and :meth:`htcondor2.Schedd.unexport_jobs`) now also raise :class:`TypeError`
+  if their ``job_spec`` argument is not a :class:`str`, :class:`list` of
+  :class:`str`, :class:`classad2.ExprTree`, or :class:`int`.
+  :jira:`2745`
 
+New Features:
 
 - Added new submit command for container universe, :subcom:`mount_under_scratch`
   that allows user to create writeable ephemeral directories in their otherwise
@@ -36,7 +44,7 @@ New Features:
   reason is now reflected in the job attributes
   :ad-attr:`VacateReason` and :ad-attr:`VacateReasonCode`.
   :jira:`2713`
-  
+
 - Environment variables from the job that start with ``PELICAN_`` will now be
   set in the environment of the pelican file transfer plugin when it is invoked
   to do file transfer. This is intended to allow jobs to turn on enhanced logging

--- a/docs/version-history/feature-versions-24-x.rst
+++ b/docs/version-history/feature-versions-24-x.rst
@@ -53,7 +53,9 @@ New Features:
 
 Bugs Fixed:
 
-- None.
+- The :tool:`htcondor` tool's ``job submit`` command now issues credentials
+  like :tool:`condor_submit`.
+  :jira:`2745`
 
 Version 24.2.1
 --------------

--- a/src/condor_tests/CMakeLists.txt
+++ b/src/condor_tests/CMakeLists.txt
@@ -352,6 +352,7 @@ endif()
 				condor_pl_test(test_pcre "Test some PCRE mapfile nonsense" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 
 				condor_pl_test(test_submit_itemdata_qargs "Test htcondor2.Submit.itemdata(qargs=qargs)" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
+				condor_pl_test(test_job_spec_types "Test htcondor2._schedd.job_spec_hack types" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 			endif()
 		endif()
 

--- a/src/condor_tests/test_job_spec_types.py
+++ b/src/condor_tests/test_job_spec_types.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env pytest
+
+import logging
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+from ornithology import (
+    action,
+)
+
+from htcondor2._schedd import (
+    job_spec_hack
+)
+
+from classad2 import (
+    ExprTree,
+)
+
+
+def f_success(* pargs):
+    assert(True)
+
+
+def f_failure(* pargs):
+    assert(False)
+
+
+class TestJobSpecTypes:
+
+    def test_job_spec_int(self):
+        job_spec_hack( "addr", 7, f_success, f_failure, [] )
+
+
+    def test_job_spec_str(self):
+        job_spec_hack( "addr", "6", f_success, f_failure, [] )
+        job_spec_hack( "addr", "6.5", f_success, f_failure, [] )
+        job_spec_hack( "addr", "ClusterID >= 4", f_failure, f_success, [] )
+
+
+    def test_job_spec_ExprTree(self):
+        constraint = ExprTree("ClusterID != 3")
+        job_spec_hack( "addr", constraint, f_failure, f_success, [] )
+
+
+    def test_job_spec_list(self):
+        job_spec_hack( "addr", ["2", "1.1", "10"], f_success, f_failure, [] )
+
+
+    # There's probably a way to mark this as expected to fail with a
+    # particular exception, but for a test this simple, I won't bother.
+    def test_job_spec_true_negative(self):
+        try:
+            job_spec_hack( "addr", 3.141, f_failure, f_failure, [] )
+            assert(False)
+        except TypeError:
+            pass

--- a/src/condor_tools/htcondor_cli/job.py
+++ b/src/condor_tools/htcondor_cli/job.py
@@ -121,6 +121,9 @@ class Submit(Verb):
             if submit_qargs != "" and submit_qargs != "1":
                 raise ValueError("Can only submit one job at a time")
 
+            # Behave like condor_submit, to minimize astonishment.
+            submit_description.issue_credentials()
+
             try:
                 result = schedd.submit(submit_description, count=1)
                 cluster_id = result.cluster()


### PR DESCRIPTION
This fixes a bug in `htcondor annex` and probably saves some of our users some grief.

This also fixes a bug in `htcondor job submit`, so that jobs thusly-submitted acquire credentials as if they'd been `condor_submit`ted.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
