### PR TITLE
HTCONDOR-3059 Fix delay scheduling jobs that completed cool down

### DIFF
--- a/src/condor_schedd.V6/qmgmt.h
+++ b/src/condor_schedd.V6/qmgmt.h
@@ -546,7 +546,7 @@ bool UserCheck(const JobQueueBase *ad, const JobQueueUserRec * test_owner);
 bool UserCheck2(const JobQueueBase *ad, const JobQueueUserRec * test_owner, bool not_super=false);
 
 bool BuildPrioRecArray(bool no_match_found=false);
-void DirtyPrioRecArray();
+void DirtyPrioRecArray(int tid=-1);
 extern ClassAd *dollarDollarExpand(int cid, int pid, ClassAd *job, ClassAd *res, bool persist_expansions);
 bool rewriteSpooledJobAd(ClassAd *job_ad, int cluster, int proc, bool modify_ad);
 


### PR DESCRIPTION
Jobs that were in cool down state and are ready to be scheduled may still be ignored by the schedd.  This was because the PrioRecArray is not being marked as 'dirty' in the event a cool down time expires.  Fix this by simply setting a daemon core timer to mark the PrioRecArray as dirty; we can easily and cheaply figure out the time to use for this timer based upon the scan from our previous build of the PrioRecArray.

[HTCONDOR-3059](https://opensciencegrid.atlassian.net/browse/HTCONDOR-3059)

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
