### PR TITLE
HTCONDOR-3247 Workaround gcc 16 overly aggressive inlining yielding

### DIFF
--- a/src/condor_utils/CMakeLists.txt
+++ b/src/condor_utils/CMakeLists.txt
@@ -187,6 +187,7 @@ classad_oldnew.h
 classad_usermap.cpp
 classad_visa.cpp
 classad_visa.h
+classy_counted_ptr.cpp
 classy_counted_ptr.h
 command_strings.cpp
 command_strings.h

--- a/src/condor_utils/classy_counted_ptr.cpp
+++ b/src/condor_utils/classy_counted_ptr.cpp
@@ -1,0 +1,43 @@
+/***************************************************************
+ *
+ * Copyright (C) 1990-2026, Condor Team, Computer Sciences Department,
+ * University of Wisconsin-Madison, WI.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "condor_common.h"
+#include "classy_counted_ptr.h"
+
+// These are defined out-of-line on purpose; see the comment in
+// classy_counted_ptr.h.  Keeping the virtual destructor and decRefCount
+// out-of-line gives the vtable a stable key function and prevents the
+// `delete this` below from being inlined+devirtualized at every call
+// site (which on derived classes that place ClassyCountedPtr at a
+// nonzero subobject offset triggers a -Wfree-nonheap-object warning
+// under GCC 16).
+
+ClassyCountedPtr::~ClassyCountedPtr()
+{
+	ASSERT( m_ref_count == 0 );
+}
+
+void
+ClassyCountedPtr::decRefCount()
+{
+	ASSERT( m_ref_count > 0 );
+	if( --m_ref_count == 0 ) {
+		delete this;
+	}
+}

--- a/src/condor_utils/classy_counted_ptr.h
+++ b/src/condor_utils/classy_counted_ptr.h
@@ -94,16 +94,19 @@ class ClassyCountedPtr {
 public:
 	ClassyCountedPtr()
 		: m_ref_count(0) {}
-	virtual ~ClassyCountedPtr()
-		{ASSERT( m_ref_count == 0 );}
+	// Destructor and decRefCount are deliberately out-of-line so that
+	// they act as the "key function" for the vtable.  Keeping them
+	// out-of-line prevents the compiler from inlining `delete this`
+	// at every call site; with multiple inheritance (e.g. CCBListener,
+	// which has ClassyCountedPtr as a non-primary base), GCC 16's
+	// devirtualization would otherwise emit an `operator delete` call
+	// on the offset-adjusted base subobject pointer rather than going
+	// through the deleting-destructor slot in the vtable, producing a
+	// -Wfree-nonheap-object warning (and potentially incorrect codegen).
+	virtual ~ClassyCountedPtr();
 
 	void incRefCount() {m_ref_count++;}
-	void decRefCount() {
-		ASSERT( m_ref_count > 0 );
-		if( --m_ref_count == 0 ) {
-			delete this;
-		}
-	}
+	void decRefCount();
 
 private:
 	int m_ref_count;


### PR DESCRIPTION
bogus warning

gcc 16 incorretly devirutalizes the classy_counted_ptr destructor When doing so, the destructor's this pointer is offset by 8 When the ClassyCountedPtr is not the zero's base class when using multiple inheritance.  gcc 16 then emits the opaque warning:

operator delete called on pointer '<unknown>' with nonzero offset

Moving the destructor out of the header file into its own cpp file prevents gcc from devirtualizing it and fixes the warning.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
