### PR TITLE
HTCONDOR-2908 Fix condor_adstash startd discovery

### DIFF
--- a/docs/version-history/v24-version.hist
+++ b/docs/version-history/v24-version.hist
@@ -7,6 +7,11 @@
 
 *** 24.0.6 bugs
 
+- Fixed a bug in :tool:`condor_adstash` that caused it to fail to discover
+  *condor_startd* daemons using :macro:`ENABLE_STARTD_DAEMON_AD`
+  (enabled by default since HTCondor 23.9).
+  :jira:`2908`
+
 *** 24.0.5 bugs
 
 - Fixed a bug in :mod:`htcondor2` preventing the submission of jobs with

--- a/src/condor_scripts/adstash/ad_sources/startd_history.py
+++ b/src/condor_scripts/adstash/ad_sources/startd_history.py
@@ -50,7 +50,7 @@ class StartdHistorySource(GenericAdSource):
             try:
                 dict_ad = to_json(ad, return_dict=True)
             except Exception as e:
-                message = f"Failure when converting document in {startd_ad['name']} history: {str(e)}"
+                message = f"Failure when converting document in {startd_ad['Machine']} history: {str(e)}"
                 exc = traceback.format_exc()
                 message += f"\n{exc}"
                 logging.warning(message)
@@ -61,23 +61,23 @@ class StartdHistorySource(GenericAdSource):
             # Here, we assume that the interface is responsible for de-duping ads
             # and only update the checkpoint after the full history queue is pushed
             # through by returning the new checkpoint at the end.
-            
+
             if startd_checkpoint is None:  # set checkpoint based on first parseable ad
                 startd_checkpoint = {"GlobalJobId": ad["GlobalJobId"], "EnteredCurrentStatus": ad["EnteredCurrentStatus"]}
             chunk.append((unique_doc_id(dict_ad), dict_ad,))
 
             if (chunk_size > 0) and (len(chunk) >= chunk_size):
-                logging.debug(f"Posting {len(chunk)} ads from {startd_ad['Name']}.")
+                logging.debug(f"Posting {len(chunk)} ads from {startd_ad['Machine']}.")
                 result = interface.post_ads(chunk, metadata=metadata, **kwargs)
                 ads_posted += result["success"]
                 yield None  # don't update checkpoint yet, per note above
                 chunk = []
 
         if len(chunk) > 0:
-            logging.debug(f"Posting {len(chunk)} ads from {startd_ad['Name']}.")
+            logging.debug(f"Posting {len(chunk)} ads from {startd_ad['Machine']}.")
             result = interface.post_ads(chunk, metadata=metadata, **kwargs)
             ads_posted += result["success"]
-        
+
         endtime = time.time()
         logging.warning(f"Startd {startd_ad['Machine']} history: response count: {ads_posted}; upload time: {(endtime-starttime)/60:.2f} min")
         yield startd_checkpoint  # finally update checkpoint

--- a/src/condor_scripts/adstash/adstash.py
+++ b/src/condor_scripts/adstash/adstash.py
@@ -329,6 +329,11 @@ def schedd_history_processor(src, schedd_ad, ckpt_queue, iface, metadata, args, 
 
 
 def startd_history_processor(src, startd_ad, ckpt_queue, iface, metadata, args, src_kwargs):
+    metadata["condor_history_runtime"] = int(time.time())
+    metadata["condor_history_host_version"] = startd_ad.get("CondorVersion", "UNKNOWN")
+    metadata["condor_history_host_platform"] = startd_ad.get("CondorPlatform", "UNKNOWN")
+    metadata["condor_history_host_machine"] = startd_ad.get("Machine", "UNKNOWN")
+    metadata["condor_history_host_name"] = startd_ad.get("Name", "UNKNOWN")
     try:
         ads = src.fetch_ads(startd_ad, max_ads=args.startd_history_max_ads)
     except Exception as e:

--- a/src/condor_scripts/adstash/utils.py
+++ b/src/condor_scripts/adstash/utils.py
@@ -76,33 +76,34 @@ def get_startds(args=None):
         collectors = []
         logging.warning("The list of Collectors to query is empty")
 
+    startd_allow_list = None
+    if args.startds is not None:
+        startd_allow_list = set(args.startds.split(","))
+
     startd_ads = {}
     for host in collectors:
         coll = htcondor.Collector(host)
         try:
-            # Get one ad per machine
-            name_ads = coll.query(
+            # Want one ad per machine, so don't bother with dynamic slots
+            slot_ads = coll.query(
                 htcondor.AdTypes.Startd,
                 constraint='(SlotType == "Static") || (SlotType == "Partitionable")',
-                projection=["Name", "Machine", "CondorVersion"],
+                projection=["Name", "Machine", "CondorVersion", "CondorPlatform", "MyAddress"],
             )
-            for ad in name_ads:
-                try:
-                    if ad["Name"][0:6] == "slot1@" or not ("@" in ad["Name"]):
-                        if args.startds and not (ad["Machine"] in args.startds.split(",")):
-                            continue
-                        # Remote history bindings only exist in startds running 8.9.7+
-                        version = tuple([int(x) for x in ad["CondorVersion"].split()[1].split(".")])
-                        if version < (8, 9, 7):
-                            logging.warning(
-                                f"The Startd on {ad['Machine']} is running HTCondor < 8.9.7 and will be skipped"
-                            )
-                            continue
-                        startd = coll.locate(htcondor.DaemonTypes.Startd, ad["Name"])
-                        startd["MyPool"] = host
-                        startd_ads[startd["Machine"]] = startd
-                except Exception:
+            for slot_ad in slot_ads:
+                machine = slot_ad["Machine"]
+                if machine in startd_ads or (startd_allow_list is not None and machine not in startd_allow_list):
                     continue
+
+                # Remote history bindings only exist in startds running 8.9.7+
+                version = tuple(int(x) for x in slot_ad["CondorVersion"].split()[1].split("."))
+                if version < (8, 9, 7):
+                    logging.warning(
+                        f"The Startd on {machine} is running HTCondor < 8.9.7 and will be skipped"
+                    )
+                    continue
+
+                startd_ads[machine] = slot_ad
 
         except IOError:
             logging.exception(f"Error while getting list of Startds from Collector {host}")


### PR DESCRIPTION
Instead of using `Collector.locate()`, add `MyAddress` to the projection list when fetching the non-dynamic slot ads the first time, which the Startd objects can use when being created. This not only fixes the incompatibility where `locate()` used to take a Startd slot name instead of a machine name for its `name` argument, but is also much, much faster. We should consider doing this for schedd discovery as well.

https://opensciencegrid.atlassian.net/browse/HTCONDOR-2908

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
