### PR TITLE
(HTCONDOR-3073)  Remove inappropriate wait for reconnect

### DIFF
--- a/docs/version-history/v24-version.hist
+++ b/docs/version-history/v24-version.hist
@@ -10,6 +10,11 @@
 
 *** 24.9.0 bugs
 
+- Fixed a bug which could cause unnecessary activation failures if the previous
+  job in the slot failed to transfer its output.  This would manifest as slots
+  being in the claimed/idle state for far longer than necessary.
+  :jira:`3073`
+
 *** 24.0.9 bugs
 
 *** 24.8.0 features

--- a/src/condor_starter.V6.1/starter.cpp
+++ b/src/condor_starter.V6.1/starter.cpp
@@ -3186,11 +3186,11 @@ Starter::transferOutput( void )
 		}
 	}
 
-    // Try to transfer output (the failure files) even if we didn't succeed
-    // in job setup (e.g., transfer input files), but just ignore any
-    // output-transfer failures in the case of a setup failure; we can only
-    // really report one thing, and that should be the setup failure,
-    // which happens as a result of calling cleanupJobs().
+	// Try to transfer output (the failure files) even if we didn't succeed
+	// in job setup (e.g., transfer input files), but just ignore any
+	// output-transfer failures in the case of a setup failure; we can only
+	// really report one thing, and that should be the setup failure,
+	// which happens as a result of calling cleanupJobs().
 	if (jic->transferOutput(transient_failure) == false && m_setupStatus == 0) {
 
 		if( transient_failure ) {
@@ -3218,25 +3218,16 @@ Starter::transferOutput( void )
 			}
 		}
 
-		jic->transferOutputMopUp();
-
-			/*
-			  there was an error with the JIC in this step.  at this
-			  point, the only possible reason is if we're talking to a
-			  shadow and file transfer failed to send back the files.
-			  in this case, just return to DaemonCore and wait for
-			  other events (like the shadow reconnecting or the startd
-			  deciding the job lease expired and killing us)
-			*/
-		dprintf( D_ALWAYS, "JIC::transferOutput() failed, waiting for job "
-				 "lease to expire or for a reconnect attempt\n" );
-		return false;
-	}
+		// If we've lost the syscall socket at this point, there's no point
+		// in doing the output transfer mop-up, but the shadow might reconnect.
+		if( /* FIXME */ false ) {
+			dprintf( D_ALWAYS, "JIC::transferOutput() failed, waiting for job "
+			                 "lease to expire or for a reconnect attempt\n" );
+			return false;
+		}
+ 	}
 
 	jic->transferOutputMopUp();
-
-		// If we're here, the JIC successfully transfered output.
-		// We're ready to move on to the next cleanup stage.
 	return cleanupJobs();
 }
 

--- a/src/condor_tests/CMakeLists.txt
+++ b/src/condor_tests/CMakeLists.txt
@@ -362,6 +362,7 @@ endif()
 			condor_pl_test(test_dag_halt "Test DAGMan halt commands" "dagman;quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 			condor_pl_test(test_multiple_schemes "Test that multiple URL scheme results are reported properly" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 			condor_pl_test(test_input_file_check "Test the input checker" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
+			condor_pl_test(test_clean_output_failure "Test output transfer failure handling" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 
 			# These tests require Python 3.6 or later.
 			if (PYTHON3_VERSION_MINOR GREATER_EQUAL 6)

--- a/src/condor_tests/test_clean_output_failure.py
+++ b/src/condor_tests/test_clean_output_failure.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env pytest
+
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+from ornithology import (
+    action,
+    Condor,
+    ClusterState,
+    DaemonLog,
+)
+
+
+@action
+def the_condor(test_dir):
+    local_dir = test_dir / "condor"
+
+    with Condor(
+        local_dir=local_dir,
+        config={
+            "STARTD_DEBUG":     "D_SUB_SECOND D_CATEGORY D_FULLDEBUG",
+            "SHADOW_DEBUG":     "D_SUB_SECOND D_CATEGORY D_FULLDEBUG",
+            "STARTER_DEBUG":    "D_SUB_SECOND D_CATEGORY D_FULLDEBUG",
+        },
+    ) as condor:
+        yield condor
+
+
+@action
+def the_job_description(test_dir):
+    print("the_job_description(): enter")
+    (test_dir / "input.txt").write_text("aBcDeF 98765")
+
+    return {
+        "LeaveJobInQueue":              True,
+        "should_transfer_files":        True,
+        "when_to_transfer_output":      "ON_EXIT",
+        "transfer_input_files":         "input.txt",
+        "transfer_output_files":        "output.txt",
+
+        "output":                       test_dir / "the_job.out",
+        "error":                        test_dir / "the_job.err",
+        "log":                          test_dir / "the_job.log",
+
+        "shell":                        "cat input.txt"
+    }
+
+
+@action
+def the_job_handle(the_condor, the_job_description):
+    print("the_job_handle(): enter")
+    job_handle = the_condor.submit(
+        description=the_job_description,
+        count=1,
+    )
+
+    assert job_handle.wait(
+        timeout=60,
+        condition = ClusterState.all_held,
+    )
+
+    yield job_handle
+
+    job_handle.remove()
+
+
+class TestOutputFailure:
+
+    def test_shadow_log(self, the_job_handle, the_condor):
+        shadow_log = the_condor.shadow_log.open()
+        lines = list(filter(
+            lambda line: 'condor_read(): timeout reading' in line,
+            shadow_log.read(),
+        ))
+        assert len(lines) == 0
+
+
+    def test_starter_log(self, the_job_handle, the_condor, test_dir):
+        # See test_guidance_commands for how to make this reliable
+        # in the presence of multiple jobs.
+        starter_log_path= test_dir / "condor" / "log" / f"StarterLog.slot1_1"
+        starter_log = DaemonLog(starter_log_path).open()
+
+        lines = list(filter(
+            lambda line: 'Connection to shadow may be lost' in line,
+            starter_log.read(),
+        ))
+        assert len(lines) == 0


### PR DESCRIPTION
Previously, the starter would unconditionally wait a shadow reconnect (or job lease expiration) if transferring output failed for any reason.  This did not cause problems because the starter had already called `notifyStarterError(critical=True)` during the output "clean up"; this caused the shadow to send a `DEACTIVATE_CLAIM_JOB_DONE` command to the startd, which in turn shut down the starter.

Currently, the startd does _not_ shut down the starter after getting that command; it believes it is keeping the slot claimed during clean-up.

This PR changes the starter in two ways:
1.  `JICShadow::notifyStarterError()` will now, when critical is true, also close the syscall socket and set `fast_exit` to true.  This combination will cause it to actually exit as intended.  (In particular, the syscall socket will be closed before REMOTE_CONDOR_job_exit() is called, which both save us a semantic change and prevents the starter from blocking on the shadow blocking on the starter exiting.)
2. `Starter::transferOutput()` will now unconditionally proceed to exit when output transfer fails.  There's a spot in the patch for a check to see if the starter should wait for a reconnect instead, but it's inactive; we should think if we want to bother to fix this now, or just roll it into the upcoming guidance changes implied by sequential common file re-use.

This PR adds a smoke test.  It happens to work for the particular case that it engineers, but isn't particularly general; its real value is that if shuts down quickly, then the starter is not in a bad state.  I'll let the reviewer decide if it warrants inclusion in the test suite.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
