### PR TITLE
HTCONDOR-3665 Replace !find() with starts_with() in xbd GetSessions

### DIFF
--- a/src/condor_kbdd/MutterInterface.unix.cpp
+++ b/src/condor_kbdd/MutterInterface.unix.cpp
@@ -197,7 +197,7 @@ MutterInterface::GetSessions()
 				  /* Find the DBUS_SESSION_BUS_ADDRESS variable in the
 					 environment, we need it to connect later */
 				  while (std::getline(environ, line, '\0')) {
-					  if (!line.find("DBUS_SESSION_BUS_ADDRESS=")) {
+					  if (line.starts_with("DBUS_SESSION_BUS_ADDRESS=")) {
 						  StatInfo s = StatInfo(dir_entry.path().c_str());
 
 						  /* Remove "DBUS_BUS_SESSION=" from string, we just want


### PR DESCRIPTION
Using !string::find() to test for a prefix is confusing and fragile -- find() returns size_t, so ! only works when the result is 0 (string starts with prefix). Replace with the clearer C++20 starts_with().

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
