### PR TITLE
(HTCONDOR-2790)  If we can't find a local file, don't not tell Condor.

### DIFF
--- a/docs/version-history/v23-version.hist
+++ b/docs/version-history/v23-version.hist
@@ -1,5 +1,19 @@
 *** 23.0.22 bugs
 
+- Fixed a bug where specifying ``transfer_output_remaps`` from a path
+  which didn't exist to a file:// URL would cause HTCondor to report a
+  useless (albeit correct) error.
+  :jira:`2790`
+
+- Fixed a bug that could cause the *condor_shadow* daemon to crash when
+  the job transfer input file list was very long (thousands of characters).
+  :jira:`2859`
+
+- Fixed a bug where two different *condor_gridmanager* processes could
+  attempt to manage the same jobs when :macro:`GRIDMANAGER_SELECTION_EXPR`
+  evaluated to *Undefined* or an empty string for any job.
+  :jira:`2895`
+
 - Fixed a rare bug in the *condor_schedd*, when
   :macro:`PER_JOB_HISTORY_DIR` is set that could cause
   a repeated restart loop.
@@ -12,10 +26,6 @@
   there were ARC CE jobs with no X509userproxy.
   :jira:`2907`
 
-- Fixed a bug that could cause the *condor_shadow* daemon to crash when
-  the job transfer input file list was very long (thousands of characters).
-  :jira:`2859`
-
 - Fixed a bug that could cause a job submission to fail if a previous
   job submission to the same *condor_schedd* failed.
   :jira:`2917`
@@ -27,11 +37,6 @@
 - Fixed a bug where daemons wouldn't immediately apply new security policy
   to incoming commands after a rconfig.
   :jira:`2929`
-
-- Fixed a bug where two different *condor_gridmanager* processes could
-  attempt to manage the same jobs when :macro:`GRIDMANAGER_SELECTION_EXPR`
-  evaluated to *Undefined* or an empty string for any job.
-  :jira:`2895`
 
 *** 23.0.21 bugs
 

--- a/src/condor_filetransfer_plugins/multifile_curl_plugin.h
+++ b/src/condor_filetransfer_plugins/multifile_curl_plugin.h
@@ -37,7 +37,7 @@ class MultiFileCurlPlugin {
     int UploadFile( const std::string &url, const std::string &local_file_name, const std::string &cred );
     int DownloadFile( const std::string &url, const std::string &local_file_name, const std::string &cred, long &partial_bytes );
     int BuildTransferRequests (const std::string & input_filename, std::vector<std::pair<std::string, transfer_request>> &requested_files) const;
-    FILE *OpenLocalFile (const std::string &local_file, const char *mode) const;
+    FILE *OpenLocalFile (const std::string &local_file, const char *mode, std::string & errorString) const;
 
         // Parse the job and machine ads (if present), looking for settings that control
         // the configuration of libcurl (such as setting timeouts) for this invocation.


### PR DESCRIPTION
An RCF noticed that when the local-file source for a URL transfer doesn't exist, the hold message is awful (because the curl plug-in doesn't generate valid output in that case).  This PR generates valid output in that case, causing a dramatic improvement in the hold message.

Arguably, HTCondor should check for file existence before asking a plug-in to work with it, but that's a much bigger ticket.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [x] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
