### PR TITLE
HTCONDOR-2845 qmgmt-xact-failure

### DIFF
--- a/docs/version-history/v23-version.hist
+++ b/docs/version-history/v23-version.hist
@@ -1,5 +1,10 @@
 *** 23.0.21 bugs
 
+- Fixed a bug that caused the *condor_gridmanager* to abort if a job that
+  it was managing disappeared from the job queue (i.e. due to someone
+  running *condor_rm -force*).
+  :jira:`2845`
+
 *** 23.0.20 bugs
 
 - Updated condor_upgrade_check to test for use for PASSWORD

--- a/src/condor_schedd.V6/qmgmt_receivers.cpp
+++ b/src/condor_schedd.V6/qmgmt_receivers.cpp
@@ -400,7 +400,7 @@ do_Q_request(QmgmtPeer &Q_PEER)
 		else {
 			errno = 0;
 
-			rval = SetAttribute( cluster_id, proc_id, attr_name.c_str(), attr_value.c_str(), flags, g_transaction_error.get() );
+			rval = SetAttribute( cluster_id, proc_id, attr_name.c_str(), attr_value.c_str(), flags, (flags & SetAttribute_NoAck) ? g_transaction_error.get() : nullptr );
 			terrno = errno;
 			dprintf( D_SYSCALLS, "\trval = %d, errno = %d\n", rval, terrno );
 				// If we're modifying a previously-submitted job AND either


### PR DESCRIPTION
The gridmanager doesn't use NoAck and depends on CommitTransaction() succeeding after a failed SetAttribute(). It handles the failure and needs the rest of the changes in the transaction to commit.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
