### PR TITLE
HTCONDOR-2803 user-stored-creds

### DIFF
--- a/src/condor_credd/credd.cpp
+++ b/src/condor_credd/credd.cpp
@@ -558,7 +558,7 @@ CredDaemon::check_creds_handler( int, Stream* s)
 		set_priv(priv);
 
 		// if the file is not found, add this request to the collection of missing requests
-		if (top_rc==-1) {
+		if (top_rc==-1 && cred_type != CredSorter::UnknownType) {
 			dprintf(D_ALWAYS, "check_creds: did not find %s\n", service_top_fname.c_str());
 			switch(cred_type) {
 			case CredSorter::LocalIssuerType:
@@ -576,6 +576,9 @@ CredDaemon::check_creds_handler( int, Stream* s)
 				formatstr(URL, "ERROR: Credential '%s' of unknown type is missing.", service.c_str());
 				goto bail;
 			}
+		} else if (use_rc == -1 && cred_type == CredSorter::UnknownType) {
+			formatstr(URL, "ERROR: Credential '%s' of unknown type is missing.", service.c_str());
+			goto bail;
 		} else if (use_rc == -1 && (cred_type == CredSorter::LocalIssuerType ||
 		                            cred_type == CredSorter::LocalClientType)) {
 			dprintf(D_ALWAYS, "check_creds: did not find %s\n", service_use_fname.c_str());

--- a/src/condor_tools/htcondor_cli/credential.py
+++ b/src/condor_tools/htcondor_cli/credential.py
@@ -72,7 +72,7 @@ class ListAll(Verb):
                     continue
 
                 for file in entry.iterdir():
-                    if file.suffix != ".top":
+                    if file.suffix != ".top" and file.suffix != ".use":
                         continue
                     credentials_by_user[entry.name][file.stem] = {
                         'refresh':  int(file.stat().st_mtime),

--- a/src/condor_tools/store_cred_main.cpp
+++ b/src/condor_tools/store_cred_main.cpp
@@ -707,6 +707,10 @@ parseCommandLine(StoreCredOptions *opts, int argc, const char *argv[])
 					err = true;
 				}
 			}
+			if (cred_type == STORE_CRED_USER_OAUTH && opts->service == nullptr) {
+				fprintf(stderr, "ERROR: add-oauth command requires a service name\n");
+				err = true;
+			}
 			// when storing Krb credentials, we want to wait for the credmon to process
 			if ((cred_type == STORE_CRED_USER_KRB) && ! no_wait) {
 				opts->mode |= STORE_CRED_WAIT_FOR_CREDMON;


### PR DESCRIPTION
When the user does condor_store_cred add-oauth or htcondor credential add, if the given service name doesn't match any of the credmons, then the credential data is written directly to a .use file in the user's oauth credentials directory. All credmons will ignore it, and it can be requested by a job via use_oauth_services.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
