### PR TITLE
HTCONDOR-2805 condor_netaddr sets wrong mask for explicit IPv4 address

### DIFF
--- a/src/condor_utils/condor_netaddr.cpp
+++ b/src/condor_utils/condor_netaddr.cpp
@@ -13,8 +13,10 @@ condor_netaddr::condor_netaddr(const condor_sockaddr& base,
 
 void condor_netaddr::set_mask() {
 	if (base_.is_ipv4()) {
-		uint32_t mask;
-		mask = htonl(~(0xffffffff >> maskbit_));
+		uint32_t mask = 0xffffffff;
+		if (maskbit_ < 32) {
+			mask = htonl(~(0xffffffff >> maskbit_));
+		}
 		mask_ = condor_sockaddr( *(struct in_addr*)&mask );
 	} else {
 		uint32_t mask[4] = { };


### PR DESCRIPTION
When condor_netaddr is given a single IPv4 address as a pattern, it sets the wrong bitmask internally. This is due to the code doing a bit shift of 32 on the 32-bit value, which the compiler appears to consider undefined behavior and ignores.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
