### PR TITLE
Fix bugs affecting concurrency limits expressions, claim recycling, and partitionable slot leftovers.

### DIFF
--- a/src/condor_schedd.V6/qmgmt.cpp
+++ b/src/condor_schedd.V6/qmgmt.cpp
@@ -9669,7 +9669,7 @@ void FindRunnableJob(PROC_ID & jobid, ClassAd* my_match_ad,
 
 			std::string jobLimits, recordedLimits;
 			if (param_boolean("CLAIM_RECYCLING_CONSIDER_LIMITS", true)) {
-				ad->LookupString(ATTR_CONCURRENCY_LIMITS, jobLimits);
+				EvalString(ATTR_CONCURRENCY_LIMITS,ad,my_match_ad,jobLimits);
 				my_match_ad->LookupString(ATTR_MATCHED_CONCURRENCY_LIMITS,
 										  recordedLimits);
 				lower_case(jobLimits);
@@ -9677,11 +9677,11 @@ void FindRunnableJob(PROC_ID & jobid, ClassAd* my_match_ad,
 
 				if (jobLimits == recordedLimits) {
 					dprintf(D_FULLDEBUG,
-							"ConcurrencyLimits match, can reuse claim\n");
+							"ConcurrencyLimits match ('%s'), can reuse claim\n",jobLimits.c_str());
 				} else {
 					dprintf(D_FULLDEBUG,
-							"ConcurrencyLimits do not match, cannot "
-							"reuse claim\n");
+							"ConcurrencyLimits do not match ('%s' in job vs '%s' in startd), cannot "
+							"reuse claim\n",jobLimits.c_str(),recordedLimits.c_str());
 					PrioRecAutoClusterRejected.emplace(p->auto_cluster_id,1);
 					continue;
 				}

--- a/src/condor_schedd.V6/schedd.cpp
+++ b/src/condor_schedd.V6/schedd.cpp
@@ -8763,6 +8763,13 @@ Scheduler::claimedStartd( DCMsgCallback *cb ) {
 		// it left the startd into the fresh pslot leftovers ad
 		msg->leftover_startd_ad()->Update(match->m_added_attrs);
 
+		// Remove attributes that should not be duplicated from the original match.
+
+		// If there were such a thing as leftovers for concurrency limits, those could
+		// be preserved, but since there aren't, remove the matched concurrency limits,
+		// so they are only applied to the original match, not additional leftover matches.
+		msg->leftover_startd_ad()->Delete(ATTR_MATCHED_CONCURRENCY_LIMITS);
+
 			// dprintf a message saying we got a new match, but be certain
 			// to only output the public claim id (keep the capability private)
 		ClaimIdParser idp( msg->leftover_claim_id() );
@@ -14768,6 +14775,9 @@ Scheduler::AddMrec(char const* id, char const* peer, PROC_ID* jobId, const Class
 				CopyAttribute(itr->first, rec->m_added_attrs, *rec->my_match_ad);
 			}
 		}
+
+		// Preserve other attributes added by the negotiator:
+		CopyAttribute(ATTR_MATCHED_CONCURRENCY_LIMITS, rec->m_added_attrs, *rec->my_match_ad);
 
 		// These attributes are added by the schedd to slot ads that
 		// arrive via DIRECT_ATTACH.


### PR DESCRIPTION
When an expression rather than a plain string is used for a concurrency limit, recycled claims and partitionable slot leftovers were ignoring the concurrency limit of jobs.

In addition, when a plain string was used for the concurrency limit, recycled claims were not being used to run jobs with identical concurrency limits.  Instead, they were only being used to run jobs with no concurrency limits (or jobs having concurrency limit expressions, not plain strings), irrespective of the matched concurrency limits stored in the claim.

I based this patch on the main branch, but it would be great if we could get it in 23 or 24 LTS.  Concurrency limits could be a good solution for providing a "fast queue" for CMS analysis facilities.

I wish this patch also solved the harder problem of making use of partitionable slot leftovers when there are concurrency limits, but it doesn't.  The leftovers cannot be immediately used within the schedd for jobs having concurrency limits, since the schedd only gets a budget for one match of the concurrency limit, so we can only start one such job per partitionable slot per negotiation cycle.  Fortunately, that is not as urgent of a problem for us.

Thanks for listening!