### PR TITLE
HTCONDOR-2760 Ignore blank execute directory values during cleanup

### DIFF
--- a/docs/version-history/feature-versions-24-x.rst
+++ b/docs/version-history/feature-versions-24-x.rst
@@ -4,6 +4,26 @@ Version 24 Feature Releases
 We release new features in these releases of HTCondor. The details of each
 version are described below.
 
+Version 24.2.2
+--------------
+
+Release Notes:
+
+- HTCondor version 24.2.2 released on December 3, 2024.
+
+- This version includes all the updates from :ref:`lts-version-history-2402`.
+
+New Features:
+
+- None.
+
+Bugs Fixed:
+
+- If knob :macro:`EXECUTE` is explicitly set to a blank string in the config file for 
+  whatever reason, the execution point (startd) may attempt to remove all files from
+  the root partition (everything in /) upon startup.
+  :jira:`2760`
+
 Version 24.2.1
 --------------
 

--- a/src/condor_startd.V6/ResMgr.cpp
+++ b/src/condor_startd.V6/ResMgr.cpp
@@ -2560,7 +2560,7 @@ ResMgr::FillExecuteDirsList( std::vector<std::string>& list )
 	for (Resource * rip : slots) {
 		if (rip) {
 			const char * execute_dir = rip->executeDir();
-			if( !contains( list, execute_dir ) ) {
+			if( execute_dir[0] && !contains( list, execute_dir ) ) {
 				list.emplace_back(execute_dir);
 			}
 		}

--- a/src/condor_startd.V6/util.cpp
+++ b/src/condor_startd.V6/util.cpp
@@ -262,6 +262,9 @@ void
 cleanup_execute_dirs(const std::vector<std::string> &list)
 {
 	for (const auto& exec_path: list) {
+		if (exec_path.empty()) {
+			continue;
+		}
 #if defined(WIN32)
 		dynuser nobody_login;
 		// remove all users matching this prefix


### PR DESCRIPTION
Using a blank execute path results in the startd trying to cleanup everything under / and all NAMED_CHROOT locations.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
