### PR TITLE
(HTCONDOR-3313)  Improve test_cif_catalogs.py's reliability.

### DIFF
--- a/src/condor_shadow.V6.1/pseudo_ops.cpp
+++ b/src/condor_shadow.V6.1/pseudo_ops.cpp
@@ -1390,7 +1390,7 @@ UniShadow::set_provider_keep_alive( const std::string & cifName ) {
 						SingleProviderSyndicate * cfLock = this->cfLocks[cifName];
 						if( cfLock == NULL ) { continue; }
 
-						dprintf( D_TEST, "Elected producer touch()ing keyfile.\n" );
+						// dprintf( D_ZKM, "Elected producer touch()ing keyfile.\n" );
 						if(! cfLock->touch()) {
 							// I boldly claim that the global destructor will delete
 							// the corresponding cfLock.
@@ -1478,6 +1478,7 @@ UniShadow::start_common_input_conversation(
 			//
 
 			case SingleProviderSyndicate::PROVIDER:
+				dprintf( D_TEST, "Producer elected.\n" );
 				set_provider_keep_alive( cifName );
 
 				// This would be cleaner as a nested coroutine, but not
@@ -1572,6 +1573,7 @@ UniShadow::start_common_input_conversation(
 			dprintf( D_ZKM, "start_common_input_conversation(): cfLock.acquire() = %d\n", (int)status );
 			switch( status ) {
 				case SingleProviderSyndicate::PROVIDER:
+					dprintf( D_TEST, "Producer elected.\n" );
 					set_provider_keep_alive( cifName );
 
 					// This would be cleaner as a nested coroutine, but not

--- a/src/condor_tests/test_cif.py
+++ b/src/condor_tests/test_cif.py
@@ -524,7 +524,7 @@ def shadow_log_is_as_expected(the_condor, count, cf_xfers, cf_waits):
     assert successful_staging_commands == count
 
     keyfile_touches = count_shadow_log_lines(
-        the_condor, "Elected producer touch"
+        the_condor, "Producer elected"
     )
     assert keyfile_touches == count
 

--- a/src/condor_tests/test_cif_catalogs.py
+++ b/src/condor_tests/test_cif_catalogs.py
@@ -509,7 +509,7 @@ def shadow_log_is_as_expected(the_condor, count, cf_xfers, cf_waits):
     assert successful_staging_commands == count
 
     keyfile_touches = count_shadow_log_lines(
-        the_condor, "Elected producer touch"
+        the_condor, "Producer elected"
     )
     assert keyfile_touches == count
 


### PR DESCRIPTION
Move a `dprintf(D_TEST, ...` from where it was printing once per shadow to where the test thought it was printing, once per producer.

As a test-only commit, this PR doesn't need version history, documentation, or its own regression test.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
