### PR TITLE
HTCONDOR-2865 PSlot resources should reflect quantities lost

### DIFF
--- a/docs/admin-manual/configuration-macros.rst
+++ b/docs/admin-manual/configuration-macros.rst
@@ -3436,10 +3436,11 @@ section.
     Controls whether the *condor_startd* will delete unclaimed dynamic slots that have a
     :ad-attr:`SlotBrokenReason` or not.  When set to True, a broken slot will not be deleted when
     it becomes unclaimed.  When set to False, a broken slot will be deleted when it becomes unclaimed
-    but the resources of the dynamic slot will not be returned to the partitionable slot.
+    but the resources of the dynamic slot will not be returned to the partitionable slot, instead
+    the total slot resources of the partitionable slot will be adjusted to reflect the lost resources.
     In either case, the daemon ad of the *condor_startd* will advertise the broken resources,
     including which slot they were assigned to and which job and user were using the slot when
-    it became broken. Default value is True.
+    it became broken. Default value is False.
 
 :macro-def:`BROKEN_SLOT_CONTEXT_ATTRS[STARTD]`
     A list of attribute names to publish in the *condor_startd* daemon ad attribute :ad-attr:`BrokenContextAds`

--- a/docs/classad-attributes/machine-classad-attributes.rst
+++ b/docs/classad-attributes/machine-classad-attributes.rst
@@ -1023,6 +1023,13 @@ Machine ClassAd Attributes
     The number of CPUs (cores) in this slot. For static slots, this
     value will be the same as in :ad-attr:`Cpus`.
 
+:classad-attribute-def:`BrokenSlotCpus`
+    The number of CPUs (cores) that this slot has lost
+    because a dynamic slot was deleted while marked as broken.
+    This attribute will appear only in partitionable slots that have lost resources to broken dynamic slots.
+    When this attribute exists, the sum of this attribute and :ad-attr:`TotalSlotCpus` will be the
+    original total CPUs for this slot.
+
 :classad-attribute-def:`TotalSlotDisk`
     The quantity of disk space in KiB given to this slot. For static
     slots, this value will be the same as machine ClassAd attribute
@@ -1030,12 +1037,26 @@ Machine ClassAd Attributes
     slot per machine, this value will be the same as machine ClassAd
     attribute :ad-attr:`TotalDisk`.
 
+:classad-attribute-def:`BrokenSlotDisk`
+    The quantity of disk space in KiB this slot has lost
+    because a dynamic slot was deleted while marked as broken.
+    This attribute will appear only in partitionable slots that have lost resources to broken dynamic slots.
+    When this attribute exists, the sum of this attribute and :ad-attr:`TotalSlotDisk` will be the
+    original total disk for this slot.
+
 :classad-attribute-def:`TotalSlotMemory`
     The quantity of RAM in MiB given to this slot. For static slots,
     this value will be the same as machine ClassAd attribute :ad-attr:`Memory`.
     For partitionable slots, where there is one partitionable slot per
     machine, this value will be the same as machine ClassAd attribute
     :ad-attr:`TotalMemory`.
+
+:classad-attribute-def:`BrokenSlotMemory`
+    The quantity of RAM in MiB this slot has lost
+    because a dynamic slot was deleted while marked as broken.
+    This attribute will appear only in partitionable slots that have lost resources to broken dynamic slots.
+    When this attribute exists, the sum of this attribute and :ad-attr:`TotalSlotMemory` will be the
+    original total memory for this slot.
 
 :classad-attribute-def:`TotalSlots`
     A sum of the static slots, partitionable slots, and dynamic slots on

--- a/docs/version-history/v24-version.hist
+++ b/docs/version-history/v24-version.hist
@@ -25,6 +25,12 @@
   arguments are used.
   :jira:`2844`
 
+- The *condor_startd* will now permanently reduce the total slot resources advertised by
+  a partitionable slot when a dynamic slot is deleted while it is marked as broken. The
+  amount of reduction will be advertised in new attributes such as ad-attr:`BrokenSlotCpus`
+  so that the original size of the slot can be computed.
+  :jira:`2865`
+
 - Added new configuration option :macro:`LVM_CLEANUP_FAILURE_MAKES_BROKEN_SLOT` to allow
   administrators to enable/disable failure of cleaning up LV's in the *condor_starter*
   to result in a broken slot.

