### PR TITLE
HTCONDOR-2997 Shadow shouldn't wait on dead starter

### DIFF
--- a/docs/version-history/v23-version.hist
+++ b/docs/version-history/v23-version.hist
@@ -1,5 +1,10 @@
 *** 23.0.24 bugs
 
+- Fixed a bug where the *condor_shadow* would wait for the job lease to
+  expire (usually 40 minutes) before returning a job to idle status when
+  the *condor_starter* failed to initialize.
+  :jira:`2997`
+
 *** 23.0.23 bugs
 
 - Fixed a bug where specifying ``transfer_output_remaps`` from a path


### PR DESCRIPTION
When the shadow learns on reconnect that the starter is gone, it shouldn't wait for the job lease to expire before exiting.
Also, don't try to decode a bogus job exit code when the starter exits before job completion.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
