### PR TITLE
HTCONDOR-2888 Allow clients to reuse connections with no authentication

### DIFF
--- a/docs/version-history/v23-version.hist
+++ b/docs/version-history/v23-version.hist
@@ -4,6 +4,11 @@
   :subcom:`preserve_relative_paths` from working.
   :jira:`2877`
 
+- Fixed a bug that prevented daemons from updating their ads in the
+  *condor_collector* when authentication is disabled but encryption or
+  integrity is enabled.
+  :jira:`2888`
+
 *** 23.10.21 bugs
 
 - Fixed a bug where chirp would not work in container universe jobs

--- a/src/condor_daemon_core.V6/daemon_command.cpp
+++ b/src/condor_daemon_core.V6/daemon_command.cpp
@@ -1472,22 +1472,17 @@ DaemonCommandProtocol::CommandProtocolResult DaemonCommandProtocol::VerifyComman
 					return CommandProtocolFinished;
 				}
 
-				// well, they didn't authenticate, turn on encryption,
-				// or turn on integrity.  check to see if any of those
-				// were required.
+				// Well, they didn't authenticate. See if that was required.
+				// Also, if security negotiation is required, see if they
+				// have a security session.
 
 				if (  (m_sec_man->sec_lookup_req(*our_policy, ATTR_SEC_NEGOTIATION)
-					   == SecMan::SEC_REQ_REQUIRED)
-				   || (m_sec_man->sec_lookup_req(*our_policy, ATTR_SEC_AUTHENTICATION)
-					   == SecMan::SEC_REQ_REQUIRED)
+					   == SecMan::SEC_REQ_REQUIRED && m_sock->getSessionID().empty())
 				   || (m_sec_man->sec_lookup_req(*our_policy, ATTR_SEC_AUTHENTICATION_NEW)
-					   == SecMan::SEC_REQ_REQUIRED)
-				   || (m_sec_man->sec_lookup_req(*our_policy, ATTR_SEC_ENCRYPTION)
-					   == SecMan::SEC_REQ_REQUIRED)
-				   || (m_sec_man->sec_lookup_req(*our_policy, ATTR_SEC_INTEGRITY)
 					   == SecMan::SEC_REQ_REQUIRED) ) {
 
-					// yep, they were.  deny.
+					// yep, negotiation or authentication was required and
+					// they didn't do it.  deny.
 
 					dprintf(D_ALWAYS,
 						"DaemonCore: PERMISSION DENIED for %d (%s) via %s%s%s from host %s (access level %s)\n",


### PR DESCRIPTION
When reusing a cached TCP connection for additional CEDAR commands (e.g. daemons updating the collector), the server shouldn't reject commands when authentication is disabled but encryption or integrity is enabled. That is now a valid configuration.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
