### PR TITLE
HTCONDOR-3312 startd-always-sends-alives

### DIFF
--- a/docs/admin-manual/configuration-macros.rst
+++ b/docs/admin-manual/configuration-macros.rst
@@ -5113,16 +5113,6 @@ These macros control the *condor_schedd*.
     user priority in the system). The macro is defined in terms of seconds
     and defaults to 300, which is 5 minutes.
 
-:macro-def:`STARTD_SENDS_ALIVES[SCHEDD]`
-    Note: This setting is deprecated, and may go away in a future
-    version of HTCondor. This setting is mainly useful when running
-    mixing very old *condor_schedd* daemons with newer pools. A boolean
-    value that defaults to ``True``, causing keep alive messages to be
-    sent from the *condor_startd* to the *condor_schedd* by TCP during
-    a claim. When ``False``, the *condor_schedd* daemon sends keep
-    alive signals to the *condor_startd*, reversing the direction.
-    This variable is only used by the *condor_schedd* daemon.
-
 :macro-def:`REQUEST_CLAIM_TIMEOUT[SCHEDD]`
     This macro sets the time (in seconds) that the *condor_schedd* will
     wait for a claim to be granted by the *condor_startd*. The default

--- a/docs/version-history/v25-version.hist
+++ b/docs/version-history/v25-version.hist
@@ -9,6 +9,11 @@
   the DOCKER_HOST environment variable, such as with a docker-in-docker setup.
   :jira:`3280`
 
+- Removed option to have the *condor_schedd* send claim lease keep-alives.
+  Now, the *condor_startd* always sends the keep-alives, which was the
+  default.
+  :jire:``3312
+
 *** 25.3.0 bugs
 
 *** 25.0.3 bugs

--- a/src/condor_schedd.V6/dedicated_scheduler.cpp
+++ b/src/condor_schedd.V6/dedicated_scheduler.cpp
@@ -917,7 +917,7 @@ DedicatedScheduler::deactivateClaim( match_rec* m_rec )
 
 
 void
