### PR TITLE
HTCONDOR-2988 Hacky fix to test flakiness -- up timeout

### DIFF
--- a/src/condor_tests/test_fto_failure_propagation.py
+++ b/src/condor_tests/test_fto_failure_propagation.py
@@ -818,7 +818,7 @@ def test_check_details(test_info):
 @action
 def wait_for_job(test_job_handle, test_wait_condition):
     """Wait for test job based on specified wait condition"""
-    assert test_job_handle.wait(condition=test_wait_condition, timeout=30)
+    assert test_job_handle.wait(condition=test_wait_condition, timeout=300)
     return test_job_handle
 
 #--------------------------------------------------------------------------

--- a/src/condor_tests/test_fto_pipe_read_full.py
+++ b/src/condor_tests/test_fto_pipe_read_full.py
@@ -72,7 +72,7 @@ class TestFTOPipeFullRead:
         assert submit_job.wait(
             condition=ClusterState.all_complete,
             fail_condition=ClusterState.any_held,
-            timeout=90
+            timeout=300
         )
 
     def test_check_num_reads(self, shadow_log):


### PR DESCRIPTION
The root cause is that occasionally, the starter and shadow get out of sync on job exit, and the starter thinks the old job is still using the slot, and will not accept new activations.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
