### PR TITLE
(HTCONDOR-2808)  `htcondor annex shutdown` doesn't work with htcondor2

### DIFF
--- a/docs/version-history/v24-version.hist
+++ b/docs/version-history/v24-version.hist
@@ -11,6 +11,9 @@
   `GridmanagerLog.root` after a reconfig.
   :jira:`2846`
 
+- ``htcondor annex shutdown`` now works again.
+  :jira:`2808`
+
 *** 24.0.5 bugs
 
 *** 24.4.0 features

--- a/src/condor_tools/htcondor_cli/annex.py
+++ b/src/condor_tools/htcondor_cli/annex.py
@@ -419,22 +419,21 @@ class Shutdown(Verb):
         password_file = htcondor.param.get("ANNEX_PASSWORD_FILE", "~/.condor/annex_password_file")
         password_file = os.path.expanduser(password_file)
 
-        # There's a bug here where I should be able to write
-        #   with htcondor.SecMan() as security_context:
-        # instead, but then security_context is a `lockedContext` object
-        # which doesn't have a `setConfig` attribute.
-        security_context = htcondor.SecMan()
-        with security_context:
-            security_context.setConfig("SEC_CLIENT_AUTHENTICATION_METHODS", "FS IDTOKENS PASSWORD")
-            security_context.setConfig("SEC_PASSWORD_FILE", password_file)
 
-            print(f"Shutting down annex '{annex_name}'...")
-            for location_ad in location_ads:
-                htcondor.send_command(
-                    location_ad,
-                    htcondor.DaemonCommands.OffFast,
-                    "MASTER",
-                )
+        # We should really provide a context object for this, but for now
+        # don't worry about it; we know we're exiting immediately after
+        # this function anyway.
+        htcondor.param["SEC_CLIENT_AUTHENTICATION_METHODS"] = "FS IDTOKENS PASSWORD"
+        htcondor.param["SEC_PASSWORD_FILE"] = password_file
+
+        print(f"Shutting down annex '{annex_name}'...")
+        for location_ad in location_ads:
+            htcondor.send_command(
+                location_ad,
+                htcondor.DaemonCommands.OffFast,
+                "MASTER",
+            )
+
 
         print(f"... each resource in '{annex_name}' has been commanded to shut down.")
         print("It may take some time for each resource to finish shutting down.");


### PR DESCRIPTION
There's no need for the missing formal context manager for what `htcondor annex shutdown` was doing, so use `htcondor.param[]` instead.

We can't really regression test this because it requires valid credentials from external providers.  (Also a lot of network access and assumptions about the providers in question being functional but idle.)

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
