### PR TITLE
HTCONDOR-2882 Add DEACTIVATE_CLAIM_JOB_DONE which shadow will use

### DIFF
--- a/src/condor_daemon_client/dc_startd.cpp
+++ b/src/condor_daemon_client/dc_startd.cpp
@@ -359,10 +359,10 @@ DCStartd::asyncRequestOpportunisticClaim( ClassAd const *req_ad, char const *des
 
 
 bool 
-DCStartd::deactivateClaim( bool graceful, bool got_job_exit, bool *claim_is_closing )
+DCStartd::deactivateClaim( bool graceful, bool got_job_done, bool *claim_is_closing )
 {
 	dprintf( D_FULLDEBUG, "Entering DCStartd::deactivateClaim(%s)\n",
-			 got_job_exit ? "job_done" : (graceful ? "graceful" : "forceful" ));
+		got_job_done ? "job_done" : (graceful ? "graceful" : "forceful" ));
 
 	if( claim_is_closing ) {
 		*claim_is_closing = false;
@@ -379,7 +379,7 @@ DCStartd::deactivateClaim( bool graceful, bool got_job_exit, bool *claim_is_clos
 	ClaimIdParser cidp(claim_id);
 
 	int cmd = graceful ? DEACTIVATE_CLAIM : DEACTIVATE_CLAIM_FORCIBLY;
-	if (got_job_exit) {
+	if (got_job_done) {
 		CondorVersionInfo cvi = cidp.secSessionInfoVersion();
 		// we need a newish Startd in order to send DEACTIVATE_CLAIM_JOB_DONE
 		if (cvi.getMajorVer() <= 0) {

--- a/src/condor_daemon_client/dc_startd.cpp
+++ b/src/condor_daemon_client/dc_startd.cpp
@@ -359,10 +359,10 @@ DCStartd::asyncRequestOpportunisticClaim( ClassAd const *req_ad, char const *des
 
 
 bool 
-DCStartd::deactivateClaim( bool graceful, bool *claim_is_closing )
+DCStartd::deactivateClaim( bool graceful, bool got_job_exit, bool *claim_is_closing )
 {
 	dprintf( D_FULLDEBUG, "Entering DCStartd::deactivateClaim(%s)\n",
-			 graceful ? "graceful" : "forceful" );
+			 got_job_exit ? "job_done" : (graceful ? "graceful" : "forceful" ));
 
 	if( claim_is_closing ) {
 		*claim_is_closing = false;
@@ -376,12 +376,26 @@ DCStartd::deactivateClaim( bool graceful, bool *claim_is_closing )
 		return false;
 	}
 
-		// if this claim is associated with a security session
 	ClaimIdParser cidp(claim_id);
+
+	int cmd = graceful ? DEACTIVATE_CLAIM : DEACTIVATE_CLAIM_FORCIBLY;
+	if (got_job_exit) {
+		CondorVersionInfo cvi = cidp.secSessionInfoVersion();
+		// we need a newish Startd in order to send DEACTIVATE_CLAIM_JOB_DONE
+		if (cvi.getMajorVer() <= 0) {
+			dprintf(D_ZKM, "Startd version is not known, will use %s\n", getCommandStringSafe(cmd));
+		} else {
+			if (cvi.built_since_version(24,6,0)) {
+				cmd = DEACTIVATE_CLAIM_JOB_DONE;
+				dprintf(D_ZKM, "Startd version is known and job_has_exited, will use JOB_DONE\n");
+			}
+		}
+	}
+
+		// if this claim is associated with a security session
 	char const *sec_session = cidp.secSessionId();
 
 	if (IsDebugLevel(D_COMMAND)) {
-		int cmd = graceful ? DEACTIVATE_CLAIM : DEACTIVATE_CLAIM_FORCIBLY;
 		dprintf (D_COMMAND, "DCStartd::deactivateClaim(%s,...) making connection to %s\n", getCommandStringSafe(cmd), _addr.c_str());
 	}
 
@@ -396,21 +410,11 @@ DCStartd::deactivateClaim( bool graceful, bool *claim_is_closing )
 		newError( CA_CONNECT_FAILED, err.c_str() );
 		return false;
 	}
-	int cmd;
-	if( graceful ) {
-		cmd = DEACTIVATE_CLAIM;
-	} else {
-		cmd = DEACTIVATE_CLAIM_FORCIBLY;
-	}
 	result = startCommand( cmd, (Sock*)&reli_sock, 20, NULL, NULL, false, sec_session ); 
 	if( ! result ) {
 		std::string err = "DCStartd::deactivateClaim: ";
 		err += "Failed to send command ";
-		if( graceful ) {
-			err += "DEACTIVATE_CLAIM";
-		} else {
-			err += "DEACTIVATE_CLAIM_FORCIBLY";
-		}
+		err += getCommandStringSafe(cmd);
 		err += " to the startd";
 		newError( CA_COMMUNICATION_ERROR, err.c_str() );
 		return false;

--- a/src/condor_daemon_client/dc_startd.h
+++ b/src/condor_daemon_client/dc_startd.h
@@ -91,10 +91,11 @@ public:
 
 		/** Send the command to this startd to deactivate the claim 
 			@param graceful Should we be graceful or forcful?
+			@param got_job_exit do we believe that the job has exited?
 			@param claim_is_closing startd indicates if not accepting more jobs
 			@return true on success, false on failure
 		 */
-	bool deactivateClaim( bool graceful = true, bool *claim_is_closing=NULL );
+	bool deactivateClaim( bool graceful, bool got_job_exit, bool *claim_is_closing);
 
 		/** Try to activate the claim on this started with the given
 			job ClassAd and version of the starter we want to use. 

--- a/src/condor_daemon_client/dc_startd.h
+++ b/src/condor_daemon_client/dc_startd.h
@@ -91,11 +91,11 @@ public:
 
 		/** Send the command to this startd to deactivate the claim 
 			@param graceful Should we be graceful or forcful?
-			@param got_job_exit do we believe that the job has exited?
+			@param got_job_done do we believe that the job is done? (i.e. got the job_exit syscall)
 			@param claim_is_closing startd indicates if not accepting more jobs
 			@return true on success, false on failure
 		 */
-	bool deactivateClaim( bool graceful, bool got_job_exit, bool *claim_is_closing);
+	bool deactivateClaim( bool graceful, bool got_job_done, bool *claim_is_closing);
 
 		/** Try to activate the claim on this started with the given
 			job ClassAd and version of the starter we want to use. 

--- a/src/condor_includes/condor_commands.h
+++ b/src/condor_includes/condor_commands.h
@@ -67,7 +67,7 @@ const int REQUEST_CLAIM_SLOT_AD          = 7;
 
 
 constexpr const
-std::array<std::pair<int, const char *>, 194> makeCommandTable() {
+std::array<std::pair<int, const char *>, 195> makeCommandTable() {
 	return {{ // Yes, we need two...
 
 /****
@@ -121,8 +121,8 @@ std::array<std::pair<int, const char *>, 194> makeCommandTable() {
 
 //#define AVAILABILITY		(SCHED_VERS+12)		/* Not used */
 //		{AVAILABILITY, "AVAILABILITY"},
-//#define NUM_FRGN_JOBS		(SCHED_VERS+13)		/* Not used */
-//		{NUM_FRGN_JOBS, "NUM_FRGN_JOBS"},
+#define DEACTIVATE_CLAIM_JOB_DONE		(SCHED_VERS+13)		/* formerly NUM_FRGN_JOBS */
+		{DEACTIVATE_CLAIM_JOB_DONE, "DEACTIVATE_CLAIM_JOB_DONE"},
 //#define STARTD_INFO			(SCHED_VERS+14)		/* Not used */
 //		{STARTD_INFO, "STARTD_INFO"},
 //#define SCHEDD_INFO			(SCHED_VERS+15)		/* Not used */

--- a/src/condor_schedd.V6/schedd.cpp
+++ b/src/condor_schedd.V6/schedd.cpp
@@ -15885,6 +15885,16 @@ abortJobsByConstraint( const char *constraint,
 			job_count = 0;
 			break;
 		}
+
+		// don't abort jobs that are already termination pending.  This fixes a race
+		// between DagMan exiting because it has seen all of the completion events
+		// even though some node jobs have not yet been moved to the completed state in the Schedd.
+		bool pending_term = false;
+		if (ad->LookupBool(ATTR_TERMINATION_PENDING, pending_term) && pending_term) {
+			dprintf(D_FULLDEBUG, "remove by constraint matched: %d.%d but will be ignored because TerminationPending\n", cluster, proc);
+			continue;
+		}
+
 		jobs.emplace_back(cluster, proc);
 
 		dprintf(D_FULLDEBUG, "remove by constraint matched: %d.%d\n", cluster, proc);

--- a/src/condor_shadow.V6.1/NTreceivers.cpp
+++ b/src/condor_shadow.V6.1/NTreceivers.cpp
@@ -186,7 +186,7 @@ do_REMOTE_syscall()
             Or the starter went away by itself after telling us
             it's ready to do so (via a job_exit syscall). */
 		if ( thisRemoteResource->wasClaimDeactivated() ||
-		     thisRemoteResource->gotJobExit() ) {
+		     thisRemoteResource->gotJobDone() ) {
 			thisRemoteResource->closeClaimSock();
 			return -1;
 		}

--- a/src/condor_shadow.V6.1/remoteresource.cpp
+++ b/src/condor_shadow.V6.1/remoteresource.cpp
@@ -101,7 +101,7 @@ RemoteResource::RemoteResource( BaseShadow *shad )
 	lease_duration = -1;
 	already_killed_graceful = false;
 	already_killed_fast = false;
-	m_got_job_exit = false;
+	m_got_job_done = false;
 	m_want_chirp = false;
 	m_want_streaming_io = false;
 	m_attempt_shutdown_tid = -1;
@@ -295,10 +295,10 @@ RemoteResource::killStarter( bool graceful )
 	// if we saw a job_exit.
 	// TODO If we add a version check or decide we don't care about 8.6.X
 	//   and earlier, we can just return true if m_got_job_exit==true.
-	bool wait_on_failure = m_wait_on_kill_failure && !m_got_job_exit;
+	bool wait_on_failure = m_wait_on_kill_failure && !m_got_job_done;
 	int num_tries = wait_on_failure ? 3 : 1;
 	while (num_tries > 0) {
-		if (dc_startd->deactivateClaim(graceful, m_got_job_exit, &claim_is_closing)) {
+		if (dc_startd->deactivateClaim(graceful, m_got_job_done, &claim_is_closing)) {
 			break;
 		}
 		num_tries--;
@@ -1804,7 +1804,7 @@ RemoteResource::resourceExit( int reason_for_exit, int exit_status )
 	dprintf( D_FULLDEBUG, "Inside RemoteResource::resourceExit()\n" );
 	setExitReason( reason_for_exit );
 
-	m_got_job_exit = true;
+	m_got_job_done = true;
 
 	// Record the activation stop time (HTCONDOR-861) and set the
 	// corresponding duration attributes.

--- a/src/condor_shadow.V6.1/remoteresource.cpp
+++ b/src/condor_shadow.V6.1/remoteresource.cpp
@@ -298,7 +298,7 @@ RemoteResource::killStarter( bool graceful )
 	bool wait_on_failure = m_wait_on_kill_failure && !m_got_job_exit;
 	int num_tries = wait_on_failure ? 3 : 1;
 	while (num_tries > 0) {
-		if (dc_startd->deactivateClaim(graceful, &claim_is_closing)) {
+		if (dc_startd->deactivateClaim(graceful, m_got_job_exit, &claim_is_closing)) {
 			break;
 		}
 		num_tries--;

--- a/src/condor_shadow.V6.1/remoteresource.h
+++ b/src/condor_shadow.V6.1/remoteresource.h
@@ -343,7 +343,7 @@ class RemoteResource : public Service {
 		/** Return true if we received a job_exit syscall from the
 			starter, false if not.
 		*/
-	bool gotJobExit() const { return m_got_job_exit; };
+	bool gotJobDone() const { return m_got_job_done; };
 
 		/** If the job on this resource exited with a signal, return
 			the signal.  If not, return -1. */
@@ -541,7 +541,7 @@ private:
 
 	bool already_killed_graceful;
 	bool already_killed_fast;
-	bool m_got_job_exit;
+	bool m_got_job_done; // set by the mis-named job_exit syscall, it means the starter is about to exit
 
 	bool m_wait_on_kill_failure;
 

--- a/src/condor_shadow.V6.1/shadow.cpp
+++ b/src/condor_shadow.V6.1/shadow.cpp
@@ -621,7 +621,7 @@ UniShadow::exitAfterEvictingJob( int reason ) {
 	// not called from UniShadow::cleanUp() because a bunch of those functions
 	// do important-looking things between calling cleanUp() and calling
 	// DC_Exit().
-	if( remRes->gotJobExit() || remRes->getClaimSock() == NULL ) {
+	if( remRes->gotJobDone() || remRes->getClaimSock() == NULL ) {
 		DC_Exit( reason );
 	} else {
 		this->delayedExitReason = reason;

--- a/src/condor_startd.V6/ResMgr.h
+++ b/src/condor_startd.V6/ResMgr.h
@@ -207,6 +207,7 @@ public:
 
 	bool 	needsPolling( void );
 	bool 	hasAnyClaim( void );
+	bool	hasAnyActiveClaim( bool for_shutdown );
 	bool	is_smp( void ) { return( num_cpus() > 1 ); }
 	int		num_cpus( void ) const { return m_attr->num_cpus(); }
 	int		num_real_cpus( void ) const { return m_attr->num_real_cpus(); }

--- a/src/condor_startd.V6/ResState.cpp
+++ b/src/condor_startd.V6/ResState.cpp
@@ -234,7 +234,7 @@ ResState::eval_policy( void )
 				// This allows startd policies to put jobs on hold during
 				// draining.
 				if( 1 == rip->eval_preempt() ) {
-					rip->preemptIsTrue();
+					rip->setPreemptIsTrue();
 				}
 
 				dprintf( D_ALWAYS, "State change: claim retirement ended/expired\n" );
@@ -261,7 +261,7 @@ ResState::eval_policy( void )
 				// irreversible retirement
 				// TLM: STATE TRANSITION #12
 				// TLM: STATE TRANSITION #16
-				rip->preemptIsTrue();
+				rip->setPreemptIsTrue();
 				rip->setBadputCausedByPreemption();
 				return rip->retire_claim(false, "PREEMPT expression evaluated to True", CONDOR_HOLD_CODE::StartdPreemptExpression, 0);
 			}

--- a/src/condor_startd.V6/Resource.cpp
+++ b/src/condor_startd.V6/Resource.cpp
@@ -625,7 +625,7 @@ Resource::deactivate_claim( void )
 {
 	dprintf(D_ALWAYS, "Called deactivate_claim()\n");
 	if( state() == claimed_state ) {
-		return r_cur->deactivateClaim( true );
+		return r_cur->deactivateClaim( true, false, false );
 	}
 	return FALSE;
 }
@@ -636,11 +636,27 @@ Resource::deactivate_claim_forcibly( void )
 {
 	dprintf(D_ALWAYS, "Called deactivate_claim_forcibly()\n");
 	if( state() == claimed_state ) {
-		return r_cur->deactivateClaim( false );
+		return r_cur->deactivateClaim( false, false, false );
 	}
 	return FALSE;
 }
 
+int
+Resource::deactivate_claim_job_done( Stream* stream, bool claim_closing )
+{
+	dprintf(D_ALWAYS, "Called deactivate_claim_job_done()\n");
+	if( state() == claimed_state ) {
+		if (r_cur->deactivateClaim( false, true, claim_closing )) {
+			// a true return indicates that the claim is still active, so we
+			// stash the stream so we can delay the deactivate reply until after we reap the starter.
+			// Since we know the job is done, there is no point in killing the starter.
+			// It is either in the process of cleaning up already, or it is already exited but unreaped.
+			r_cur->setDeactivateStream(stream);
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
 
 void
 Resource::removeClaim( Claim* c )
@@ -1972,11 +1988,12 @@ Resource::preemptWasTrue() const
 }
 
 void
-Resource::preemptIsTrue()
+Resource::setPreemptIsTrue()
 {
-	if(r_cur) r_cur->preemptIsTrue();
+	if(r_cur) r_cur->setPreemptIsTrue();
 }
 
+#if 0
 bool
 Resource::curClaimIsClosing()
 {
@@ -1987,6 +2004,7 @@ Resource::curClaimIsClosing()
 		claimWorklifeExpired() ||
 		isDraining();
 }
+#endif
 
 bool
 Resource::isDraining()

--- a/src/condor_startd.V6/Resource.h
+++ b/src/condor_startd.V6/Resource.h
@@ -116,13 +116,18 @@ public:
 		// Quickly kill starter but keep claim
 	int		deactivate_claim_forcibly( void );
 
+		// Job is done, wait for starter to exit, keep the claim
+	int		deactivate_claim_job_done( Stream*, bool claim_closing );
+
 		// Tell the starter to put the job on hold
 	void hold_job(bool soft);
 
 	void setVacateReason(const std::string reason, int code, int subcode);
 
+#if 0
 		// True if no more jobs will be accepted on the current claim.
 	bool curClaimIsClosing();
+#endif
 
 		// True if this slot is draining
 	bool isDraining();
@@ -401,7 +406,7 @@ public:
 	bool    inRetirement( void );
 	int		hasPreemptingClaim( void );
 	int     preemptWasTrue( void ) const; //PREEMPT was true in current claim
-	void    preemptIsTrue();              //records that PREEMPT was true
+	void    setPreemptIsTrue();           //records that PREEMPT evaluated to True
 	const ExprTree * getDrainingExpr();
 
 	// methods that manipulate the Requirements attributes via the Reqexp struct

--- a/src/condor_startd.V6/Starter.h
+++ b/src/condor_startd.V6/Starter.h
@@ -48,6 +48,7 @@ public:
 	time_t	got_update(void) const {return s_last_update_time;}
 	bool	got_final_update(void) const {return s_got_final_update;}
 	int		has_pending_update() const { return s_job_update_sock ? s_job_update_sock->bytes_available_to_read() : -1; }
+	void	handle_pending_updates() { if (s_job_update_sock) receiveJobClassAdUpdate(s_job_update_sock); }
 	bool	signal(int);
 	bool	killfamily();
 	void	exited(Claim *, int status);
@@ -160,5 +161,6 @@ private:
 
 // living (or unreaped) starters live in a global data structure and can be looked up by PID.
 Starter *findStarterByPid(pid_t pid);
+size_t numLivingStarters();
 
 #endif /* _CONDOR_STARTD_STARTER_H */

--- a/src/condor_startd.V6/claim.cpp
+++ b/src/condor_startd.V6/claim.cpp
@@ -88,6 +88,7 @@ Claim::Claim( Resource* res_ip, ClaimType claim_type, int lease_duration )
 	, c_badput_caused_by_draining(false)
 	, c_badput_caused_by_preemption(false)
 	, c_schedd_closed_claim(false)
+	, c_schedd_reported_job_done(false)
 	, c_pledged_machine_max_vacate_time(0)
 	, c_cpus_usage(0)
 	, c_image_size(0)
@@ -146,6 +147,9 @@ Claim::~Claim()
 				resmgr->startd_stats.job_busy_time += busyTime;
 			}
 
+			// if we have a pending deactivate reply, send it now.
+			sendDeactivateReply();
+	
 			// Transfer ownership of our jobad to the starter so it can write a correct history entry.
 			starter->setOrphanedJob(c_jobad);
 			c_jobad = NULL;
@@ -163,6 +167,7 @@ Claim::~Claim()
 	}
 		// delete the request stream and do any necessary related cleanup
 	setRequestStream( NULL );
+	setDeactivateStream(nullptr); // we should never get here with an open socket, but just in case...
 
 	if( c_global_job_id ) { 
 		free( c_global_job_id );
@@ -1336,6 +1341,79 @@ Claim::requestClaimSockClosed(Stream *s)
 	return FALSE;
 }
 
+void
+Claim::setDeactivateStream(Stream* stream)
+{
+	if( c_deactivate_stream ) {
+		daemonCore->Cancel_Socket( c_deactivate_stream );
+		delete( c_deactivate_stream );
+	}
+	c_deactivate_stream = stream;
+
+	// register a callback if the deactivate reply sock is closed before we can reply
+	if( c_deactivate_stream ) {
+		std::string desc;
+		formatstr(desc, "deactivate claim %s", publicClaimId() );
+
+		int register_rc = daemonCore->Register_Socket(
+			c_deactivate_stream,
+			desc.c_str(),
+			(SocketHandlercpp)&Claim::deactivateClaimSockClosed,
+			"deactivateClaimSockClosed",
+			this );
+
+		if( register_rc < 0 ) {
+			dprintf(D_ALWAYS,
+				"Failed to register claim deactivate socket "
+				" to detect premature closure for claim %s.\n",
+				publicClaimId() );
+		}
+	}
+}
+
+int
+Claim::deactivateClaimSockClosed(Stream *s)
+{
+	dprintf( D_ALWAYS,
+		"Request claim socket closed prematurely for claim %s. "
+		"This probably means the schedd gave up.\n",
+		publicClaimId() );
+
+	ASSERT( s == c_deactivate_stream );
+	c_deactivate_stream = NULL; // socket will be closed when we return
+
+	return FALSE;
+}
+
+bool
+Claim::sendDeactivateReply()
+{
+	if (c_deactivate_stream) {
+
+		auto * stream = c_deactivate_stream;
+		stream->encode();
+
+		ClassAd response_ad;
+		response_ad.Assign(ATTR_START,c_may_reactivate);
+		bool success = true;
+		if( !putClassAd(stream, response_ad) || !stream->end_of_message() ) {
+			dprintf(D_FULLDEBUG,"Failed to send response ClassAd in deactivate_claim.\n");
+			success = false;
+		}
+		setDeactivateStream(nullptr);
+
+		if (c_rip && ep_eventlog.inEvent(ULOG_EP_DEACTIVATE_CLAIM, c_rip)) {
+			auto & ep_event = ep_eventlog.composeEvent(ULOG_EP_DEACTIVATE_CLAIM, c_rip);
+			ep_event.Ad().Assign("ReplyTime", _condor_debug_get_time_double());
+			ep_event.Ad().Assign("Success", success);
+			ep_eventlog.flush();
+		}
+
+		return success;
+	}
+	return false;
+}
+
 
 char*
 Claim::id( void )
@@ -1488,47 +1566,54 @@ pid_t Claim::spawnStarter( Starter* starter, ClassAd * job, Stream* s)
 void
 Claim::starterExited( Starter* starter, int status)
 {
-	bool orphanedJob = false;
+	int orphanedJob = 0;
 
 		// Notify our starter object that its starter exited, so it
 		// can cancel timers any pending timers, cleanup the starter's
 		// execute directory, and do any other cleanup. 
 		// note: null pointer check here is to make coverity happy, not because we think it possible for starter to be null.
 	if (starter) {
+
+		// if the update socket is still open, process all messages from it before we delete the starter object
+		int pending_update = starter->has_pending_update();
+		if (pending_update > 0) {
+			dprintf(D_ALWAYS, "Starter (pid=%d) is being reaped with %d pending job update message bytes\n",
+				starter->pid(), pending_update);
+			starter->handle_pending_updates();
+		}
+
+		// 
 		int tries = 3;
-		orphanedJob = true;
 		while (tries--) {
 			daemonCore->Kill_Family(starter->pid());
 			ProcFamilyUsage usage;
 			daemonCore->Snapshot();
 			daemonCore->Get_Family_Usage(starter->pid(), usage, true);
 
-			// If no procs remain, we are good
+			// report number of processes in the family if non-zero or it was previously non-zero
+			if (orphanedJob || usage.num_procs) {
+				dprintf(D_STATUS, "Startd has detected %d still-running processes under starter %d\n", usage.num_procs, starter->pid());
+			}
+			orphanedJob = usage.num_procs;
 			if (usage.num_procs == 0) {
-				orphanedJob = false;
+				// If no procs remain, we are good
 				break;
 			}
 			sleep(1); // Give a chance for init to reap
 		}
 
 		if (orphanedJob) {
-			// If any procs remain, they must be unkillable.  We'll mark the slot as broken
 			if (param_boolean("STARTD_LEFTOVER_PROCS_BREAK_SLOTS", false)) {
-				dprintf(D_ALWAYS, "Startd has detected still-running processes under starter %d, marking slots as broken\n", starter->pid());
+				dprintf(D_ERROR, "Slot will break because of %d still-running job processes\n", orphanedJob);
+				// If any procs remain, they must be unkillable.  We'll mark the slot as broken down below
 			} else {
-				dprintf(D_ALWAYS, "Startd has detected still-running processes under starter %d, not marking slots as broken\n", starter->pid());
-				orphanedJob = false;
+				// hope for the best.
+				orphanedJob = 0;
 			}
 		}
 
 		// Now that the starter is gone, we need to change our state
 		changeState( CLAIM_IDLE );
-
-		int pending_update = starter->has_pending_update();
-		if (pending_update > 0) {
-			dprintf(D_ALWAYS, "Starter (pid=%d) is being reaped with %d pending job update message bytes\n",
-					starter->pid(), pending_update);
-		}
 
 		starter->exited(this, status);
 		delete starter; starter = NULL;
@@ -1549,6 +1634,7 @@ Claim::starterExited( Starter* starter, int status)
 		dprintf(D_ALWAYS,"Adding to badput caused by draining: %ld cpu-seconds\n",badput);
 		resmgr->addToDrainingBadput( badput );
 	}
+
 
 	// save off the job ad (if any) so that resetClaim doesn't delete it before we know
 	// whether we want to save it because the slot resources are about to be broken
@@ -1609,11 +1695,11 @@ Claim::starterExited( Starter* starter, int status)
 		}
 
 		if ( ! c_rip->r_attr->is_broken()) {
-			dprintf(D_ALWAYS,"Starter exited with code: %d which is SlotBrokenCode=%d Reason=%s\n", WEXITSTATUS(status), code, reason);
+			dprintf(D_ERROR,"Starter exit code: %d which is SlotBrokenCode=%d Reason=%s\n", WEXITSTATUS(status), code, reason);
 			c_rip->r_attr->set_broken(code, reason);
 			auto & brit = c_rip->set_broken_context(c_client, job); // save client info, and give ownership of the job ad
 			if (ep_eventlog.isEnabled()) {
-				// write a RESOURCE_BREAK event
+				// write a RESOURCE_BREAK event reporting break reason and resources
 				auto & ep_event = ep_eventlog.composeEvent(ULOG_EP_RESOURCE_BREAK, c_rip);
 				ep_event.Ad().Assign("Code", code);
 				ep_event.Ad().Assign("Reason", reason);
@@ -1630,6 +1716,11 @@ Claim::starterExited( Starter* starter, int status)
 			c_rip->update_needed(Resource::WhyFor::wf_refreshRes);
 			resmgr->rip_update_needed(1<<Resource::WhyFor::wf_daemonAd);
 		}
+	}
+
+	// if there is pending reply to DEACTIVATE_CLAIM, send the reply now
+	if (sendDeactivateReply() && ! mayReactivate()) {
+		// TODO: do we need to change the slot state to reflect a closed claim here?
 	}
 
 		// Finally, let our resource know that our starter exited, so
@@ -1656,7 +1747,9 @@ Claim::starterPidMatches( pid_t starter_pid ) const
 bool
 Claim::isDeactivating( void )
 {
-	if( c_state == CLAIM_VACATING || c_state == CLAIM_KILLING ) {
+	if( c_state == CLAIM_VACATING || c_state == CLAIM_KILLING ||
+		// TODO: add a new Claim state while waiting to reap the starter on job completion
+		(c_schedd_reported_job_done && c_state == CLAIM_RUNNING)) {
 		return true;
 	}
 	return false;
@@ -1702,9 +1795,16 @@ Claim::isRunning( void )
 
 
 bool
-Claim::deactivateClaim( bool graceful )
+Claim::deactivateClaim( bool graceful, bool job_done, bool claim_closing )
 {
-	if( isActive() ) {
+	if (claim_closing) c_may_reactivate = false;
+	if (job_done) {
+		c_schedd_reported_job_done = true;
+		// TODO: add a Claim state for waiting to reap Starter
+		// changeState(CLAIM_KILLING);
+		return isActive();
+	}
+	if( isActive()) {
 		if( graceful ) {
 			starterHoldJob("Claim deactivated", CONDOR_HOLD_CODE::ClaimDeactivated, 0, true);
 		} else {
@@ -2156,6 +2256,7 @@ Claim::resetClaim( void )
 	c_may_unretire = true;
 	c_preempt_was_true = false;
 	c_badput_caused_by_draining = false;
+	c_schedd_reported_job_done = false;
 }
 
 

--- a/src/condor_startd.V6/cod_mgr.cpp
+++ b/src/condor_startd.V6/cod_mgr.cpp
@@ -200,6 +200,7 @@ int
 CODMgr::release( Stream* s, ClassAd* req, Claim* claim )
 {
 	VacateType vac_type = getVacateType( req );
+	bool job_done = false; // for now assume that job is not done already
 
 		// tell this claim we're trying to release it
 	claim->setPendingCmd( CA_RELEASE_CLAIM );
@@ -224,7 +225,7 @@ CODMgr::release( Stream* s, ClassAd* req, Claim* claim )
 			// clean up the claim when it's gone.  so, all we can do
 			// now is stash the Stream in the claim, and signal the
 			// starter as appropriate;
-		claim->deactivateClaim( vac_type == VACATE_GRACEFUL );
+		claim->deactivateClaim( vac_type == VACATE_GRACEFUL, job_done, false );
 		break;
 
 	case CLAIM_VACATING:
@@ -233,7 +234,7 @@ CODMgr::release( Stream* s, ClassAd* req, Claim* claim )
 			// now that we know to release this claim, there's nothing
 			// else to do except wait for the starter to exit.
 		if( vac_type == VACATE_FAST ) {
-			claim->deactivateClaim( false );
+			claim->deactivateClaim( false, job_done, false );
 		}
 		break;
 
@@ -340,6 +341,7 @@ CODMgr::deactivate( Stream* s, ClassAd* req, Claim* claim )
 {
 	std::string err_msg;
 	VacateType vac_type = getVacateType( req );
+	bool job_done = false;
 
 	claim->setPendingCmd( CA_DEACTIVATE_CLAIM );
 	claim->setRequestStream( s );
@@ -369,7 +371,7 @@ CODMgr::deactivate( Stream* s, ClassAd* req, Claim* claim )
 			// notify the other side when it's gone.  so, all we can
 			// do now is stash the Stream in the claim, and signal the
 			// starter as appropriate;
-		claim->deactivateClaim( vac_type == VACATE_GRACEFUL );
+		claim->deactivateClaim( vac_type == VACATE_GRACEFUL, job_done, false );
 		break;
 
 	case CLAIM_VACATING:
@@ -379,7 +381,7 @@ CODMgr::deactivate( Stream* s, ClassAd* req, Claim* claim )
 			// stream, there's nothing else to do except wait for the
 			// starter to exit.
 		if( vac_type == VACATE_FAST ) {
-			claim->deactivateClaim( false );
+			claim->deactivateClaim( false, job_done, false );
 		}
 		break;
 

--- a/src/condor_startd.V6/startd.h
+++ b/src/condor_startd.V6/startd.h
@@ -180,7 +180,7 @@ extern StartdEventLog ep_eventlog;
 #endif /* _STARTD_NO_DECLARE_GLOBALS */
 
 // Check to see if we're all free
-void	startd_check_free(int tid = -1);
+void	startd_exit_if_idle(int tid = -1);
 // so we can call this to reconfig on command
 void	main_config();
 

--- a/src/condor_startd.V6/startd_bench_job_mgr.cpp
+++ b/src/condor_startd.V6/startd_bench_job_mgr.cpp
@@ -211,7 +211,7 @@ StartdBenchJobMgr::BenchmarksFinished( void )
 	m_rip->benchmarks_finished( );
 	resmgr->update_all();
 	if ( m_shutting_down ) {
-		startd_check_free();
+		startd_exit_if_idle();
 	}
 	else if ( NULL != cron_job_mgr ) {
 		cron_job_mgr->ScheduleAllJobs();

--- a/src/condor_startd.V6/startd_cron_job_mgr.cpp
+++ b/src/condor_startd.V6/startd_cron_job_mgr.cpp
@@ -204,7 +204,7 @@ StartdCronJobMgr::JobExited( const CronJob &job )
 {
 	bool status = CronJobMgr::JobExited( job );
 	if ( m_shutting_down &&  IsAllIdle() ) {
-		startd_check_free();
+		startd_exit_if_idle();
 	}
 	if ( bench_job_mgr ) {
 		bench_job_mgr->ScheduleAllJobs();

--- a/src/condor_tests/test_fto_failure_propagation.py
+++ b/src/condor_tests/test_fto_failure_propagation.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env pytest
 
+#Configuration for personal condor. The test is sensitive to slot re-use
+# so we want the startd to have enough slots to start all jobs at once
+#testreq: personal
+"""<<CONDOR_TESTREQ_CONFIG
+    NUM_CPUS = 20
+"""
+#endtestreq
+
 import pytest
 from ornithology import *
 import classad2

--- a/src/condor_utils/condor_claimid_parser.h
+++ b/src/condor_utils/condor_claimid_parser.h
@@ -149,6 +149,25 @@ class ClaimIdParser {
 		*this = ClaimIdParser(new_claim_id.c_str());
 	}
 
+	// extract the version info from the session info
+	CondorVersionInfo secSessionInfoVersion()
+	{
+		int maj=0,min=0,sub=0;
+		// call secSessionInfo to force the m_session_info member to populate
+		if (secSessionInfo() && !m_session_info.empty()) {
+			// then we can look inside it to find the ShortVersion
+			auto ver = m_session_info.find("ShortVersion=\"");
+			if (ver != std::string::npos) {
+				const char * short_version = m_session_info.c_str() + ver + 14;
+				char *pos = NULL;
+				maj = strtol(short_version, &pos, 10);
+				min = (pos[0] == '.') ? strtol(pos+1, &pos, 10) : 0;
+				sub = (pos[0] == '.') ? strtol(pos+1, &pos, 10) : 0;
+			}
+		}
+		return {maj,min,sub};
+	}
+
  private:
 	std::string m_claim_id;
 	std::string m_public_part;


### PR DESCRIPTION
  instead of DEACTIVATE_CLAIM_FORCIBLY when it detects a startd version that understands it.
  The Startd will handle this command by delaying the deactivation reply until it has reaped the starter
  This fixes the Starter/Shadow/Startd race that was causing lost updates and also
  allows for the detection of slots broken by starter exit code before the deactivation reply.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
