### PR TITLE
(HTCONDOR-2745)  Call `issue_credentials()` in `htcondor job submit`.

### DIFF
--- a/docs/version-history/feature-versions-23-x.rst
+++ b/docs/version-history/feature-versions-23-x.rst
@@ -26,6 +26,9 @@ Bugs Fixed:
   This change was done incorrectly in 23.9.6.
   :jira:`2746`
 
+- The :tool:`htcondor` tool's ``job submit`` command now issues credentials
+  like :tool:`condor_submit`.
+  :jira:`2745`
 
 Version 23.10.18
 ----------------

--- a/src/condor_tools/htcondor_cli/job.py
+++ b/src/condor_tools/htcondor_cli/job.py
@@ -121,6 +121,9 @@ class Submit(Verb):
             if submit_qargs != "" and submit_qargs != "1":
                 raise ValueError("Can only submit one job at a time")
 
+            # Behave like condor_submit, to minimize astonishment.
+            submit_description.issue_credentials()
+
             try:
                 result = schedd.submit(submit_description, count=1)
                 cluster_id = result.cluster()


### PR DESCRIPTION
We just forgot to do this after implementing `issue_credentials()`.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
