### PR TITLE
HTCONDOR-2850 scitokens-slash

### DIFF
--- a/src/condor_io/authentication.cpp
+++ b/src/condor_io/authentication.cpp
@@ -626,7 +626,7 @@ void Authentication::load_map_file() {
 	}
 }
 
-void Authentication::map_authentication_name_to_canonical_name(int authentication_type, const char* method_string, const char* authentication_name, std::string& canonical_user) {
+void Authentication::map_authentication_name_to_canonical_name(int /*authentication_type*/, const char* method_string, const char* authentication_name, std::string& canonical_user) {
     load_map_file();
 
 	dprintf (D_SECURITY|D_VERBOSE, "AUTHENTICATION: attempting to map '%s'\n", authentication_name);

--- a/src/condor_io/authentication.cpp
+++ b/src/condor_io/authentication.cpp
@@ -640,32 +640,6 @@ void Authentication::map_authentication_name_to_canonical_name(int authenticatio
 		bool mapret = global_map_file->GetCanonicalization(method_string, auth_name_to_map, canonical_user);
 		dprintf (D_SECURITY|D_VERBOSE, "AUTHENTICATION: 2: mapret: %i canonical_user: %s\n", mapret, canonical_user.c_str());
 
-		// if the method is SCITOKENS and mapping failed, try again
-		// with a trailing '/'.  this is to assist admins who have
-		// misconfigured their mapfile.
-		//
-		// depending on the setting of SEC_SCITOKENS_ALLOW_EXTRA_SLASH
-		// (default false) we will either let it slide or print a loud
-		// warning to make it easier to identify the problem.
-		// 
-		// reminder: GetCanonicalization returns "true" on failure.
-		if (mapret && authentication_type == CAUTH_SCITOKENS) {
-			auth_name_to_map += '/';
-			bool withslash_result = global_map_file->GetCanonicalization(method_string, auth_name_to_map, canonical_user);
-			if (!withslash_result) {
-				if (param_boolean("SEC_SCITOKENS_ALLOW_EXTRA_SLASH", false)) {
-					// just continue as if everything is fine.  we've now
-					// already updated canonical_user with the result. complain
-					// a little bit though so the admin can notice and fix it.
-					dprintf(D_SECURITY, "MAPFILE: WARNING: The CERTIFICATE_MAPFILE entry for SCITOKENS \"%s\" contains a trailing '/'. This was allowed because SEC_SCITOKENS_ALLOW_EXTRA_SLASH is set to TRUE.\n", authentication_name);
-					mapret = withslash_result;
-				} else {
-					// complain loudly
-					dprintf(D_ALWAYS, "MAPFILE: ERROR: The CERTIFICATE_MAPFILE entry for SCITOKENS \"%s\" contains a trailing '/'. Either correct the mapfile or set SEC_SCITOKENS_ALLOW_EXTRA_SLASH in the configuration.\n", authentication_name);
-				}
-			}
-		}
-
 		if (!mapret) {
 			// returns true on failure?
 			dprintf (D_FULLDEBUG|D_VERBOSE, "AUTHENTICATION: successful mapping to %s\n", canonical_user.c_str());

--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -916,12 +916,6 @@ type=string
 usage=Restrict when slots can be preempted for user priority
 tags=matchmaker
 
-[SEC_SCITOKENS_ALLOW_EXTRA_SLASH]
-default=false
-type=bool
-usage=Allows SCITOKENS map file entries to match with an extra trailing slash.
-tags=security
-
 [SEC_SCITOKENS_ALLOW_FOREIGN_TOKEN_TYPES]
 default=true
 type=bool


### PR DESCRIPTION
The code to test if a SciTokens identity in the map file has an errant trailing slash is faulty. The associated knob
SEC_SCITOKENS_ALLOW_EXTRA_SLASH is undocumented.
We should just pull this code out.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
