### PR TITLE
HTCONDOR-3665 Fix dereference before null check in parse_int

### DIFF
--- a/src/condor_tests/startup_limit_ctl.cpp
+++ b/src/condor_tests/startup_limit_ctl.cpp
@@ -36,9 +36,10 @@ void usage()
 
 bool parse_int(const char *s, int &out)
 {
+    if (!s || *s == '\0') { return false; }
     char *end = nullptr;
     long v = strtol(s, &end, 10);
-    if (!s || *s == '\0' || (end && *end)) { return false; }
+    if (end && *end) { return false; }
     out = (int)v;
     return true;
 }


### PR DESCRIPTION
strtol(s, ...) dereferences s before the null check on the next line. Move the null/empty check before the strtol call.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
