### PR TITLE
HTCONDOR-3087 Modernize the c++ and data structure choices for PrioRec

### DIFF
--- a/src/condor_includes/condor_debug.h
+++ b/src/condor_includes/condor_debug.h
@@ -68,7 +68,7 @@ enum {
    D_TEST,  // messages with this category are parsed by various tests.
    D_STATS,       // tcp STATS for file transfer, used by the C_GAHP
    D_MATERIALIZE, // materialization of jobs in the schedd
-   D_BUG,   // messages that indicate the daemon is going down.
+   D_DYE,   // messages that indicate the daemon is going down.
 
    // NOTE: can't go beyond 31 categories so long as DebugOutputChoice is just an unsigned int.
 

--- a/src/condor_schedd.V6/dedicated_scheduler.cpp
+++ b/src/condor_schedd.V6/dedicated_scheduler.cpp
@@ -770,17 +770,12 @@ DedicatedScheduler::negotiate( int command, Sock* sock, char const* remote_pool 
 		// Now, we've just got to handle the per-job negotiation
 		// protocol itself.
 
+	// create a ResourceRequestList with one entry for each job
+	// using a fake autocluster id for each entry. 
 	auto *requests = new ResourceRequestList;
 	int next_cluster = 0;
-	std::list<PROC_ID>::iterator id;
-
-	for( id = resource_requests.begin();
-		 id != resource_requests.end();
-		 id++ )
-	{
-		auto *cluster = new ResourceRequestCluster( ++next_cluster );
-		requests->push_back( cluster );
-		cluster->addJob( *(id) );
+	for (auto & jid : resource_requests) {
+		requests->add(++next_cluster, jid);
 	}
 
 	classy_counted_ptr<DedicatedScheddNegotiate> neg_handler =
@@ -3260,7 +3255,7 @@ DedicatedScheduler::AddMrec(
 		// Note, we want to claim this startd as the
 		// "DedicatedScheduler" owner, which is why we call
 		// owner() here...
-	auto *mrec = new match_rec( claim_id, startd_addr, &empty_job_id,
+	auto *mrec = new match_rec( claim_id, startd_addr, empty_job_id,
 									 match_ad,owner(),remote_pool,true);
 
 	// Next, insert this match_rec into our hashtables
@@ -4142,7 +4137,7 @@ DedicatedScheduler::checkReconnectQueue( int /* timerID */ ) {
 			dprintf(D_FULLDEBUG, "Dedicated Scheduler:: reconnect target address is %s; claim is %s\n", sinful, cid.publicClaimId());
 
 			auto *mrec = 
-				new match_rec(claim, sinful, &id,
+				new match_rec(claim, sinful, id,
 						  machineAd, owner(), nullptr, true);
 
 			mrec->setStatus(M_CLAIMED);

--- a/src/condor_schedd.V6/pccc.cpp
+++ b/src/condor_schedd.V6/pccc.cpp
@@ -481,7 +481,7 @@ pcccStopCallback::dcMessageCallback( DCMsgCallback * cb ) {
 			// We ignore the remote pool attribute because we've
 			// already checked if the job is running.
 			match_rec * coalescedMatch = scheduler.AddMrec(
-				claimID.c_str(), startd.addr(), & nowJob,
+				claimID.c_str(), startd.addr(), nowJob,
 				& slotAd, owner.c_str(), NULL
 			);
 			if(! coalescedMatch) {
@@ -556,23 +556,23 @@ int accounting_single( PROC_ID nowJob ) {
 	ClassAd matchAd;
 
 	jobID = PROC_ID( ++clusterID, 0 );
-	match_rec * matchA = scheduler.AddMrec( "A", "peerA", & jobID, & matchAd, "tlmiller", NULL );
+	match_rec * matchA = scheduler.AddMrec( "A", "peerA", jobID, & matchAd, "tlmiller", NULL );
 	jobID = PROC_ID( ++clusterID, 0 );
-	match_rec * matchB = scheduler.AddMrec( "B", "peerB", & jobID, & matchAd, "tlmiller", NULL );
+	match_rec * matchB = scheduler.AddMrec( "B", "peerB", jobID, & matchAd, "tlmiller", NULL );
 	jobID = PROC_ID( ++clusterID, 0 );
-	match_rec * matchC = scheduler.AddMrec( "C", "peerC", & jobID, & matchAd, "tlmiller", NULL );
+	match_rec * matchC = scheduler.AddMrec( "C", "peerC", jobID, & matchAd, "tlmiller", NULL );
 	jobID = PROC_ID( ++clusterID, 0 );
-	match_rec * matchD = scheduler.AddMrec( "D", "peerD", & jobID, & matchAd, "tlmiller", NULL );
+	match_rec * matchD = scheduler.AddMrec( "D", "peerD", jobID, & matchAd, "tlmiller", NULL );
 	jobID = PROC_ID( ++clusterID, 0 );
-	match_rec * matchE = scheduler.AddMrec( "E", "peerE", & jobID, & matchAd, "tlmiller", NULL );
+	match_rec * matchE = scheduler.AddMrec( "E", "peerE", jobID, & matchAd, "tlmiller", NULL );
 	jobID = PROC_ID( ++clusterID, 0 );
-	match_rec * matchF = scheduler.AddMrec( "F", "peerF", & jobID, & matchAd, "tlmiller", NULL );
+	match_rec * matchF = scheduler.AddMrec( "F", "peerF", jobID, & matchAd, "tlmiller", NULL );
 	jobID = PROC_ID( ++clusterID, 0 );
-	match_rec * matchG = scheduler.AddMrec( "G", "peerG", & jobID, & matchAd, "tlmiller", NULL );
+	match_rec * matchG = scheduler.AddMrec( "G", "peerG", jobID, & matchAd, "tlmiller", NULL );
 	jobID = PROC_ID( ++clusterID, 0 );
-	match_rec * matchH = scheduler.AddMrec( "H", "peerH", & jobID, & matchAd, "tlmiller", NULL );
+	match_rec * matchH = scheduler.AddMrec( "H", "peerH", jobID, & matchAd, "tlmiller", NULL );
 	jobID = PROC_ID( ++clusterID, 0 );
-	match_rec * matchI = scheduler.AddMrec( "I", "peerI", & jobID, & matchAd, "tlmiller", NULL );
+	match_rec * matchI = scheduler.AddMrec( "I", "peerI", jobID, & matchAd, "tlmiller", NULL );
 
 	if(! pcccNew( nowJob ) ) { return __LINE__; }
 	if(! pcccSatisfied( nowJob )) { return __LINE__; }
@@ -627,11 +627,11 @@ int accounting_multiple( PROC_ID jobA, PROC_ID jobB, PROC_ID jobC ) {
 	ClassAd matchAd;
 
 	jobID = PROC_ID( ++clusterID, 0 );
-	match_rec * matchA = scheduler.AddMrec( "A", "peerA", & jobA, & matchAd, "tlmiller", NULL );
+	match_rec * matchA = scheduler.AddMrec( "A", "peerA", jobA, & matchAd, "tlmiller", NULL );
 	jobID = PROC_ID( ++clusterID, 0 );
-	match_rec * matchB = scheduler.AddMrec( "B", "peerB", & jobB, & matchAd, "tlmiller", NULL );
+	match_rec * matchB = scheduler.AddMrec( "B", "peerB", jobB, & matchAd, "tlmiller", NULL );
 	jobID = PROC_ID( ++clusterID, 0 );
-	match_rec * matchC = scheduler.AddMrec( "C", "peerC", & jobC, & matchAd, "tlmiller", NULL );
+	match_rec * matchC = scheduler.AddMrec( "C", "peerC", jobC, & matchAd, "tlmiller", NULL );
 
 	if(! pcccNew( jobA )) { return __LINE__; }
 	if(! pcccNew( jobB )) { return __LINE__; }

--- a/src/condor_schedd.V6/prio_rec.h
+++ b/src/condor_schedd.V6/prio_rec.h
@@ -26,36 +26,64 @@
 #ifndef _PRIO_REC_H_
 #define _PRIO_REC_H_
 
-const 	int		INITIAL_MAX_PRIO_REC = 2048;
+#include <deque>
 
 /* this record contains all the parameters required for
  * assigning priorities to all jobs */
 
 class prio_rec {
 public:
-    PROC_ID     id;
-    int         pre_job_prio1;
-    int         pre_job_prio2;
-    int         post_job_prio1;
-    int         post_job_prio2;
-    int         job_prio;
-	int			auto_cluster_id;
+	PROC_ID     id{0,0};
+	int         pre_job_prio1{0};
+	int         pre_job_prio2{0};
+	int         post_job_prio1{0};
+	int         post_job_prio2{0};
+	int         job_prio{0};
+	int         auto_cluster_id{0};
 	std::string submitter;
-	bool		not_runnable;
-	bool		matched;
+	bool        not_runnable{false};
+	bool        matched{false};
+};
 
-	prio_rec() {
-		id.cluster = 0;
-		id.proc = 0;
-		job_prio = 0;
-		auto_cluster_id = 0;
-		pre_job_prio1 = 0;
-		pre_job_prio2 = 0;
-		post_job_prio1 = 0;
-		post_job_prio2 = 0;
-		not_runnable = false;
-		matched = false;
+// prio rec lower bound by submitter
+// This allows us to binary search the PrioRecArray by submitter
+// Note this must match the primary key comparison in struct prio_compar (in qmgmt.cpp)
+struct prio_rec_submitter_lb {
+	bool operator()(const prio_rec& a, const std::string &user) const {
+		if (a.submitter.length() < user.length()) {
+			return false;
+		}
+
+		if (a.submitter.length() > user.length()) {
+			return true;
+		}
+
+		if (a.submitter > user) {
+			return true;
+		}
+
+		return false;
 	}
 };
+
+// The corresponding upper bound function, the negation of the above
+struct prio_rec_submitter_ub {
+	bool operator()(const std::string &user, const prio_rec &a) const {
+		if (a.submitter.length() < user.length()) {
+			return true;
+		}
+
+		if (a.submitter.length() > user.length()) {
+			return false;
+		}
+
+		if (a.submitter < user) {
+			return true;
+		}
+
+		return false;
+	}
+};
+
 
 #endif

--- a/src/condor_schedd.V6/qmgmt.cpp
+++ b/src/condor_schedd.V6/qmgmt.cpp
@@ -242,6 +242,7 @@ typedef _condor_auto_accum_runtime< stats_entry_probe<double> > condor_auto_runt
 schedd_runtime_probe WalkJobQ_runtime;
 schedd_runtime_probe WalkJobQ_mark_idle_runtime;
 schedd_runtime_probe WalkJobQ_get_job_prio_runtime;
+schedd_runtime_probe WalkJobQ_update_autocluster_id_runtime;
 
 class Service;
 
@@ -251,13 +252,14 @@ const double PrioRecRebuildMaxTimeSlice = 0.05;
 const double PrioRecRebuildMaxTimeSliceWhenNoMatchFound = 0.1;
 const double PrioRecRebuildMaxInterval = 20 * 60;
 Timeslice   PrioRecArrayTimeslice;
-prio_rec	PrioRecArray[INITIAL_MAX_PRIO_REC];
-prio_rec	* PrioRec = &PrioRecArray[0];
-int			N_PrioRecs = 0;
+#ifdef PRIO_REC_IS_VECTOR
+ std::vector<prio_rec> PrioRec;
+#else
+ std::deque<prio_rec> PrioRec;
+#endif
 std::map<int,int> PrioRecAutoClusterRejected;
 int BuildPrioRecArrayTid = -1;
 
-static int 	MAX_PRIO_REC=INITIAL_MAX_PRIO_REC ;	// INITIAL_MAX_* in prio_rec.h
 
 JOB_ID_KEY_BUF HeaderKey(0,0);
 
@@ -387,45 +389,6 @@ bool operator()(const prio_rec& a, const prio_rec& b) const
 }
 };
 
-// Return the same comparison as above, but just comparing the submitter
-// field.  This allows us to binary search the PrioRecArray by submitter
-// Note the comparison up to the submitter must match the above
-struct prio_rec_submitter_lb {
-bool operator()(const prio_rec& a, const std::string &user) const {
-	if (a.submitter.length() < user.length()) {
-		return false;
-	}
-
-	if (a.submitter.length() > user.length()) {
-		return true;
-	}
-
-	if (a.submitter > user) {
-		return true;
-	}
-
-	return false;
-}
-};
-
-// The corresponding upper bound function, the negation of the above
-struct prio_rec_submitter_ub {
-bool operator()(const std::string &user, const prio_rec &a) const {
-	if (a.submitter.length() < user.length()) {
-		return true;
-	}
-
-	if (a.submitter.length() > user.length()) {
-		return false;
-	}
-
-	if (a.submitter < user) {
-		return true;
-	}
-
-	return false;
-}
-};
 
 int
 SetPrivateAttributeString(int cluster_id, int proc_id, const char *attr_name, const char *attr_value)
@@ -1763,11 +1726,23 @@ JobQueueCluster::~JobQueueCluster()
 
 bool JobQueueJob::IsNoopJob()
 {
+#if 1
+	if (run == JobRunnableState::DirtyNoop) {
+		bool noop = false;
+		if (this->LookupBool(ATTR_JOB_NOOP, noop) && noop) {
+			run = JobRunnableState::Noop;
+		} else {
+			run = JobRunnableState::Unset;
+		}
+	}
+	return run == JobRunnableState::Noop;
+#else
 	if ( ! has_noop_attr) return false;
 	bool noop = false;
 	if ( ! this->LookupBool(ATTR_JOB_NOOP, noop)) { has_noop_attr = false; }
 	else { has_noop_attr = true; }
 	return has_noop_attr && noop;
+#endif
 }
 
 void JobQueueBase::CheckJidAndType(const JOB_ID_KEY &key)
@@ -2996,41 +2971,20 @@ int QmgmtHandleSetJobFactory(int cluster_id, const char* filename, const char * 
 	return rval;
 }
 
-
 int
 grow_prio_recs( int newsize )
 {
-	int i = 0;
-	prio_rec *tmp = nullptr;
-
-	// just return if PrioRec already equal/larger than the size requested
-	if ( MAX_PRIO_REC >= newsize ) {
-		return 0;
+  #ifdef PRIO_REC_IS_VECTOR
+	if (new_size > (int)PrioRec.capacity()) {
+		PrioRec.reserve(new_size);
 	}
-
 	dprintf(D_FULLDEBUG,"Dynamically growing PrioRec to %d\n",newsize);
-
-	tmp = new prio_rec[(unsigned int)newsize];
-	if ( tmp == nullptr ) {
-		EXCEPT( "grow_prio_recs: out of memory" );
-	}
-
-	/* copy old PrioRecs over */
-	for (i=0;i<N_PrioRecs;i++)
-		tmp[i] = PrioRec[i];
-
-	/* delete old too-small space, but only if we new-ed it; the
-	 * first space came from the heap, so check and don't try to 
-	 * delete that */
-	if ( &PrioRec[0] != &PrioRecArray[0] )
-		delete [] PrioRec;
-
-	/* replace with spanky new big one */
-	PrioRec = tmp;
-	MAX_PRIO_REC = newsize;
+  #else
+	// no need to grow a std::deque
+	(void)newsize;
+  #endif
 	return 0;
 }
-
 
 // test an unqualified username "bob" or a fully qualfied username "bob@domain" to see
 // if it is a queue superuser
@@ -8528,7 +8482,6 @@ schedd_runtime_probe GetAutoCluster_cchit_runtime;
 double last_autocluster_runtime;
 bool   last_autocluster_make_sig;
 int    last_autocluster_type=0;
-int    last_autocluster_classad_cache_hit=0;
 stats_entry_abs<int> SCGetAutoClusterType;
 
 int get_job_prio(JobQueueJob *job, const JOB_ID_KEY & jid, void *)
@@ -8538,47 +8491,34 @@ int get_job_prio(JobQueueJob *job, const JOB_ID_KEY & jid, void *)
             pre_job_prio2 = 0, 
             post_job_prio1 = 0, 
             post_job_prio2 = 0;
-    char    owner[100];
-	const char* dummy = nullptr;
 
 	ASSERT(job);
 
-	owner[0] = 0;
-
-		// We must call getAutoClusterid() in get_job_prio!!!  We CANNOT
-		// return from this function before we call getAutoClusterid(), so call
-		// it early on (before any returns) right now.  The reason for this is
-		// getAutoClusterid() performs a mark/sweep algorithm to garbage collect
-		// old autocluster information.  If we fail to call getAutoClusterid, the
-		// autocluster information for this job will be removed, causing the schedd
-		// to ASSERT later on in the autocluster code. 
-		// Quesitons?  Ask Todd <tannenba@cs.wisc.edu> 01/04
-	last_autocluster_runtime = 0;
-	last_autocluster_classad_cache_hit = 1;
-	last_autocluster_make_sig = false;
-
-	int auto_id = scheduler.autocluster.getAutoClusterid(job);
-	job->autocluster_id = auto_id;
-
-	GetAutoCluster_runtime += last_autocluster_runtime;
-	if (last_autocluster_make_sig) { GetAutoCluster_signature_runtime += last_autocluster_runtime; }
-	else { GetAutoCluster_hit_runtime += last_autocluster_runtime; }
-	SCGetAutoClusterType = last_autocluster_type;
-	GetAutoCluster_cchit_runtime += last_autocluster_classad_cache_hit;
-
-	GetAutoCluster_runtime += last_autocluster_runtime;
-	if (last_autocluster_make_sig) { GetAutoCluster_signature_runtime += last_autocluster_runtime; }
-	else { GetAutoCluster_hit_runtime += last_autocluster_runtime; }
-	SCGetAutoClusterType = last_autocluster_type;
-	GetAutoCluster_cchit_runtime += last_autocluster_classad_cache_hit;
-
-	// Figure out if we should contine and put this job into the PrioRec array
-	// or not.
-	if ( ! Runnable(job, dummy) ||
-			scheduler.AlreadyMatched(job, job->Universe()))
-	{
+#if 0
+	// skip this job, it is not runnable
+	// TODO: maybe put cooldown jobs in PrioRec array?
+	if (job->run != JobRunnableState::Runnable) {
 		return 0;
 	}
+#else
+	// TODO: trust that the job->run code is already up-to-date here....
+	// Figure out if we should contine and put this job into the PrioRec array
+	// or not. 
+	runnable_reason_code code;
+	if ( ! Runnable(job, code)) {
+		job->run = JobRunnableState::NotRunnable;
+		if (code == runnable_reason_code::IsNoopJob) {
+			job->run = JobRunnableState::Noop;
+		}
+		return 0;
+	} else {
+		job->run = JobRunnableState::Runnable;
+		if (scheduler.AlreadyMatched(job, job->Universe())) {
+			job->run = JobRunnableState::Matched;
+			return 0;
+		}
+	}
+#endif
 
 	// --- Insert this job into the PrioRec array ---
 
@@ -8600,6 +8540,20 @@ int get_job_prio(JobQueueJob *job, const JOB_ID_KEY & jid, void *)
 
     job->LookupInteger(ATTR_JOB_PRIO, job_prio);
 
+#if 0
+	// the name in the the submitterdata should be the same
+	// as the name we get got with the old code.  Note that
+	// we may be forcing a submitter record to be created here
+	scheduler.get_submitter(job);
+	if ( ! job->submitterdata) {
+		dprintf(D_ERROR, "job %d.%d is marked runnable but submitterdata is not set!", jid.cluster, jid.proc);
+		return 0;
+	}
+	const char * powner = job->submitterdata->Name();
+#else
+	// TODO: use scheduler.get_submitter code above instead of this..
+	char    owner[100];
+	owner[0] = 0;
 	char * powner = owner;
 	int cremain = sizeof(owner);
 		// Note, we should use this method instead of just looking up
@@ -8627,30 +8581,89 @@ int get_job_prio(JobQueueJob *job, const JOB_ID_KEY & jid, void *)
 			strncat(powner, accounting_domain.c_str(), cremain);
 		}
 	}
+#endif
 
-    PrioRec[N_PrioRecs].id             = jid;
-    PrioRec[N_PrioRecs].job_prio       = job_prio;
-    PrioRec[N_PrioRecs].pre_job_prio1  = pre_job_prio1;
-    PrioRec[N_PrioRecs].pre_job_prio2  = pre_job_prio2;
-    PrioRec[N_PrioRecs].post_job_prio1 = post_job_prio1;
-    PrioRec[N_PrioRecs].post_job_prio2 = post_job_prio2;
-    PrioRec[N_PrioRecs].not_runnable   = false;
-    PrioRec[N_PrioRecs].matched        = false;
-	if ( auto_id == -1 ) {
-		PrioRec[N_PrioRecs].auto_cluster_id = jid.cluster;
+	auto & rec = PrioRec.emplace_back();
+	rec.submitter      = powner;
+	rec.id             = jid;
+	rec.job_prio       = job_prio;
+	rec.pre_job_prio1  = pre_job_prio1;
+	rec.pre_job_prio2  = pre_job_prio2;
+	rec.post_job_prio1 = post_job_prio1;
+	rec.post_job_prio2 = post_job_prio2;
+	rec.not_runnable   = false;
+	rec.matched        = false;
+	if (job->autocluster_id < 0) {
+		rec.auto_cluster_id = jid.cluster;
 	} else {
-		PrioRec[N_PrioRecs].auto_cluster_id = auto_id;
-	}
-
-	PrioRec[N_PrioRecs].submitter = powner;
-
-    N_PrioRecs += 1;
-	if ( N_PrioRecs == MAX_PRIO_REC ) {
-		grow_prio_recs( 2 * N_PrioRecs );
+		rec.auto_cluster_id = job->autocluster_id;
 	}
 
 	return 0;
 }
+
+// map the reason code return from Runnable() to a JobQueueJob JobRunnableState code
+static JobRunnableState mapRunnableReasonCode(runnable_reason_code code)
+{
+	static const JobRunnableState aState[]{
+		JobRunnableState::Runnable,    //IsRunnable=0,
+		JobRunnableState::NotRunnable, //NotFound,
+		JobRunnableState::Noop,        //IsNoopJob,
+		JobRunnableState::NotRunnable, //NotIdle,
+		JobRunnableState::NotRunnable, //UniverseNotInService,
+		JobRunnableState::NotRunnable, //InLongCooldown,
+		JobRunnableState::Cooldown,    //InShortCooldown,
+		JobRunnableState::Matched,     //AlreadyMatched,
+	};
+	ASSERT((size_t)code >= 0 && (size_t)code < COUNTOF(aState));
+	return aState[(size_t)code];
+}
+
+struct _get_job_prio_info { int num_runnable{0}; int num_cooldown{0}; int num_matched{0}; int num_skipped{0}; };
+
+int update_autocluster_id(JobQueueJob *job, const JOB_ID_KEY & /*jid*/, void * pv)
+{
+	struct _get_job_prio_info & info = *(struct _get_job_prio_info*)pv;
+
+	// getAutoClusterid() performs a mark/sweep algorithm to garbage collect
+	// old autocluster information.  If we fail to call getAutoClusterid, the
+	// autocluster information for this job will be removed, causing the schedd
+	// to ASSERT later on in the autocluster code. 
+	// Quesitons?  Ask Todd <tannenba@cs.wisc.edu> 01/04
+	last_autocluster_runtime = 0;
+	last_autocluster_make_sig = false;
+
+	int auto_id = scheduler.autocluster.getAutoClusterid(job);
+	job->autocluster_id = auto_id;
+
+	GetAutoCluster_runtime += last_autocluster_runtime;
+	if (last_autocluster_make_sig) { GetAutoCluster_signature_runtime += last_autocluster_runtime; }
+	else { GetAutoCluster_hit_runtime += last_autocluster_runtime; }
+	SCGetAutoClusterType = last_autocluster_type;
+
+	// Figure out if we should put this job into the PrioRec array
+	// or not, only jobs that end up in state Runnable will go into the prio rec array
+	// todo maybe also put short cooldown jobs in the array?
+	runnable_reason_code code;
+	if ( ! Runnable(job, code)) {
+		job->run = mapRunnableReasonCode(code);
+		++info.num_skipped;
+		if (code == runnable_reason_code::InShortCooldown) { ++info.num_cooldown; }
+	} else {
+		// assume runnable, but we still need to check to see if we have a match record already
+		job->run = JobRunnableState::Runnable;
+		if (scheduler.AlreadyMatched(job, job->Universe())) {
+			job->run = JobRunnableState::Matched;
+			++info.num_matched;
+			++info.num_skipped;
+		} else {
+			++info.num_runnable;
+		}
+	}
+
+	return 0;
+}
+
 
 bool
 jobLeaseIsValid( ClassAd* job, int cluster, int proc )
@@ -9056,15 +9069,17 @@ static void DoBuildPrioRecArray() {
 	scheduler.autocluster.mark();
 	BuildPrioRec_mark_runtime += rt.tick(now);
 
-	N_PrioRecs = 0;
+	PrioRec.clear();
+	struct _get_job_prio_info info;
+	WalkJobQueue2(update_autocluster_id, &info);
+	grow_prio_recs(info.num_runnable + info.num_cooldown + 5); // +5 because ToddT sez so...
 	WalkJobQueue(get_job_prio);
 	BuildPrioRec_walk_runtime += rt.tick(now);
 
 		// N_PrioRecs might be 0, if we have no jobs to run at the
 		// moment. 
-	if( N_PrioRecs ) {
-		std::sort(PrioRec, PrioRec + N_PrioRecs, prio_compar{});
-		BuildPrioRec_sort_runtime += rt.tick(now);
+	if ( ! PrioRec.empty()) {
+		std::sort(PrioRec.begin(), PrioRec.end(), prio_compar{});
 	}
 
 	scheduler.autocluster.sweep();
@@ -9172,7 +9187,8 @@ bool UniverseUsesVanillaStartExpr(int universe)
 void FindRunnableJob(PROC_ID & jobid, ClassAd* my_match_ad, 
 					 char const * user)
 {
-	JobQueueJob *ad = nullptr;
+	JobQueueJob *job = nullptr;
+	runnable_reason_code runnable_code;
 
 	if (user && (strlen(user) == 0)) {
 		user = nullptr;
@@ -9227,23 +9243,23 @@ void FindRunnableJob(PROC_ID & jobid, ClassAd* my_match_ad,
 	std::string user_str = user ? user : "";
 
 	do {
-		prio_rec *first = &PrioRec[0];
-		prio_rec *end = &PrioRec[N_PrioRecs];
+		auto first = PrioRec.begin();
+		auto end = PrioRec.end();
 
 		if (!match_any_user) {
 			first = std::lower_bound(first, end, user_str, prio_rec_submitter_lb{});
 			end = std::upper_bound(first, end, user_str, prio_rec_submitter_ub{});
 		}
 
-		for (prio_rec *p = first; p != end; p++) {
+		for (auto p = first; p != end; p++) {
 			if ( p->not_runnable || p->matched ) {
 					// This record has been disabled, because it is no longer
 					// runnable or already matched.
 				continue;
 			}
 
-			ad = GetJobAd( p->id.cluster, p->id.proc );
-			if (!ad) {
+			job = GetJobAd(p->id);
+			if ( ! job) {
 					// This ad must have been deleted since we last built
 					// runnable job list.
 				continue;
@@ -9255,31 +9271,37 @@ void FindRunnableJob(PROC_ID & jobid, ClassAd* my_match_ad,
 				continue;
 			}
 
-			if (scheduler.AlreadyMatched(&p->id)) {
+			if (scheduler.AlreadyMatched(job, job->Universe())) {
 				p->matched = true;
+				runnable_code = runnable_reason_code::AlreadyMatched;
 			}
-			if (!Runnable(&p->id)) {
+			else if ( ! Runnable(job, runnable_code)) {
+				// TODO: special case for cooldown here??
 				p->not_runnable = true;
 			}
-			if (p->matched || p->not_runnable) {
+
+			if (runnable_code != runnable_reason_code::IsRunnable) {
 					// This job's status must have changed since the
 					// time it was added to the runnable job list.
 					// The not_runnable and matched flags will prevent
 					// this job from being considered in any
 					// future iterations through the list.
-				dprintf(D_FULLDEBUG,
-						"record for job %d.%d skipped until PrioRec rebuild (%s)\n",
-						p->id.cluster, p->id.proc, p->matched ? "already matched" : "no longer runnable");
+				const char * reason = getRunnableReason(runnable_code);
+				dprintf(D_FULLDEBUG, "record for job %d.%d skipped until PrioRec rebuild - %s\n",
+					job->jid.cluster, job->jid.proc, reason);
 
 					// Move along to the next job in the prio rec array
 				continue;
 			}
 
+			dprintf (D_FULLDEBUG, "Job %d.%d: is runnable\n", job->jid.cluster, job->jid.proc);
+
 			if (!match_user.empty()) {
 				// TODO Get the owner from the JobQueueJob object.
 				//   Need to be careful about whether UID_DOMAIN is included.
+				// fix as part of user_is_the_new_owner cleanup...
 				std::string job_user;
-				ad->LookupString(ATTR_USER, job_user);
+				job->LookupString(ATTR_USER, job_user);
 				if (match_user != job_user) {
 					continue;
 				}
@@ -9288,7 +9310,7 @@ void FindRunnableJob(PROC_ID & jobid, ClassAd* my_match_ad,
 				// Now check if the job and the claimed resource match.
 				// NOTE : we must do this AFTER we ensure the job is still runnable, which
 				// is why we invoke Runnable() above first.
-			if ( ! IsAMatch( ad, my_match_ad ) ) {
+			if ( ! IsAMatch( job, my_match_ad ) ) {
 					// Job and machine do not match.
 					// Assume that none of the other jobs in this auto-cluster will match.
 					// THIS IS A DANGEROUS ASSUMPTION - what if this job is no longer
@@ -9303,12 +9325,12 @@ void FindRunnableJob(PROC_ID & jobid, ClassAd* my_match_ad,
 				// as embodied by the START_VANILLA_UNIVERSE expression.
 #ifdef USE_VANILLA_START
 			if (eval_for_each_job) {
-				vad.Insert(job_attr, ad);
+				vad.Insert(job_attr, job);
 				bool runnable = scheduler.evalVanillaStartExpr(vad);
 				std::ignore = vad.Remove(job_attr);
 
 				if ( ! runnable) {
-					dprintf(D_FULLDEBUG | D_MATCH, "job %d.%d Matches, but START_VANILLA_UNIVERSE is false\n", ad->jid.cluster, ad->jid.proc);
+					dprintf(D_FULLDEBUG | D_MATCH, "job %d.%d Matches, but START_VANILLA_UNIVERSE is false\n", job->jid.cluster, job->jid.proc);
 						// Move along to the next job in the prio rec array
 					continue;
 				}
@@ -9328,7 +9350,7 @@ void FindRunnableJob(PROC_ID & jobid, ClassAd* my_match_ad,
 				my_match_ad->LookupFloat(ATTR_CURRENT_RANK, current_startd_rank) )
 			{
 				double new_startd_rank = 0;
-				if( EvalFloat(ATTR_RANK, my_match_ad, ad, new_startd_rank) )
+				if( EvalFloat(ATTR_RANK, my_match_ad, job, new_startd_rank) )
 				{
 					if( new_startd_rank < current_startd_rank ) {
 						continue;
@@ -9349,7 +9371,7 @@ void FindRunnableJob(PROC_ID & jobid, ClassAd* my_match_ad,
 
 			std::string jobLimits, recordedLimits;
 			if (param_boolean("CLAIM_RECYCLING_CONSIDER_LIMITS", true)) {
-				EvalString(ATTR_CONCURRENCY_LIMITS,ad,my_match_ad,jobLimits);
+				EvalString(ATTR_CONCURRENCY_LIMITS, job, my_match_ad, jobLimits);
 				my_match_ad->LookupString(ATTR_MATCHED_CONCURRENCY_LIMITS,
 										  recordedLimits);
 				lower_case(jobLimits);
@@ -9367,7 +9389,7 @@ void FindRunnableJob(PROC_ID & jobid, ClassAd* my_match_ad,
 				}
 			}
 
-			jobid = p->id; // success!
+			jobid = job->jid; // success!
 			return;
 
 		}	// end of for loop through PrioRec array
@@ -9386,37 +9408,39 @@ void FindRunnableJob(PROC_ID & jobid, ClassAd* my_match_ad,
 	// no more jobs to run anywhere.  nothing more to do.  failure.
 }
 
-bool Runnable(JobQueueJob *job, const char *& reason)
+bool Runnable(JobQueueJob *job, runnable_reason_code & reason)
 {
 	int cur = 0, max = 1;
 
 	if ( ! job || ! job->IsJob())
 	{
-		reason = "not runnable (not found)";
+		reason = runnable_reason_code::NotFound;
 		return false;
 	}
 
 	if (job->IsNoopJob())
 	{
-		reason = "not runnable (IsNoopJob)";
+		reason = runnable_reason_code::IsNoopJob;
 		return false;
 	}
 
 	if (job->Status() != IDLE) {
-		reason = "not runnanble (not IDLE)";
+		reason = runnable_reason_code::NotIdle;
 		return false;
 	}
 
 	if( !service_this_universe(job->Universe(), job) )
 	{
-		reason = "not runnable (universe not in service)";
+		reason = runnable_reason_code::UniverseNotInService;
 		return false;
 	}
 
 	time_t cool_down = 0;
 	job->LookupInteger(ATTR_JOB_COOL_DOWN_EXPIRATION, cool_down);
-	if (cool_down >= time(nullptr)) {
-		reason = "not runnable (in cool-down)";
+	time_t now = time(nullptr);
+	const int cooldown_soon = 5*60;
+	if (cool_down >= now) {
+		reason = (cool_down > (now + cooldown_soon)) ? runnable_reason_code::InLongCooldown : runnable_reason_code::InShortCooldown;
 		return false;
 	}
 
@@ -9425,14 +9449,39 @@ bool Runnable(JobQueueJob *job, const char *& reason)
 
 	if (cur < max)
 	{
-		reason = "is runnable";
+		reason = runnable_reason_code::IsRunnable;
 		return true;
 	}
 	
-	reason = "not runnable (already matched)";
+	reason = runnable_reason_code::AlreadyMatched;
 	return false;
 }
 
+const char * getRunnableReason(runnable_reason_code code)
+{
+	static const char * const aReason[]{
+		"is runnable", // IsRunnable
+		"not runnable (not found)", //NotFound
+		"not runnable (IsNoopJob)", //IsNoopJob,
+		"not runnable (not IDLE)", //NotIdle,
+		"not runnable (universe not in service)", //UniverseNotInService,
+		"not runnable (in cool-down > 5min)", //InLongCooldown,
+		"not runnable (in cool-down < 5min)", //InShortCooldown,
+		"not runnable (already matched)", //AlreadyMatched,
+	};
+	ASSERT((size_t)code >= 0 && (size_t)code < COUNTOF(aReason));
+	return aReason[(size_t)code];
+}
+
+bool Runnable(JobQueueJob *job, const char *& reason)
+{
+	runnable_reason_code code;
+	bool isrun = Runnable(job, code);
+	reason = getRunnableReason(code);
+	return isrun;
+}
+
+#if 0
 bool Runnable(PROC_ID* id)
 {
 	const char * reason = "";
@@ -9440,6 +9489,7 @@ bool Runnable(PROC_ID* id)
 	dprintf (D_FULLDEBUG, "Job %d.%d: %s\n", id->cluster, id->proc, reason);
 	return runnable;
 }
+#endif
 
 void
 dirtyJobQueue()

--- a/src/condor_schedd.V6/qmgmt.h
+++ b/src/condor_schedd.V6/qmgmt.h
@@ -330,17 +330,31 @@ inline const class JobQueueUserRec * EffectiveUserRec(QmgmtPeer * peer)
 	return nullptr;
 }
 
+// state of JobQueueJob run variable, used along with the prio-rec array to track which jobs
+// need matches and which have already been given matches.
+// Also used to cache ATTR_JOB_NOOP since that is also checked in the prio-rec
+enum class JobRunnableState : char {
+	Unset       = 0,
+	Runnable    = 1,
+	NotRunnable = 2,
+	Matched     = 3,
+	Cooldown    = 4,
+	DirtyNoop   = 5,  // when ATTR_JOB_NOOP has been set, but not yet checked to see if it is true
+	Noop        = 6,  // when ATTR_JOB_NOOP is true for the job
+};
+
 class JobQueueJob : public JobQueueBase {
 public:
-	//JOB_ID_KEY jid;
+	//JOB_ID_KEY jid (defined in JobQueueBase)
 protected:
-	char universe;      // this is in sync with ATTR_JOB_UNIVERSE
-	char has_noop_attr; // 1 if job has ATTR_JOB_NOOP
-	char status;        // this is in sync with committed job status and used when tracking job counts by state
+	//char entry_type (defined in JobQueueBase)
+	char universe{0};      // this is in sync with ATTR_JOB_UNIVERSE
+	char status{0};        // this is in sync with committed job status and used when tracking job counts by state
 public:
-	int dirty_flags;	// one or more of JQJ_CHACHE_DIRTY_ flags indicating that the job ad differs from the JobQueueJob 
-	int set_id;
-	int autocluster_id;
+	JobRunnableState run{JobRunnableState::Unset};
+	int dirty_flags{0};	// one or more of JQJ_CHACHE_DIRTY_ flags indicating that the job ad differs from the JobQueueJob 
+	int set_id{0};
+	int autocluster_id{0};
 	// cached pointer into schedulers's SubmitterDataMap and OwnerInfoMap
 	// it is set by count_jobs() or by scheduler::get_submitter_and_owner()
 	// DO NOT FREE FROM HERE!
@@ -355,8 +369,8 @@ public:
 		: JobQueueBase(key, (key.proc < 0) ? entry_type_cluster : entry_type_job)
 		//TT , jid(0,0)
 		, universe(0)
-		, has_noop_attr(2) // value of 2 forces IsNoopJob() to populate this field
 		, status(0) // JOB_STATUS_MIN
+		, run(JobRunnableState::Unset)
 		, dirty_flags(0)
 		, set_id(0)
 		, autocluster_id(0)
@@ -374,7 +388,7 @@ public:
 	void SetUniverse(int uni) { universe = uni; }
 	void SetStatus(int st) { status = st; }
 	bool IsNoopJob();
-	void DirtyNoopAttr() { has_noop_attr = 2; }
+	void DirtyNoopAttr() { run = JobRunnableState::DirtyNoop; }
 #if 0
 	// FUTURE:
 	int NumProcs() { if (entry_type == entry_type_cluster) return future_num_procs_or_hosts; return 0; }
@@ -778,13 +792,29 @@ bool UserRecCreate(int userrec_id, const char * ownerinfoName, const ClassAd & c
 void UserRecFixupDefaultsAd(ClassAd & defaultsAd);
 
 // priority records
-extern prio_rec *PrioRec;
-extern int N_PrioRecs;
-extern int grow_prio_recs(int);
+//#define PRIO_REC_IS_VECTOR 1
+#ifdef PRIO_REC_IS_VECTOR
+  extern std::vector<prio_rec> PrioRec;
+#else
+  extern std::deque<prio_rec> PrioRec;
+#endif
 
 extern void	FindRunnableJob(PROC_ID & jobid, ClassAd* my_match_ad, char const * user);
-extern bool Runnable(PROC_ID*);
-extern bool Runnable(JobQueueJob *job, const char *& reason);
+//extern bool Runnable(PROC_ID*);
+enum class runnable_reason_code : int {
+	IsRunnable=0,
+	NotFound,
+	IsNoopJob,
+	NotIdle,
+	UniverseNotInService,
+	InLongCooldown,  // cooldown > 5min
+	InShortCooldown, // cooldown <= 5min
+	AlreadyMatched,
+};
+//extern bool Runnable(JobQueueJob *job, const char *& reason);
+extern bool Runnable(JobQueueJob *job, runnable_reason_code & code);
+extern const char * getRunnableReason(runnable_reason_code code);
+
 
 extern class ForkWork schedd_forker;
 

--- a/src/condor_schedd.V6/qmgmt.h
+++ b/src/condor_schedd.V6/qmgmt.h
@@ -358,25 +358,16 @@ public:
 	// cached pointer into schedulers's SubmitterDataMap and OwnerInfoMap
 	// it is set by count_jobs() or by scheduler::get_submitter_and_owner()
 	// DO NOT FREE FROM HERE!
-	OwnerInfo * ownerinfo;
-	struct SubmitterData * submitterdata;
+	OwnerInfo * ownerinfo{nullptr};
+	struct SubmitterData * submitterdata{nullptr};
 protected:
-	JobQueueCluster * parent; // job pointer back to the 
+	JobQueueCluster * parent{nullptr}; // job pointer back to the cluster ad
 	qelm qe;
 
 public:
 	JobQueueJob(const JOB_ID_KEY & key)
 		: JobQueueBase(key, (key.proc < 0) ? entry_type_cluster : entry_type_job)
-		//TT , jid(0,0)
-		, universe(0)
-		, status(0) // JOB_STATUS_MIN
-		, run(JobRunnableState::Unset)
-		, dirty_flags(0)
-		, set_id(0)
-		, autocluster_id(0)
-		, ownerinfo(NULL)
-		, submitterdata(NULL)
-		, parent(NULL)
+		//base class initializes jid to 0,0
 	{}
 	virtual ~JobQueueJob() {};
 
@@ -408,23 +399,17 @@ public:
 // structure of job_queue hashtable entries for clusters.
 class JobQueueCluster : public JobQueueJob {
 public:
-	JobFactory * factory; // this will be non-null only for cluster ads, and only when the cluster is doing late materialization
+	JobFactory * factory{nullptr}; // this will be non-null only for cluster ads, and only when the cluster is doing late materialization
 protected:
-	int cluster_size; // number of materialized jobs in this cluster that the schedd is currently tracking.
-	int num_attached; // number of procs attached to this cluster.
-	int num_idle;
-	int num_running;
-	int num_held;
+	int cluster_size{0}; // number of materialized jobs in this cluster that the schedd is currently tracking.
+	int num_attached{0}; // number of procs attached to this cluster.
+	int num_idle{0};
+	int num_running{0};
+	int num_held{0};
 
 public:
 	JobQueueCluster(JOB_ID_KEY & job_id)
 		: JobQueueJob(job_id)
-		, factory(NULL)
-		, cluster_size(0)
-		, num_attached(0)
-		, num_idle(0)
-		, num_running(0)
-		, num_held(0)
 		{
 		}
 	virtual ~JobQueueCluster();
@@ -455,13 +440,13 @@ public:
 
 protected:
 	// 3 bytes needed to align the next int
-	char spareA = 0;
-	char spareB = 0;
-	bool dirty = false;
+	char spareA{0};
+	char spareB{0};
+	bool dirty{false};
 public:
-	garbagePolicyEnum garbagePolicy = garbagePolicyEnum::immediateAfterEmpty;
-	unsigned int member_count = 0;
-	OwnerInfo * ownerinfo = nullptr;
+	garbagePolicyEnum garbagePolicy{garbagePolicyEnum::immediateAfterEmpty};
+	unsigned int member_count{0};
+	OwnerInfo * ownerinfo{nullptr};
 	LiveJobCounters jobStatusAggregates;
 	unsigned int Jobset() const { return (unsigned int)jid.cluster; }
 

--- a/src/condor_schedd.V6/schedd_negotiate.cpp
+++ b/src/condor_schedd.V6/schedd_negotiate.cpp
@@ -24,36 +24,7 @@
 #include "schedd_negotiate.h"
 
 
-ResourceRequestCluster::ResourceRequestCluster(int auto_cluster_id):
-	m_auto_cluster_id(auto_cluster_id)
-{
-}
-
-void
-ResourceRequestCluster::addJob(PROC_ID job_id)
-{
-	m_job_ids.push_back( job_id );
-}
-
-bool
-ResourceRequestCluster::popJob(PROC_ID &job_id)
-{
-	if( m_job_ids.empty() ) {
-		return false;
-	}
-	job_id = m_job_ids.front();
-	m_job_ids.pop_front();
-	return true;
-}
-
-ResourceRequestList::~ResourceRequestList()
-{
-	while( !empty() ) {
-		ResourceRequestCluster *cluster = front();
-		pop_front();
-		delete cluster;
-	}
-}
+static int next_negotiate_instance_id = 1;
 
 ScheddNegotiate::ScheddNegotiate
 (
@@ -64,10 +35,6 @@ ScheddNegotiate::ScheddNegotiate
 ):
 	DCMsg(cmd),
 	m_jobs(jobs),
-	m_current_resources_requested(1),
-	m_current_resources_delivered(0),
-	m_jobs_can_offer(-1),
-	m_will_match_claimed_pslots(false),
 	m_owner(owner ? owner : ""),
 	m_remote_pool(remote_pool ? remote_pool : ""),
 	m_current_auto_cluster_id(-1),
@@ -81,6 +48,7 @@ ScheddNegotiate::ScheddNegotiate
 {
 	m_current_job_id.cluster = -1;
 	m_current_job_id.proc = -1;
+	m_instance = next_negotiate_instance_id++;
 }
 
 ScheddNegotiate::~ScheddNegotiate()
@@ -107,6 +75,9 @@ ScheddNegotiate::negotiate(Sock *sock)
 		// consists of asynchronously reading messages from the
 		// negotiator and sending responses until this round of
 		// negotiation is done.
+	dprintf(D_DYE, "%08x_%06d:%s\tNEGOTIATE\t%s rr=%d\n",
+		sock->getUniqueId(), m_instance,
+		m_owner.c_str(), m_remote_pool.c_str(), m_jobs ? (int)m_jobs->size() : 0);
 
 		// This will eventually call ScheddNegotiate::readMsg().
 	classy_counted_ptr<DCMessenger> messenger = new DCMessenger(sock);
@@ -154,13 +125,17 @@ ScheddNegotiate::nextJob()
 	}
 
 	while( !m_jobs->empty() && m_jobs_can_offer ) {
-		ResourceRequestCluster *cluster = m_jobs->front();
-		ASSERT( cluster );
+		ResourceRequestCluster & cluster = m_jobs->front();
 
-		m_current_auto_cluster_id = cluster->getAutoClusterId();
+		m_current_auto_cluster_id = cluster.getAutoClusterId();
 
 		if( !getAutoClusterRejected(m_current_auto_cluster_id) ) {
-			while( cluster->popJob(m_current_job_id) ) {
+			size_t clusterSize = cluster.size();
+			for (auto & jid : cluster) {
+				--clusterSize; // decrement as we iterate so we know how many jobs remain
+				if (!jid.isJobKey()) continue;
+				m_current_job_id = jid;
+
 				const char* because = "";
 				bool skip_all = false;
 				JobQueueJob * job = GetJobAd(m_current_job_id);
@@ -203,8 +178,8 @@ ScheddNegotiate::nextJob()
 						m_current_job_ad.LookupInteger(ATTR_JOB_UNIVERSE,universe);
 						// For now, do not use request counts with the dedicated scheduler
 						if ( universe != CONDOR_UNIVERSE_PARALLEL ) {
-							// add one to cluster size to cover the current popped job
-							int resource_count = 1+cluster->size();
+							// resource_count is the remaining un-iterated jobs plus this one.
+							int resource_count = 1+clusterSize;
 							if (count_max > 0) { resource_count = MIN(resource_count, count_max); }
 							if (resource_count > m_jobs_can_offer && (m_jobs_can_offer > 0))
 							{
@@ -229,7 +204,6 @@ ScheddNegotiate::nextJob()
 		}
 
 		m_jobs->pop_front();
-		delete cluster;
 	}
 	if (!m_jobs_can_offer)
 	{
@@ -389,9 +363,7 @@ ScheddNegotiate::sendResourceRequestList(Sock *sock)
 		// we already sent an ad with a resource_request_count.  So we want
 		// to skip ahead to the next cluster.
 		if ( !m_jobs->empty() ) {
-			ResourceRequestCluster *cluster = m_jobs->front();
 			m_jobs->pop_front();
-			delete cluster;
 		}
 
 		m_num_resource_reqs_sent++;
@@ -428,6 +400,17 @@ ScheddNegotiate::sendJobInfo(Sock *sock, bool just_sig_attrs)
 	if( !sock->put(JOB_INFO) ) {
 		dprintf( D_ALWAYS, "Can't send JOB_INFO to mgr\n" );
 		return false;
+	}
+
+	if (IsDebugCategory(D_DYE)) {
+		std::string details;
+		m_current_job_ad.LookupString(ATTR_OWNER, details);
+		details += " "; details += m_owner;
+		int count = 0, aid = 0;
+		m_current_job_ad.LookupInteger(ATTR_RESOURCE_REQUEST_COUNT, count);
+		m_current_job_ad.LookupInteger(ATTR_AUTO_CLUSTER_ID, aid);
+		formatstr_cat(details, " %d |%d|%d.%d|", count, aid, m_current_job_id.cluster, m_current_job_id.proc);
+		dprintf(D_DYE, "\t%s\n", details.c_str());
 	}
 
 		// Tell the negotiator that we understand pslot preemption
@@ -517,6 +500,30 @@ ScheddNegotiate::messageReceived( DCMessenger *messenger, Sock *sock )
 {
 		// This is called when readMsg() returns true.
 		// Now carry out the negotiator's request that we just read.
+
+	if (IsDebugCategory(D_DYE)) {
+		std::string details;
+		switch(m_operation) {
+		case REJECTED_WITH_REASON: details = m_reject_reason; break;
+		case SEND_JOB_INFO: {
+			if ( m_jobs && ! m_jobs->empty()) { auto & rr = m_jobs->front(); formatstr(details, "ac=%d", rr.getAutoClusterId()); }
+			} break;
+		case PERMISSION_AND_AD: {
+			m_match_ad.LookupString(ATTR_NAME,details);
+			JOB_ID_KEY jid;
+			m_match_ad.LookupInteger(ATTR_RESOURCE_REQUEST_CLUSTER, jid.cluster);
+			m_match_ad.LookupInteger(ATTR_RESOURCE_REQUEST_PROC, jid.proc);
+			formatstr_cat(details, " %d ", m_current_resources_delivered);
+			// TODO: have negotiator send RR id back, not just job id.
+			details += "|?|"; details += (std::string)(jid); details += "|";
+			} break;
+		case END_NEGOTIATE: {
+			if (RRLRequestIsPending()) { details = "<prefetch>"; } else { details = "<end>"; }
+			} break;
+		}
+		dprintf(D_DYE, "%08x_%06d:%s\t%s\t%s\n", sock->getUniqueId(), m_instance,
+			m_owner.c_str(), getCommandStringSafe(m_operation), details.c_str());
+	}
 
 	switch( m_operation ) {
 

--- a/src/condor_schedd.V6/schedd_negotiate.h
+++ b/src/condor_schedd.V6/schedd_negotiate.h
@@ -23,49 +23,74 @@
 #include "dc_message.h"
 #include "prio_rec.h"
 
-/*
+ /*
  * ResourceRequestCluster
  *
- * Represents a set of jobs sharing the same priority and auto cluster id.
+ * Represents a set of jobs sharing the same submitter, priority and auto cluster id.
+ * 
+ * the autocluster_id may not be an actual autocluster id, but it should be different
+ * for each entry in the ResourceRequestList. Think of it as the resource request id.
  *
- * The auto cluster ids are only assumed to be internally consistent
- * at the time the snapshot of the job queue was taken.  They are not used
- * to reference any external data structure.
  */
 class ResourceRequestCluster {
- public:
-	ResourceRequestCluster(int auto_cluster_id);
+public:
+	ResourceRequestCluster(int id=0, int capacity=0) : m_autocluster_id(id) {
+		if (capacity) m_jobs.reserve(capacity);
+	}
+	void addJob(PROC_ID jid) { m_jobs.push_back(jid); }
 
-		// appends a job to this cluster
-	void addJob(PROC_ID job_id);
+	// returns number of jobs in this cluster
+	size_t size() { return m_jobs.size(); }
 
-		// returns true if a job was found; o.w. false
-	bool popJob(PROC_ID &job_id);
+	// returns the auto cluster id for this cluster
+	int getAutoClusterId() const { return m_autocluster_id; }
 
-		// returns number of jobs in this cluster
-	size_t size() { return m_job_ids.size(); }
+	using container = std::vector<PROC_ID>;
+	using iterator = container::iterator;
+	using const_iterator = container::const_iterator;
+	iterator begin() { return m_jobs.begin(); }
+	const_iterator begin() const { return m_jobs.cbegin(); }
+	iterator end() { return m_jobs.end(); }
+	const_iterator end() const { return m_jobs.cend(); }
 
-		// returns the auto cluster id for this cluster
-	int getAutoClusterId() const { return m_auto_cluster_id; }
- private:
-
-	int m_auto_cluster_id;
-	std::list<PROC_ID> m_job_ids;
+protected:
+	std::vector<PROC_ID> m_jobs;
+	int                  m_autocluster_id{0};
 };
 
 /*
- * ResourceRequestList
- *
- * Contains an ordered list of job auto clusters for matchmaking.  All
- * jobs in the list are owned by the same user (or accounting group).
- * 
- * The ResourceRequestClusters in this list are deleted when the list
- * is deleted.
- */
-class ResourceRequestList: public std::list<ResourceRequestCluster *> {
- public:
-	~ResourceRequestList();
+* ResourceRequestList
+*
+* Contains an ordered list of job auto clusters for matchmaking.  All
+* jobs in the list are owned by the same user (or accounting group).
+* 
+* The list is owned by an instance of ScheddNegotiate and consumed (deleted) by it
+* as the conversation proceeds. Currently ResourceRequestClusters in this list
+* and are also deleted during negotiation, but planned future changes will
+* Make the resource request clusters persist, but list will not.
+*/
+class ResourceRequestList {
+public:
+	void add(int id, PROC_ID & jid) {
+		if ( ! items.empty() && items.back().getAutoClusterId() == id) {
+			items.back().addJob(jid);
+		} else {
+			items.emplace_back(id).addJob(jid);
+		}
+	}
+	int currentId() {
+		if (items.empty()) return -1;
+		return items.back().getAutoClusterId();
+	}
+	bool empty() { return items.empty(); }
+	size_t size() { return items.size(); }
+	ResourceRequestCluster & front() { return items.front(); }
+	void pop_front() { return items.pop_front(); }
+
+protected:
+	std::deque<ResourceRequestCluster> items;
 };
+
 
 /*
  * ScheddNegotiate
@@ -162,16 +187,17 @@ class ScheddNegotiate: public DCMsg {
 	bool RRLRequestIsPending() const { return ((getNumJobsMatched() == 0) && (getNumJobsRejected() == 0));} 
 
  protected:
-	ResourceRequestList *m_jobs;
+	ResourceRequestList *m_jobs{nullptr};
+	int m_instance{0}; // instance id used for logging
 		// how many resources are we requesting with this request?
-	int m_current_resources_requested;
+	int m_current_resources_requested{1};
 		// how many resources have been delivered so far with this request?
-	int m_current_resources_delivered;
+	int m_current_resources_delivered{0};
 		// how many more resources can we offer to the matchmaker?
 		// If -1, then we don't limit the offered resources.
-	int m_jobs_can_offer;
+	int m_jobs_can_offer{-1};
 		// will matchmaker match pslots that we have claimed?
-	bool m_will_match_claimed_pslots;
+	bool m_will_match_claimed_pslots{false};
 	bool m_can_do_match_diag_3{false};
 	bool m_can_do_match_dye{false};
 	ClassAd * m_reject_ad{nullptr};   // detailed match rejection ad (24.x negotiators or later)

--- a/src/condor_schedd.V6/schedd_negotiate.h
+++ b/src/condor_schedd.V6/schedd_negotiate.h
@@ -77,6 +77,7 @@ public:
 		} else {
 			items.emplace_back(id).addJob(jid);
 		}
+		largest_cluster = MAX(largest_cluster, items.back().size());
 	}
 	int currentId() {
 		if (items.empty()) return -1;
@@ -85,10 +86,12 @@ public:
 	bool empty() { return items.empty(); }
 	size_t size() { return items.size(); }
 	ResourceRequestCluster & front() { return items.front(); }
-	void pop_front() { return items.pop_front(); }
+	void pop_front() { items.pop_front(); }
+	void flatten();
 
 protected:
 	std::deque<ResourceRequestCluster> items;
+	size_t largest_cluster{0};
 };
 
 
@@ -241,6 +244,9 @@ class ScheddNegotiate: public DCMsg {
 	void setAutoClusterRejected(int auto_cluster_id);
 
 	bool sendJobInfo(Sock *sock, bool just_sig_attrs=false);
+
+		// negotiator sent SEND_JOB_INFO, so it doesn't want to hear about resource requests lists
+	void notSendingResourceRequests();
 
 	bool sendResourceRequestList(Sock *sock);
 

--- a/src/condor_schedd.V6/schedd_stats.cpp
+++ b/src/condor_schedd.V6/schedd_stats.cpp
@@ -222,6 +222,7 @@ void ScheddStatistics::InitMain()
    SCHEDD_STATS_ADD_EXTERN_RUNTIME(Pool, WalkJobQ_updateSchedDInterval,    IF_VERBOSEPUB);
    SCHEDD_STATS_ADD_EXTERN_RUNTIME(Pool, WalkJobQ_mark_idle,               IF_VERBOSEPUB);
    SCHEDD_STATS_ADD_EXTERN_RUNTIME(Pool, WalkJobQ_get_job_prio,            IF_VERBOSEPUB);
+   SCHEDD_STATS_ADD_EXTERN_RUNTIME(Pool, WalkJobQ_update_autocluster_id,   IF_VERBOSEPUB);
 
    // timings for the autocluster code
    SCHEDD_STATS_ADD_EXTERN_RUNTIME(Pool, GetAutoCluster,           IF_VERBOSEPUB);

--- a/src/condor_utils/dprintf_common.cpp
+++ b/src/condor_utils/dprintf_common.cpp
@@ -59,7 +59,7 @@ const char * const _condor_DebugCategoryNames[D_CATEGORY_COUNT] = {
 	"D_PROCFAMILY", "D_IDLE", "D_THREADS", "D_ACCOUNTANT",
 	"D_SYSCALLS", "D_CRON", "D_HOSTNAME", "D_PERF_TRACE", // D_CRON formerly D_CKPT
 	"D_LOAD", "D_25", "D_26", "D_AUDIT", "D_TEST",      // D_25 formerly D_PROC (HAD)  D_26 formerly D_NFS
-	"D_STATS", "D_MATERIALIZE", "D_31",
+	"D_STATS", "D_MATERIALIZE", "D_DYE",
 };
 // these are flags rather than categories
 // "D_EXPR", "D_FULLDEBUG", "D_PID", "D_FDS", "D_CAT", "D_NOHEADER",


### PR DESCRIPTION
match_rec, and ResourceRequestList classes in the Schedd.  The joblist for each resource request is no longer consumed while talking to the negotiator.  This enables the use of a more complex joblist that can be referred to when matches arrive. This commit also fixes a bug in the stats where the time spend calculating autoclusters was being double counted.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
