### PR TITLE
HTCONDOR-3665 Fix socket fd leak in sendDockerAPI

### DIFF
--- a/src/condor_utils/docker-api.cpp
+++ b/src/condor_utils/docker-api.cpp
@@ -955,6 +955,7 @@ sendDockerAPIRequest( const std::string & request, std::string & response ) {
 			docker_socket_path = docker_host.substr(sizeof("unix://") - 1);
 		} else {
 			dprintf(D_ALWAYS, "Cannot retrieve docker universe statistics, DOCKER_HOST environment variable (%s) is not set to a unix socket path\n", docker_host.c_str());
+			close(uds);
 			return -1;
 		}
 	}


### PR DESCRIPTION
When DOCKER_HOST is set but does not start with "unix://", the function returns -1 without closing the unix domain socket opened earlier. Add close(uds) before the early return, matching the pattern used by the other error-return paths in the same function.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
