### PR TITLE
HTCONDOR-3665 Value-initialize scalar arrays in LibrarianConfig

### DIFF
--- a/src/archive_librarian/config.hpp
+++ b/src/archive_librarian/config.hpp
@@ -57,10 +57,10 @@ public:
 	const std::string& operator[](LibrarianConfigOptions::str opt) const { return strOpts[static_cast<size_t>(opt)]; }
 
 private:
-	std::array<bool, static_cast<size_t>(LibrarianConfigOptions::b::_SIZE)> boolOpts;
-	std::array<int, static_cast<size_t>(LibrarianConfigOptions::i::_SIZE)> intOpts;
-	std::array<long long, static_cast<size_t>(LibrarianConfigOptions::ll::_SIZE)> longlongOpts;
-	std::array<double, static_cast<size_t>(LibrarianConfigOptions::dbl::_SIZE)> doubleOpts;
+	std::array<bool, static_cast<size_t>(LibrarianConfigOptions::b::_SIZE)> boolOpts{};
+	std::array<int, static_cast<size_t>(LibrarianConfigOptions::i::_SIZE)> intOpts{};
+	std::array<long long, static_cast<size_t>(LibrarianConfigOptions::ll::_SIZE)> longlongOpts{};
+	std::array<double, static_cast<size_t>(LibrarianConfigOptions::dbl::_SIZE)> doubleOpts{};
 	std::array<std::string, static_cast<size_t>(LibrarianConfigOptions::str::_SIZE)> strOpts;
 };
 

--- a/src/archive_librarian/config.hpp
+++ b/src/archive_librarian/config.hpp
@@ -61,6 +61,6 @@ private:
 	std::array<int, static_cast<size_t>(LibrarianConfigOptions::i::_SIZE)> intOpts{};
 	std::array<long long, static_cast<size_t>(LibrarianConfigOptions::ll::_SIZE)> longlongOpts{};
 	std::array<double, static_cast<size_t>(LibrarianConfigOptions::dbl::_SIZE)> doubleOpts{};
-	std::array<std::string, static_cast<size_t>(LibrarianConfigOptions::str::_SIZE)> strOpts;
+	std::array<std::string, static_cast<size_t>(LibrarianConfigOptions::str::_SIZE)> strOpts{};
 };
 


### PR DESCRIPTION
The std::array members for bool, int, long long, and double are default-initialized (leaving elements indeterminate) before the constructor body runs. Add {} to value-initialize all elements to zero before the constructor overwrites specific ones.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
