### PR TITLE
HTCONDOR-2653 Don't signal credmon if .use file already exists

### DIFF
--- a/src/condor_utils/store_cred.cpp
+++ b/src/condor_utils/store_cred.cpp
@@ -1637,11 +1637,23 @@ int store_cred_handler(int /*i*/, Stream *s)
 		// to signal the credmon and have the completion file appear.  we don't
 		// want this to block so we go back to daemoncore and set a timer
 		// for 0 seconds.  the timer will reset itself as needed.
-		if (wake_the_credmon(mode) && request_credmon_wait) {
+
+		struct stat ccfile_stat;
+		priv_state priv = set_root_priv();
+		int rc = stat(ccfile.c_str(), &ccfile_stat);
+		set_priv(priv);
+
+		if (rc == 0) {
+			// If the completion file already exists, just return success
+			// with the file mtime.
+			answer = ccfile_stat.st_mtime;
+			dprintf(D_ALWAYS, "Completion file %s exists. mtime=%lld\n", ccfile.c_str(), (long long)answer);
+		} else if (wake_the_credmon(mode) && request_credmon_wait) {
 			StoreCredState* retry_state = new StoreCredState();
 			retry_state->ccfile = strdup(ccfile.c_str());
 			retry_state->retries = param_integer("CREDD_POLLING_TIMEOUT", 20);
 			retry_state->s = new ReliSock(*((ReliSock*)s));
+			retry_state->return_ad = return_ad;
 
 			dprintf( D_FULLDEBUG, "store_cred: setting timer to poll for completion file: %s, retries : %i, sock: %p\n",
 				retry_state->ccfile, retry_state->retries, retry_state->s);


### PR DESCRIPTION
This avoids putting extra load on the credmon when there's no work to do.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
