### PR TITLE
HTCONDOR-3665 Pass FileInfo by const reference in updateFileInfo

### DIFF
--- a/src/archive_librarian/dbHandler.cpp
+++ b/src/archive_librarian/dbHandler.cpp
@@ -708,7 +708,7 @@ void DBHandler::writeFileInfo(FileInfo &info) {
  * Update LastOffset for the history and epoch files after parsing.
  * Change offset to match progress in reading Epoch + History files
  */
-void DBHandler::updateFileInfo(FileInfo historyFile) {
+void DBHandler::updateFileInfo(const FileInfo &historyFile) {
     const char* updateSQL = R"(
         UPDATE Files
         SET LastOffset = ?

--- a/src/archive_librarian/dbHandler.h
+++ b/src/archive_librarian/dbHandler.h
@@ -51,7 +51,7 @@ public:
 
     // File Information Operations
     void writeFileInfo(FileInfo &info);
-    void updateFileInfo(FileInfo historyFile);
+    void updateFileInfo(const FileInfo &historyFile);
 
     // Status and Monitoring Operations
     bool writeStatusAndData(const Status& status, const StatusData& statusData);


### PR DESCRIPTION
FileInfo contains multiple std::string members and was passed by value, copying all strings unnecessarily. Pass by const reference since the function only reads from it.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
