### PR TITLE
(HTCONDOR-3319)  Only create invalid classad2.ExprTree objects if the bindings are calling.

### DIFF
--- a/bindings/python/classad2/_expr_tree.py
+++ b/bindings/python/classad2/_expr_tree.py
@@ -19,12 +19,14 @@ class ExprTree:
     An expression in the ClassAd language.
     """
 
+    _Nill = object()
+
     # FIXME: Allowing the creation of stray ExprTrees from Python is probably
     # not a good idea, but Ornithology needs it for now.
     def __init__(self, expr : Optional[Union[str, "ExprTree"]] = None):
         """
         :param expr:
-           * If :py:obj:`None`, create an empty :class:`ExprTree`.
+           * If :py:obj:`None`, create an undefined :class:`ExprTree`.
            * If a :class:`str`, parse the string in the ClassAd language
              and create the corresponding :class:`ExprTree`.
            * If an :class:`ExprTree`, create a deep copy of ``expr``.
@@ -32,9 +34,17 @@ class ExprTree:
         self._handle = handle_t()
         _exprtree_init(self, self._handle)
 
-        # FIXME: This is awful, but at least it doesn't involve more C code.
-        if expr is not None:
-            classad_string = f'[expression = {str(expr)}]'
+        if expr is ExprTree._Nill:
+            # This used by the C++ side when it creates a new ExprTree
+            # to signal that it will populate the fields itself.
+            pass
+        else:
+            if expr is None:
+                classad_string = f'[expression = undefined]'
+            else:
+                classad_string = f'[expression = {str(expr)}]'
+
+            # FIXME: This is awful, but at least it doesn't involve more C code.
             c = ClassAd(classad_string)
             expression = c.lookup('expression')
             assert type(expression) == ExprTree

--- a/src/python-bindings/common2/py_util.cpp
+++ b/src/python-bindings/common2/py_util.cpp
@@ -114,10 +114,22 @@ py_new_classad_exprtree( ExprTree * original ) {
 		py_exprtree_class = PyObject_GetAttrString( py_classad2_module, "ExprTree" );
 	}
 
+	static PyObject * py_exprtree_nill = NULL;
+	if( py_exprtree_nill == NULL ) {
+		py_exprtree_nill = PyObject_GetAttrString( py_exprtree_class, "_Nill" );
+	}
+
+
 	ExprTree * copy = original->Copy();
 	copy->SetParentScope(NULL);
 
-	PyObject * pyExprTree = PyObject_CallObject(py_exprtree_class, NULL);
+	PyObject * pyArgsTuple = Py_BuildValue( "(O)", py_exprtree_nill );
+	if( pyArgsTuple == NULL ) {
+		// Py_BuildValue() has already set an exception for us.
+		return NULL;
+	}
+	PyObject * pyExprTree = PyObject_CallObject(py_exprtree_class, pyArgsTuple );
+	Py_DecRef(pyArgsTuple);
 	auto * handle = get_handle_from(pyExprTree);
 
 	// PyObject_CallObject() should have called __init__() for us, which


### PR DESCRIPTION
We can't just create an empty `ExprTree` if the argument to `__init__()` is `None` because the C++ code needs to construct a new `classad2.ExprTree` object on _its_ side, and uses the default constructor to do so.

Instead, create a special flag value that the C++ side can look up and pass into the constructor; this is now the only way to construct an invalid `classad2.ExprTree`.  Passing `None` can now be detected as a valid use of the API (and the initialization is identical, except that the argument passed to the C++ side is always the string `undefined`).

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
