### PR TITLE
HTCONDOR-3665 Don't even try to run coverity in non htcondor

### DIFF
--- a/.github/workflows/ci-coverity.yml
+++ b/.github/workflows/ci-coverity.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   resolve-ubunturoot-image:
+    if: github.repository == 'htcondor/htcondor'
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.extract.outputs.image }}
@@ -21,6 +22,7 @@ jobs:
           echo "image=$IMAGE" >> $GITHUB_OUTPUT
 
   build_and_analyze:
+    if: github.repository == 'htcondor/htcondor'
     needs: resolve-ubunturoot-image
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
repositories

The coverity gha needs the coverity API key, which only the htcondor repo should have.  However, if you fork the htcondor repo, you get the gha, and you waste 30 minutes of cpu time building htcondor every morning just for the analysis to fail because of the missing key.  Let's skip that.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
