### PR TITLE
 HTCONDOR-3666 Set PYTHON_PATH correctly in condor_configure.

### DIFF
--- a/src/condor_scripts/condor_configure
+++ b/src/condor_scripts/condor_configure
@@ -577,9 +577,9 @@ unless ( $opt_disable_env_scripts ) {
 	print SH "PATH=\"$release_dir/bin:$release_dir/sbin:\$PATH\"\n";
 	print SH "export PATH\n";
 	print SH "if [ \"X\" != \"X\${PYTHONPATH-}\" ]; then\n";
-	print SH "  PYTHONPATH=\"$release_dir/lib/python:\$PYTHONPATH\"\n";
+	print SH "  PYTHONPATH=\"$release_dir/lib/python3:\$PYTHONPATH\"\n";
 	print SH "else\n";
-	print SH "  PYTHONPATH=\"$release_dir/lib/python\"\n";
+	print SH "  PYTHONPATH=\"$release_dir/lib/python3\"\n";
 	print SH "fi\n";
 	print SH "export PYTHONPATH\n";
 	close( SH );
@@ -590,9 +590,9 @@ unless ( $opt_disable_env_scripts ) {
 	print CSH "setenv CONDOR_CONFIG \"$config_file\"\n";
 	print CSH "setenv PATH \"$release_dir/bin:$release_dir/sbin:\$PATH\"\n";
 	print CSH "if (\$?PYTHONPATH) then\n";
-	print CSH "  setenv PYTHONPATH \"$release_dir/lib/python:\$PYTHONPATH\"\n";
+	print CSH "  setenv PYTHONPATH \"$release_dir/lib/python3:\$PYTHONPATH\"\n";
 	print CSH "else\n";
-	print CSH "  setenv PYTHONPATH \"$release_dir/lib/python\"\n";
+	print CSH "  setenv PYTHONPATH \"$release_dir/lib/python3\"\n";
 	print CSH "endif\n";
 	close( CSH );
 
@@ -601,7 +601,7 @@ unless ( $opt_disable_env_scripts ) {
 	print FISH "# The script should be sourced by the fish shell\n";
 	print FISH "set -x CONDOR_CONFIG \"$config_file\"\n";
 	print FISH "set -x -p PATH \"$release_dir/bin\" \"$release_dir/sbin\"\n";
-	print FISH "set -x -p PYTHONPATH \"$release_dir/lib/python\n";
+	print FISH "set -x -p PYTHONPATH \"$release_dir/lib/python3\n";
 	close( FISH );
 
 	if ( $opt_bosco ) {


### PR DESCRIPTION
https://opensciencegrid.atlassian.net/browse/HTCONDOR-3666

Developers still use the ancient condor_configure script to test newly built binaries by doing condor_configure --make-personal-condor.   Now that we no longer support Python 2 anywhere, lets finally update this script to set PYTHON_PATH to lib/python3 instead of lib/python.  

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