-DedicatedScheduler::sendAlives( )
+DedicatedScheduler::checkClaimLeases( )
 {
 	match_rec	*mrec = nullptr;
 	time_t now = time(nullptr);

--- a/src/condor_schedd.V6/dedicated_scheduler.cpp
+++ b/src/condor_schedd.V6/dedicated_scheduler.cpp
@@ -920,27 +920,18 @@ void
 DedicatedScheduler::sendAlives( )
 {
 	match_rec	*mrec = nullptr;
-	int		  	numsent=0;
 	time_t now = time(nullptr);
-	bool starter_handles_alives = param_boolean("STARTER_HANDLES_ALIVES",true);
 
 	BeginTransaction();
 
 	all_matches->startIterations();
 	while( all_matches->iterate(mrec) == 1 ) {
-		if( mrec->m_startd_sends_alives == false &&
-			( mrec->status == M_ACTIVE || mrec->status == M_CLAIMED ) ) {
-			if( sendAlive( mrec ) ) {
-				numsent++;
-			}
-		}
 
-		if (mrec->m_startd_sends_alives && (mrec->status == M_ACTIVE)) {
+		if (mrec->status == M_ACTIVE) {
 				// in receive_startd_update, we've updated the lease time only in the job ad
 				// actually write it to the job log here in one big transaction.
 			time_t renew_time = 0;
-			if ( starter_handles_alives && 
-				 mrec->shadowRec && mrec->shadowRec->pid > 0 ) 
+			if ( mrec->shadowRec && mrec->shadowRec->pid > 0 )
 			{
 				// If we're trusting the existance of the shadow to 
 				// keep the claim alive (because of kernel sockopt keepalives),
@@ -954,11 +945,6 @@ DedicatedScheduler::sendAlives( )
 	}
 
 	CommitTransactionOrDieTrying();
-
-	if( numsent ) {
-		dprintf( D_PROTOCOL, "## 6. (Done sending alive messages to "
-				 "%d dedicated startds)\n", numsent );
-	}
 }
 
 int

--- a/src/condor_schedd.V6/dedicated_scheduler.h
+++ b/src/condor_schedd.V6/dedicated_scheduler.h
@@ -212,7 +212,7 @@ class DedicatedScheduler : public Service {
 		// Used for claiming/releasing startds we control
 	bool releaseClaim( match_rec* m_rec );
 	bool deactivateClaim( match_rec* m_rec );
-	void sendAlives( void );
+	void checkClaimLeases( void );
 
 		// Reaper for the MPI shadow
 	int reaper( int pid, int status );

--- a/src/condor_schedd.V6/schedd.cpp
+++ b/src/condor_schedd.V6/schedd.cpp
@@ -15093,7 +15093,7 @@ Scheduler::RegisterTimers()
 	startjobsid = daemonCore->Register_Timer( start_jobs_timeslice,
 		(TimerHandlercpp)&Scheduler::StartJobs,"StartJobs",this);
 	aliveid = daemonCore->Register_Timer(10, alive_interval,
-		(TimerHandlercpp)&Scheduler::sendAlives,"sendAlives", this);
+		(TimerHandlercpp)&Scheduler::checkClaimLeases,"checkClaimLeases", this);
     // Preset the job queue clean timer only upon cold start, or if the timer
     // value has been changed.  If the timer period has not changed, leave the
     // timer alone.  This will avoid undesirable behavior whereby timer is
@@ -15884,8 +15884,8 @@ Scheduler::receive_startd_alive(int cmd, Stream *s) const
 			// If this match is active, i.e. we have a shadow, then
 			// update the ATTR_LAST_JOB_LEASE_RENEWAL in RAM.  We will
 			// commit it to disk in a big transaction batch via the timer
-			// handler method sendAlives().  We do this for scalability; we
-			// may have thousands of startds sending us updates...
+			// handler method checkClaimLeases().  We do this for scalability;
+			// we may have thousands of startds sending us updates...
 
 		// If the match is merely CLAIMED (e.g. CLAIMED/IDLE), there is no 
 		// job ad, but we want to mark this in the claim record itself
@@ -16052,7 +16052,7 @@ Scheduler::handle_collector_token_request(int, Stream *stream)
 }
 
 void
-Scheduler::sendAlives( int /* timerID */ )
+Scheduler::checkClaimLeases( int /* timerID */ )
 {
 		/*
 		  we need to timestamp any job ad with the last time we sent a
@@ -16153,7 +16153,7 @@ Scheduler::sendAlives( int /* timerID */ )
 	// Just so we don't have to deal with a seperate DC timer for
 	// this, just call the dedicated_scheduler's version of the
 	// same thing so we keep all of those claims alive, too.
-	dedicated_scheduler.sendAlives();
+	dedicated_scheduler.checkClaimLeases();
 }
 
 void

--- a/src/condor_schedd.V6/schedd.cpp
+++ b/src/condor_schedd.V6/schedd.cpp
@@ -9012,7 +9012,7 @@ Scheduler::contactStartd( ContactStartdArgs* args )
 	// Tell the startd side who should send alives... startd or schedd
 	jobAd->Assign( ATTR_STARTD_SENDS_ALIVES, true );
 	// Tell the startd if to should not send alives if starter is alive
-	jobAd->Assign( ATTR_STARTER_HANDLES_ALIVES, true);
+	jobAd->Assign( ATTR_STARTER_HANDLES_ALIVES, true );
 
 	// Tell the startd our name, which will go into the slot ad
 	jobAd->Assign(ATTR_SCHEDD_NAME, Name);

--- a/src/condor_schedd.V6/scheduler.h
+++ b/src/condor_schedd.V6/scheduler.h
@@ -273,7 +273,6 @@ class match_rec
 	bool			is_ocu {false}; // when true, hold forever, hand out to others
     PROC_ID         ocu_originator;  // procid of the ocu claimer job
 									
-	bool m_startd_sends_alives{false}; // in practice, actual default is true since 7.5.4
 	bool m_claim_pslot{false};
 	int  m_multi_slot{0}; // when > 1, this is a multi-slot claim request
 
@@ -1133,7 +1132,6 @@ struct JOB_ID_KEY;
 extern void set_job_status(int cluster, int proc, int status);
 extern bool claimStartd( match_rec* mrec );
 extern bool claimStartdConnected( Sock *sock, match_rec* mrec, ClassAd *job_ad);
-extern bool sendAlive( match_rec* mrec );
 extern void fixReasonAttrs( PROC_ID job_id, JobAction action );
 extern bool moveStrAttr( PROC_ID job_id, const char* old_attr,  
 						 const char* new_attr, bool verbose );

--- a/src/condor_schedd.V6/scheduler.h
+++ b/src/condor_schedd.V6/scheduler.h
@@ -548,7 +548,7 @@ class Scheduler : public Service
 	void			ExpediteStartJobs() const;
 	void			StartJobs( int timerID = -1 );
 	void			StartJob(match_rec *rec);
-	void			sendAlives( int timerID = -1 );
+	void			checkClaimLeases( int timerID = -1 );
 	void			RecomputeAliveInterval(int cluster, int proc);
 	void			StartJobHandler( int timerID = -1 );
 	void			addRunnableJob( shadow_rec* );
@@ -1057,7 +1057,7 @@ private:
 		// leaseAliveInterval is the minimum interval we need to send
 		// keepalives based upon ATTR_JOB_LEASE_DURATION...
 	int				leaseAliveInterval;  
-	int				aliveid;	// timer id for sending keepalives to startd
+	int				aliveid;	// timer id for checking claim leases
 	int				MaxExceptions;	 // Max shadow excep. before we relinquish
 
 		// get connection info for creating sec session to a running job

--- a/src/condor_startd.V6/claim.cpp
+++ b/src/condor_startd.V6/claim.cpp
@@ -974,23 +974,20 @@ Claim::startLeaseTimer()
 	// because the  job ad we get from the shadow at activation time doesn't have
 	// the necessary attributes - they are only in the job ad we get from the schedd at claim time
 	// see #6568 for more details.
-	std::string value;
-	param( value, "STARTD_SENDS_ALIVES", "peer" );
+	// CRUFT Starting in 25.3, the schedd always sets this to true
 	if ( c_jobad && c_jobad->LookupBool( ATTR_STARTD_SENDS_ALIVES, c_startd_sends_alives ) ) {
 		// Use value from ad
-	} else if ( strcasecmp( value.c_str(), "false" ) == 0 ) {
-		c_startd_sends_alives = false;
-	} else if ( strcasecmp( value.c_str(), "true" ) == 0 ) {
-		c_startd_sends_alives = true;
 	} else {
-		// No direction from the schedd or config file.
-		c_startd_sends_alives = false;
+		// No direction from the schedd.
+		// Assume true, so future schedds can drop this ancient option.
+		c_startd_sends_alives = true;
 	}
 
 	// If startd is sending the alives, look to see if the schedd is requesting
 	// that we let only send alives when there is no starter present (i.e. when
 	// the claim is idle).
-	c_starter_handles_alives = false;  // default to false unless schedd tells us
+	// CRUFT Starting in 25.3, the schedd always sets this to true
+	c_starter_handles_alives = true;  // default to true unless schedd tells us
 	if (c_jobad) {
 		c_jobad->LookupBool( ATTR_STARTER_HANDLES_ALIVES, c_starter_handles_alives );
 	}

--- a/src/condor_startd.V6/command.cpp
+++ b/src/condor_startd.V6/command.cpp
@@ -2134,7 +2134,6 @@ caLocateStarter( Stream *s, char* cmd_str, ClassAd* req_ad )
 	Claim* claim = NULL;
 	int rval = TRUE;
 	ClassAd reply;
-	std::string startd_sends_alives;
 
 	req_ad->LookupString(ATTR_CLAIM_ID, claimid);
 	req_ad->LookupString(ATTR_GLOBAL_JOB_ID, global_job_id);
@@ -2158,9 +2157,7 @@ caLocateStarter( Stream *s, char* cmd_str, ClassAd* req_ad )
 		// if startd is sending keepalives to the schedd,
 		// then we _must_ be passed the address of the schedd
 		// since it likely changed.
-	param( startd_sends_alives, "STARTD_SENDS_ALIVES", "peer" );
-	if ( (schedd_addr.empty()) && 
-		 strcasecmp( startd_sends_alives.c_str(), "false" ) )
+	if ( schedd_addr.empty() )
 	{
 		std::string err_msg;
 		formatstr(err_msg, "Required %s, not found in request",

--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -1863,17 +1863,6 @@ type=int
 tags=startd
 description=Rate at which the Startd sends updates to the Collector
 
-[STARTD_SENDS_ALIVES]
-default=peer
-type=string
-tags=startd,command
-
-[STARTER_HANDLES_ALIVES]
-default=true
-type=bool
-description=Startd should only send alives when slot idle
-tags=schedd,claim
-
 [VM_GAHP_CONFIG]
 default=
 type=string


### PR DESCRIPTION
Now, the schedd insists that the startd always sends alives and the shadow/starter handle alives when they're running. The startd will still honor schedd-sends-alives requests from the schedd, thought it now assumes no direction from the schedd means startd-sends-alives.
Also, keep match_rec::last_alive in synch with ATTR_LAST_JOB_LEASE_RENEWAL in all code paths and use it instead of consulting the job ad.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
