### PR TITLE
(HTCONDOR-3133)  Fix a `htcondor2.param`-related bug in `htcondor annex`

### DIFF
--- a/src/condor_tools/htcondor_cli/annex_create.py
+++ b/src/condor_tools/htcondor_cli/annex_create.py
@@ -460,7 +460,7 @@ def create_annex_token(logger, type):
         out, err = proc.communicate(timeout=TOKEN_FETCH_TIMEOUT)
 
         if proc.returncode == 0:
-            sec_token_directory = htcondor.param.get("SEC_TOKEN_DIRECTORY")
+            sec_token_directory = htcondor.param.get("SEC_TOKEN_DIRECTORY", "")
             if sec_token_directory == "":
                 sec_token_directory = "~/.condor/tokens.d"
             return os.path.expanduser(f"{sec_token_directory}/{token_name}")


### PR DESCRIPTION
`SEC_TOKEN_DIRECTORY` defaults to the empty string.  This used to be returned as the empty string from `param.get()` but is now returned as `None`.  Change the default in the `param.get()` call to the emptry string.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
