### PR TITLE
(HTCONDOR-3121)  Some HTTP URLs require a `user-agent` header

### DIFF
--- a/docs/version-history/v24-version.hist
+++ b/docs/version-history/v24-version.hist
@@ -1,7 +1,7 @@
 *** 24.0.10 bugs
 
 - The plug-in used to handle ``http`` and ``https`` URLs now sets the
-  ``user-agent`` header by default.  URLs which return a 403/Forbidden
+  ``user-agent`` header by default (``condor_curl_plugin/0.2``).  URLs which return a 403/Forbidden
   error when the ``user-agent`` is empty will now function as expected.
   jira:`3121`
 

--- a/docs/version-history/v24-version.hist
+++ b/docs/version-history/v24-version.hist
@@ -1,5 +1,10 @@
 *** 24.0.10 bugs
 
+- The plug-in used to handle ``http`` and ``https`` URLs now sets the
+  ``user-agent`` header by default.  URLs which return a 403/Forbidden
+  error when the ``user-agent`` is empty will now function as expected.
+  jira:`3121`
+
 *** 24.0.9 bugs
 
 - The results of ``key in htcondor2.param`` and

--- a/src/condor_filetransfer_plugins/multifile_curl_plugin.cpp
+++ b/src/condor_filetransfer_plugins/multifile_curl_plugin.cpp
@@ -263,7 +263,7 @@ MultiFileCurlPlugin::InitializeCurlHandle(const std::string &url, const std::str
         // will 403 without one. (!!)  [https://repo.anaconda.com]
         // ... blowing as ASSERT() here is probably not OK, though.
         r = curl_easy_setopt( _handle, CURLOPT_USERAGENT, "multifile_curl_plugin/" "PLUGIN_VERSION" );
-        if (r != CURL_OK) {
+        if (r != CURLE_OK) {
             fprintf(stderr, "Can't setopt USERAGENT\n");
         }
 

--- a/src/condor_filetransfer_plugins/multifile_curl_plugin.cpp
+++ b/src/condor_filetransfer_plugins/multifile_curl_plugin.cpp
@@ -259,6 +259,14 @@ MultiFileCurlPlugin::InitializeCurlHandle(const std::string &url, const std::str
 			fprintf(stderr, "Can't setopt HEADERFUNCTION\n");
 		}
 
+        // We MUST successfully set the USERAGENT, because some URLs
+        // will 403 without one. (!!)  [https://repo.anaconda.com]
+        // ... blowing as ASSERT() here is probably not OK, though.
+        r = curl_easy_setopt( _handle, CURLOPT_USERAGENT, "multifile_curl_plugin/" "PLUGIN_VERSION" );
+        if (r != CURL_OK) {
+            fprintf(stderr, "Can't setopt USERAGENT\n");
+        }
+
         GetToken(cred, token);
     }
     // Libcurl options for FTP
@@ -929,7 +937,7 @@ MultiFileCurlPlugin::InitializeStats( std::string request_url ) {
 
 size_t
 MultiFileCurlPlugin::HeaderCallback( char* buffer, size_t size, size_t nitems, void *userdata ) {
-    fprintf(stderr, "[MultiFileCurlPlugin::HeaderCallback] called\n");
+    // fprintf(stderr, "[MultiFileCurlPlugin::HeaderCallback] called\n");
     auto ft_stats = static_cast<FileTransferStats*>(userdata);
 
     // Work around a bug in libcurl; see HTCONDOR-1426.

--- a/src/condor_filetransfer_plugins/multifile_curl_plugin.cpp
+++ b/src/condor_filetransfer_plugins/multifile_curl_plugin.cpp
@@ -262,7 +262,7 @@ MultiFileCurlPlugin::InitializeCurlHandle(const std::string &url, const std::str
         // We MUST successfully set the USERAGENT, because some URLs
         // will 403 without one. (!!)  [https://repo.anaconda.com]
         // ... blowing as ASSERT() here is probably not OK, though.
-        r = curl_easy_setopt( _handle, CURLOPT_USERAGENT, "multifile_curl_plugin/" "PLUGIN_VERSION" );
+        r = curl_easy_setopt( _handle, CURLOPT_USERAGENT, "condor_curl_plugin/" "PLUGIN_VERSION" );
         if (r != CURLE_OK) {
             fprintf(stderr, "Can't setopt USERAGENT\n");
         }


### PR DESCRIPTION
This patch sets the user-agent to multifile_curl_plugin/0.2 (or whatever the current version of the plug-in is), which seems to work with that URL fine.  I don’t know what effects, if any, it will have on other servers.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
