### PR TITLE
(HTCONDOR-3272)  Fix in-line unit separators.

### DIFF
--- a/docs/version-history/v24-version.hist
+++ b/docs/version-history/v24-version.hist
@@ -1,5 +1,14 @@
 *** 24.0.14 bugs
 
+- Fixed a bug where space and comma would be included in the list of
+  separators for itemdata even if the itemdata had been supplied with
+  the ASCII "unit separator".  This would cause itemdata entries containing
+  spaces (or commas) to be incorrectly interpreted as multiple items, which
+  could manifest as parse errors.  You can work around this bug if only one
+  of your entries has spaces and/or commas by moving that entry to the end
+  of the line (or dictionary, if you're submitting itemdata via Python).
+  :jira:`3272`
+
 *** 24.0.12 features
 
 - Updated :tool:`condor_upgrade_check` to test for well known gotchas

--- a/src/condor_utils/submit_utils.cpp
+++ b/src/condor_utils/submit_utils.cpp
@@ -8548,6 +8548,7 @@ int SubmitForeachArgs::split_item(std::string_view item, std::vector<std::string
 
 	// empty table options gets original split behavior.  (basically standard_foreach_table_opts)
 	bool legacy_split = table_opts.empty();
+	bool split_on_ws = table_opts.ws_sep; // capture the split-on-whitespace flag in case we need to turn it off
 
 	// setup token seps
 	const char* token_seps = ", \t";
@@ -8557,6 +8558,7 @@ int SubmitForeachArgs::split_item(std::string_view item, std::vector<std::string
 	char sep_char = 0;
 	if (legacy_split && item.find_first_of('\x1f') != std::string_view::npos) {
 		sep_char = '\x1f'; // autodetected US separator
+		split_on_ws = false; // turnoff whitespace splitting.
 	} else {
 		sep_char = table_opts.sep_char;
 	}
@@ -8564,7 +8566,7 @@ int SubmitForeachArgs::split_item(std::string_view item, std::vector<std::string
 		// build a dynamic token_seps string
 		char* seps = table_token_seps;
 		*seps++ = sep_char;
-		if (table_opts.ws_sep) { *seps++ = ' '; *seps++ = '\t'; }
+		if (split_on_ws) { *seps++ = ' '; *seps++ = '\t'; }
 		*seps = 0;
 
 		token_seps = table_token_seps;


### PR DESCRIPTION
This fixes a problem added when the `FROM TABLE` feature went in where in-line item data using item separator was incorrectly parsed.

This fixes such files submitted via *condor_submit* in 24.0, but doesn't help with item data values containing spaces submitted via the Python bindings until later (25.0.x at the latest).

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [x] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
