### PR TITLE
HTCONDOR-2876 fix-gridmanager-error

### DIFF
--- a/src/condor_schedd.V6/grid_universe.cpp
+++ b/src/condor_schedd.V6/grid_universe.cpp
@@ -450,8 +450,6 @@ GridUniverseLogic::StartOrFindGManager(const char* user, const char* osname,
 
 	args.AppendArg("condor_gridmanager");
 	args.AppendArg("-f");
-	args.AppendArg("-n");
-	args.AppendArg(Name);
 
 	std::string log_suffix = osname;
 
@@ -502,6 +500,8 @@ GridUniverseLogic::StartOrFindGManager(const char* user, const char* osname,
 	args.AppendArg(osname);
 	args.AppendArg("-u");
 	args.AppendArg(user);
+	args.AppendArg("-n");
+	args.AppendArg(Name);
 
 	std::string tmp;
 	if (!init_user_ids(name_of_user(osname, tmp), domain_of_user(osname, ""))) {


### PR DESCRIPTION
The new gridmanager-specific -n flag must come after the daemoncore -a flag on the command line. This wasn't an issue before 24.X, since we didn't use the -a flag with the gridmanager.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [x] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [x] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
