### PR TITLE
HTCONDOR-3105 Don't pollute a socket's auth info with dirty classad

### DIFF
--- a/src/condor_io/condor_secman.cpp
+++ b/src/condor_io/condor_secman.cpp
@@ -1494,8 +1494,7 @@ SecManStartCommand::sendAuthInfo_inner()
 	// was decided on when the key was issued.
 	// otherwise, get our security policy and work it out with the server.
 	if (m_have_session) {
-		MergeClassAds( &m_auth_info, session_entry->policy(), true );
-
+		MergeClassAds( &m_auth_info, session_entry->policy(), true, false);
 		if (IsDebugVerbose(D_SECURITY)) {
 			dprintf (D_SECURITY, "SECMAN: found cached session id %s for %s.\n",
 					session_entry->id().c_str(), m_session_key.c_str());


### PR DESCRIPTION
tracking

The default argument to MergeClassAds does this, leaving behind a set of classad attribute names in the dirty attrs, which we never need or use.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
