### PR TITLE
HTCONDOR-3305: Ensure .so files are moved to tarball usr/lib on Debian

### DIFF
--- a/nmi_tools/glue/build/make-tarball-from-debs
+++ b/nmi_tools/glue/build/make-tarball-from-debs
@@ -97,8 +97,8 @@ if [ $? -ne 0 ];then
     exit 1
 fi
 
-# Move configuration files back to example directory
-mv tarball/etc/condor/config.d/* tarball/usr/share/doc/condor/examples/
+# Move configuration files back to examples directory
+mv tarball/etc/condor/config.d/* tarball/examples/
 
 # Extract external debs
 for path in /usr/local/condor/externals/*.deb; do
@@ -107,6 +107,11 @@ for path in /usr/local/condor/externals/*.deb; do
     echo $file >> tarball/Manifest.txt
     extract_deb $path tarball
 done
+
+# On Debian and Unbuntu consolidate shared objects into a single directory
+if [ -d tarball/usr/lib/$arch-linux-gnu ]; then
+    find tarball/usr/lib/$arch-linux-gnu -name \*.so\* -exec mv {} tarball/usr/lib \;
+fi
 
 $cmd_dir/set-tarball-rpath tarball '$ORIGIN/../lib:$ORIGIN/../lib/condor'
 if [ $? -ne 0 ];then

--- a/nmi_tools/glue/build/make-tarball-links
+++ b/nmi_tools/glue/build/make-tarball-links
@@ -17,14 +17,6 @@ if [ ! -d etc -o ! -d usr ]; then
     echo That does not look like an HTCondor tarball
     exit 1
 fi
-# On Debian and Unbuntu consolidate shared objects into a single directory
-if [ -d lib ]; then
-    find lib -name \*.so\* -exec mv {} usr/lib \;
-    rm -rf lib
-fi
-if [ -d usr/lib/x86_64-linux-gnu ]; then
-    find usr/lib/x86_64-linux-gnu -name \*.so\* -exec mv {} usr/lib \;
-fi
 # Make compatabilty links to conform to the old tarball layout
 ln -s usr/bin bin
 ln -s usr/sbin sbin


### PR DESCRIPTION
The examples directory can be in various places and is linked in as appropriate by the make-tarball-links script.
The shared objects must be moved after they are extracted.
All our platform have migrated away from /lib, so that code is no longer needed.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