--- a/src/condor_startd.V6/ResAttributes.h
+++ b/src/condor_startd.V6/ResAttributes.h
@@ -440,7 +440,7 @@ public:
 	void unbind_DevIds(MachAttributes* map, int slot_id, int slot_sub_id, int new_sub_id=0); // release non-fungable resource ids
 	void reconfig_DevIds(MachAttributes* map, int slot_id, int slot_sub_id); // check for offline changes for non-fungible resource ids
 
-	void publish_static(ClassAd*, const ResBag * inuse) const;  // Publish desired info to given CA
+	void publish_static(ClassAd*, const ResBag * inuse, const ResBag * broken) const;  // Publish desired info to given CA
 	void publish_dynamic(ClassAd*) const;  // Publish desired info to given CA
 	void compute_virt_mem_share(double virt_mem);
 	void compute_disk();

--- a/src/condor_startd.V6/Resource.h
+++ b/src/condor_startd.V6/Resource.h
@@ -311,9 +311,9 @@ public:
 			// deduct in-use resources from the backfill p-slot
 			// if there is more than one backfill p-slot, inuse resources will be overcounted.
 			// TODO: spread out deductions across multiple backfill p-slots and/or static slots?
-			r_attr->publish_static(cad, &inUse);
+			r_attr->publish_static(cad, &inUse, r_lost_child_res);
 		} else {
-			r_attr->publish_static(cad, nullptr);
+			r_attr->publish_static(cad, nullptr, r_lost_child_res);
 		}
 	}
 
@@ -443,6 +443,7 @@ public:
 
 	CODMgr*			r_cod_mgr;	// Object to manage COD claims
 	CpuAttributes*	r_attr;		// Attributes of this resource
+	ResBag*			r_lost_child_res{nullptr}; // quantities of resources that were assigned to child slots and then lost or broken
 	LoadQueue		r_load_queue;  // Holds 1 minute avg % cpu usage
 	char*			r_name;		// Name of this resource
 	char*			r_id_str;	// CPU id of this resource (string form)

--- a/src/condor_startd.V6/startd_main.cpp
+++ b/src/condor_startd.V6/startd_main.cpp
@@ -503,7 +503,7 @@ init_params( int first_time)
 		classad::FunctionCall::RegisterFunction( func_name, OtherSlotEval );
 
 		enable_claimable_partitionable_slots = param_boolean("ENABLE_CLAIMABLE_PARTITIONABLE_SLOTS", false);
-		continue_to_advertise_broken_dslots = param_boolean("CONTINUE_TO_ADVERTISE_BROKEN_DYNAMIC_SLOTS", true);
+		continue_to_advertise_broken_dslots = param_boolean("CONTINUE_TO_ADVERTISE_BROKEN_DYNAMIC_SLOTS", false);
 	}
 
 	resmgr->init_config_classad();

--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -1668,7 +1668,7 @@ description=Enable a singular daemon ad for Startds, and separate Slot ads for e
 usage=Set to False to advertise Machine ads only. True to use Slot and StartDaemon ads, Auto to use collector version to decide
 
 [CONTINUE_TO_ADVERTISE_BROKEN_DYNAMIC_SLOTS]
-default=true
+default=false
 type=bool
 description=Dynamic slots in broken state should continue to exist as slots
 useage=Set to True to advertise broken dslots as slots, set to False to mark the slot resources as broken, but allow the slot to be deleted


### PR DESCRIPTION


  The TotalSlot* resources of a PSlot will be reduced when a DSlot is deleted
  while broken.  A new set of BrokenSlot* attributes will advertise the total
  resources lost to the PSlot. The default for deleting broken DSlots when
  the claim is released will be changed to
  CONTINUE_TO_ADVERTISE_BROKEN_DYNAMIC_SLOTS = false

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
