### PR TITLE
HTCONDOR-2988 Robustify flakey tests

### DIFF
--- a/src/condor_tests/cmd_q_shows-name.run
+++ b/src/condor_tests/cmd_q_shows-name.run
@@ -49,20 +49,10 @@ my $collectorport = $condor_instance_local->GetCollectorAddress();
 my $localconfig = $condor_instance_local->GetCondorConfig();
 
 # where am I running
-my $currenthost = `condor_status -af Machine -limit 1`;
-chomp($currenthost);
+my $currenthost = CondorTest::getFqdnHost();
 
 my $primarycollector = $currenthost;
 $primarycollector = $primarycollector . ":" . $collectorport;
-
-#if($iswindows) {
-	#my @nameparts = split /\./, $currenthost;
-	#foreach my $name (@nameparts) {
-		#print "aadr:$name\n";
-	#}
-	#$currenthost = $nameparts[0];
-#}
-
 
 my $sheddoneappend_condor_config = '
 	SHARED_PORT_PORT = 0

--- a/src/condor_tests/cmd_q_shows-pool.run
+++ b/src/condor_tests/cmd_q_shows-pool.run
@@ -52,8 +52,7 @@ print "Fetched collector address with l->GetCollectorAddress(): yields  $collect
 my $localconfig = $condor_instance_local->GetCondorConfig();
 
 # where am I running
-my $currenthost = `condor_status -af Machine -limit 1`;
-chomp($currenthost);
+my $currenthost = CondorTest::getFqdnHost();
 
 if($iswindows) {
 	my @nameparts = split /\./, $currenthost;

--- a/src/condor_tests/job_local_resources.run
+++ b/src/condor_tests/job_local_resources.run
@@ -49,8 +49,7 @@ CondorTest::StartCondorWithParams(
 	condorlocalsrc => "$configfile",
 );
 
-my $host = `condor_status -af Machine -limit 1`;
-chomp($host);
+my $host = CondorTest::getFqdnHost();
 
 my $on_abort = sub {
 	CondorTest::debug("Abort from removing sleep 0 jobs.\n",1);


### PR DESCRIPTION
by replacing condor_status -af Machine with native perl code to get the hostname.  The former doesn't work when you query before the startd ad has made it to the collector.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
