### PR TITLE
HTCONDOR-2876 gridmanager-schedd-name

### DIFF
--- a/docs/version-history/v23-version.hist
+++ b/docs/version-history/v23-version.hist
@@ -13,6 +13,10 @@
   eventually crashing when they ran out of stack memory.
   :jira:`2873`
 
+- Fixed a bug that caused grid ads from different Access Points to
+  overwrite each other in the collector.
+  :jira:`2876`
+
 *** 23.0.20 bugs
 
 - Updated condor_upgrade_check to test for use for PASSWORD

--- a/src/condor_gridmanager/gridmanager.cpp
+++ b/src/condor_gridmanager/gridmanager.cpp
@@ -196,13 +196,6 @@ Init()
 		}
 	}
 
-	const char *val = getenv( "SCHEDD_NAME" );
-	if ( val ) {
-		ScheddName = strdup( val );
-	} else {
-		ScheddName = strdup( "" );
-	}
-
 	if ( ScheddObj == NULL ) {
 		ScheddObj = new DCSchedd( ScheddAddr );
 		ASSERT( ScheddObj );

--- a/src/condor_gridmanager/gridmanager_main.cpp
+++ b/src/condor_gridmanager/gridmanager_main.cpp
@@ -105,6 +105,13 @@ main_init( int argc, char ** const argv )
 				usage( argv[0] );
 			i++;
 			break;
+		case 'n':
+			if (argc <= i + 1) {
+				usage(argv[0]);
+			}
+			ScheddName = strdup(argv[i + 1]);
+			i++;
+			break;
 		default:
 			usage( argv[0] );
 			break;

--- a/src/condor_schedd.V6/grid_universe.cpp
+++ b/src/condor_schedd.V6/grid_universe.cpp
@@ -33,6 +33,8 @@
 #include "condor_email.h"
 #include "shared_port_endpoint.h"
 
+extern char *Name;
+
 // Initialize static data members
 const int GridUniverseLogic::job_added_delay = 3;
 const int GridUniverseLogic::job_removed_delay = 2;
@@ -451,6 +453,8 @@ GridUniverseLogic::StartOrFindGManager(const char* owner, const char* domain,
 
 	args.AppendArg("condor_gridmanager");
 	args.AppendArg("-f");
+	args.AppendArg("-n");
+	args.AppendArg(Name);
 
 	if ( attr_value && *attr_value && param_boolean( "GRIDMANAGER_LOG_APPEND_SELECTION_EXPR", false ) ) {
 		const std::string filename_filter = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_";


### PR DESCRIPTION
This is the only way for the gridmanager to reliably set the ScheddName attribute in its grid ads sent to the collector.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
