### PR TITLE
HTCONDOR-2787 harmonize sphinx warning messages

### DIFF
--- a/docs/extensions/ad-attr.py
+++ b/docs/extensions/ad-attr.py
@@ -59,12 +59,12 @@ def classad_attr_role(name, rawtext, text, lineno, inliner, options={}, content=
     filename = AD_TYPE_FILES.get(ad_type) if ad_type in AD_TYPE_FILES else None
 
     if attr_name not in ATTRIBUTE_FILES:
-        warn(f"{docname} @ {lineno} | ClassAd Attribute '{attr_name}' not defined in any ClassAd Documentation files")
+        warn(f"{docname}:{lineno} | ClassAd Attribute '{attr_name}' not defined in any ClassAd Documentation files")
         filename = "classad-types.html"
     elif filename is None:
         filename = ATTRIBUTE_FILES[attr_name][0]
         if len(ATTRIBUTE_FILES[attr_name]) > 1:
-            warn(f"{docname} @ {lineno} | ClassAd Attribute '{attr_name}' is defined in multiple files. Defaulting to {filename}")
+            warn(f"{docname}:{lineno} | ClassAd Attribute '{attr_name}' is defined in multiple files. Defaulting to {filename}")
 
     ref_link = f"href=\"{root_dir}/classad-attributes/{filename}#{attr_name}\""
     return make_ref_and_index_nodes(name, full_name, attr_index, ref_link,

--- a/docs/extensions/classad-attribute-def.py
+++ b/docs/extensions/classad-attribute-def.py
@@ -29,7 +29,7 @@ def classad_attribute_def_role(name, rawtext, text, lineno, inliner, options={},
         attr_type = match.capitalize() + " "
 
     if text in ATTRIBUTE_DEFS.get(attr_type, []):
-        warn(f"{docname} @ {lineno} | {attr_type} ClassAd attribute '{text}' already defined")
+        warn(f"{docname}:{lineno} | {attr_type} ClassAd attribute '{text}' already defined")
         textnode = nodes.Text(text, " ")
         return [textnode], []
     elif attr_type in ATTRIBUTE_DEFS:

--- a/docs/extensions/classad-function-def.py
+++ b/docs/extensions/classad-function-def.py
@@ -22,7 +22,7 @@ def classad_func_def_role(name, rawtext, text, lineno, inliner, options={}, cont
 
     if ")" not in function or "(" not in function or " " not in function[:function.find("(")]:
         # Expect 'ReturnType FunctionName([args])'
-        warn(f"{docname} @ {lineno} | Invalid ClassAd Function '{function}' expects 'Return function(...)'")
+        warn(f"{docname}:{lineno} | Invalid ClassAd Function '{function}' expects 'Return function(...)'")
         return [make_inline_literal_node(text)], []
 
     fn_end = function.find("(")

--- a/docs/extensions/classad-function.py
+++ b/docs/extensions/classad-function.py
@@ -41,7 +41,7 @@ def classad_function_role(name, rawtext, text, lineno, inliner, options={}, cont
 
     if function not in CLASSAD_FUNCTIONS:
         docname = inliner.document.settings.env.docname
-        warn(f"{docname} @ {lineno} | '{function}' ClassAd function not in defined list. Either a typo or not defined.")
+        warn(f"{docname}:{lineno} | '{function}' ClassAd function not in defined list. Either a typo or not defined.")
 
     ref_link = f"href=\"{root_dir}/classads/classad-builtin-functions.html#" + str(function) + "()\""
     return make_ref_and_index_nodes(name, function, index, ref_link,

--- a/docs/extensions/dag-cmd-def.py
+++ b/docs/extensions/dag-cmd-def.py
@@ -18,7 +18,7 @@ def dagcom_def_role(name, rawtext, text, lineno, inliner, options={}, content=[]
     global DAG_CMD_DEFS
     if text in DAG_CMD_DEFS:
         docname = inliner.document.settings.env.docname
-        warn(f"{docname} @ {lineno} | '{text}' DAG command already defined!")
+        warn(f"{docname}:{lineno} | '{text}' DAG command already defined!")
         textnode = nodes.Text(text, " ")
         return [textnode], []
     DAG_CMD_DEFS.append(text)

--- a/docs/extensions/dag-cmd.py
+++ b/docs/extensions/dag-cmd.py
@@ -24,7 +24,7 @@ def dagcom_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     cmd_name, cmd_index = custom_ext_parser(text)
     if cmd_name not in DAG_CMDS:
         docname = inliner.document.settings.env.docname
-        warn(f"{docname} @ {lineno} | '{cmd_name}' DAG command not in defined list. Either a typo or not defined.")
+        warn(f"{docname}:{lineno} | '{cmd_name}' DAG command not in defined list. Either a typo or not defined.")
     ref_link = f"href=\"{root_dir}/automated-workflows/dagman-reference.html#" + str(cmd_name) + "\""
     return make_ref_and_index_nodes(name, cmd_name, cmd_index,
                                     ref_link, rawtext, inliner, lineno, options)

--- a/docs/extensions/macro-def.py
+++ b/docs/extensions/macro-def.py
@@ -25,7 +25,7 @@ def macro_def_role(name, rawtext, text, lineno, inliner, options={}, content=[])
 
     if knob in KNOB_DEFS:
         docname = inliner.document.settings.env.docname
-        warn(f"{docname} @ {lineno} | '{knob}' configuration knob already defined!")
+        warn(f"{docname}:{lineno} | '{knob}' configuration knob already defined!")
         textnode = nodes.Text(knob, " ")
         return [textnode], []
     else:

--- a/docs/extensions/macro.py
+++ b/docs/extensions/macro.py
@@ -119,7 +119,7 @@ def macro_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
             # If here then not in pure defined list or matched a recorded regex
             if not regex_match:
                 docname = inliner.document.settings.env.docname
-                warn(f"{docname} @ {lineno} | Config knob '{macro_name}' not found in defined list. Either a typo or knob needs definition.")
+                warn(f"{docname}:{lineno} | Config knob '{macro_name}' not found in defined list. Either a typo or knob needs definition.")
         ref_link = f"href=\"{root_dir}/{url_path}#" + str(ref) + "\""
     return make_ref_and_index_nodes(name, macro_name, macro_index,
                                     ref_link, rawtext, inliner, lineno, options)

--- a/docs/extensions/subcom-def.py
+++ b/docs/extensions/subcom-def.py
@@ -18,7 +18,7 @@ def subcom_def_role(name, rawtext, text, lineno, inliner, options={}, content=[]
     global SUBMIT_CMD_DEFS
     if text in SUBMIT_CMD_DEFS:
         docname = inliner.document.settings.env.docname
-        warn(f"{docname} @ {lineno} | '{text}' submit command already defined!")
+        warn(f"{docname}:{lineno} | '{text}' submit command already defined!")
         textnode = nodes.Text(text, " ")
         return [textnode], []
     else:

--- a/docs/extensions/subcom.py
+++ b/docs/extensions/subcom.py
@@ -31,7 +31,7 @@ def subcom_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     subcom_name, subcom_index = custom_ext_parser(text)
     if subcom_name not in SUBMIT_CMDS:
         docname = inliner.document.settings.env.docname
-        warn(f"{docname} @ {lineno} | Submit command '{subcom_name}' not found in defined list. Either a typo or not defined.")
+        warn(f"{docname}:{lineno} | Submit command '{subcom_name}' not found in defined list. Either a typo or not defined.")
     ref_link = f"href=\"{root_dir}/man-pages/condor_submit.html#" + str(subcom_name) + "\""
     return make_ref_and_index_nodes(name, subcom_name, subcom_index,
                                     ref_link, rawtext, inliner, lineno, options)

--- a/docs/extensions/tool.py
+++ b/docs/extensions/tool.py
@@ -44,7 +44,7 @@ def tool_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
 
     if program_name not in TOOLS:
         docname = inliner.document.settings.env.docname
-        warn(f"{docname} @ {lineno} | Referenced tool '{program_name}' has no corresponding man page. Typo perhaps?")
+        warn(f"{docname}:{lineno} | Referenced tool '{program_name}' has no corresponding man page. Typo perhaps?")
     ref_link = f"href=\"{root_dir}/man-pages/{program_name}.html{htc_cli_verb_anchor}\""
     return make_ref_and_index_nodes(name, original_name, program_index,
                                     ref_link, rawtext, inliner, lineno, options)


### PR DESCRIPTION
The defacto standard syntax for compiler warning messages is filename:lineno.  Today, our sphinx warning emit
filename @ lineno.  Let's change the sphinx warnings to look more like compiler warning/errors, which allows tools to jump to them directly.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
