### PR TITLE
HTCONDOR-3102: Spruce up x86_64_v2 detection

### DIFF
--- a/build/nmi-build/setup.sh
+++ b/build/nmi-build/setup.sh
@@ -21,13 +21,16 @@ VERSION_CODENAME='none'
 . /etc/os-release
 echo "Building on $NAME $VERSION"
 VERSION_ID=${VERSION_ID%%.*}
-if rpm -qf /bin/sh | grep -q 'x86_64_v2'; then
-    ARCH='x86_64_v2'
-    REPO_ARCH='x86_64_v2'
-else
-    ARCH=$(arch)
-    REPO_ARCH='noarch'
+ARCH=$(arch)
+REPO_ARCH='noarch'
+
+if [ $ID = 'almalinux' ]; then
+    if rpm -qf /bin/sh | grep -q 'x86_64_v2'; then
+        ARCH='x86_64_v2'
+        REPO_ARCH='x86_64_v2'
+    fi
 fi
+
 echo "ID=$ID VERSION_ID=$VERSION_ID VERSION_CODENAME=$VERSION_CODENAME ARCH=$ARCH"
 
 if [ $ID = 'debian' ] || [ $ID = 'ubuntu' ]; then
@@ -36,7 +39,7 @@ else
     SUDO_GROUP='wheel'
 fi
 
-if [ $ID = debian ] || [ $ID = 'ubuntu' ]; then
+if [ $ID = 'debian' ] || [ $ID = 'ubuntu' ]; then
     apt-get update
     export DEBIAN_FRONTEND='noninteractive'
     INSTALL='apt-get install --yes'


### PR DESCRIPTION
Although the previous code worked on Debian/Ubuntu. I am suprised that the lack of the rpm did not cause this script to error out. In any case, it is only worth checking for the alternate architecture on AlmaLinux.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
