### PR TITLE
HTCONDOR-2983: Remove pelican dependency for openSUSE

### DIFF
--- a/build/packaging/rpm/condor.spec
+++ b/build/packaging/rpm/condor.spec
@@ -272,17 +272,23 @@ Requires: systemd-libs
 Requires: rsync
 Requires: condor-upgrade-checks
 
-# Support OSDF client
-Requires: pelican >= 7.15.1
-Requires: pelican-osdf-compat >= 7.15.1
-
-# Require tested Apptainer
+# Dependencies on HTCondor tested packages (Apptainer and Pelican)
 %if 0%{?rhel} != 7
 %if 0%{?suse_version}
+# Require tested Apptainer
 # Unfortunately, openSUSE is lagging behind
 Requires: apptainer >= 1.3.6
+# Require tested Pelican packages
+# Unfortunately, the pelican package is not installable on openSUSE
+#     Pelican has a hard dependency on glibc-common,
+#     which does not exist in openSUSE leap 15
 %else
+# Require tested Apptainer
+# Hold back apptainer until version 1.4.1 is released
 Requires: apptainer >= 1.3.6
+# Require tested Pelican packages
+Requires: pelican >= 7.15.1
+Requires: pelican-osdf-compat >= 7.15.1
 %endif
 %endif
 


### PR DESCRIPTION
It turns out that the pelican rpm requires glibc-common and that is not available on openSUSE LEAP 15

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
