### PR TITLE
Python bindings: add missing import of htcondor2 to _credd.py

### DIFF
--- a/bindings/python/htcondor2/_credd.py
+++ b/bindings/python/htcondor2/_credd.py
@@ -16,6 +16,7 @@ from .htcondor2_impl import (
     HTCondorException,
 )
 
+import htcondor2
 
 class Credd():
 


### PR DESCRIPTION
Using htcondor2 there's an error when trying to add_user_cred()

```
>>> import htcondor2
>>> coll = htcondor2.Collector("tweetybird03.cern.ch")
>>> credd = htcondor2.Credd()
>>> credd.add_user_cred(htcondor2.CredTypes.Kerberos, None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python3.9/site-packages/htcondor2/_credd.py", line 132, in add_user_cred
    producer = htcondor2.param["SEC_CREDENTIAL_PRODUCER"]
NameError: name 'htcondor2' is not defined
```

Just looks like a missing import
