### PR TITLE
HTCONDOR-3665 batlab test timeout xfer'ing large files

### DIFF
--- a/src/condor_tests/test_cif_catalogs.py
+++ b/src/condor_tests/test_cif_catalogs.py
@@ -473,13 +473,14 @@ def completed_container_jobs(the_container_condor, the_container_user_dir, the_c
     (the_container_kill_dir / f"kill-cc-{job_handle_b.clusterid}.1").touch(exist_ok=True)
 
 
-    # Wait for them to finish.
+    # Wait for them to finish.  Container jobs (Singularity startup/teardown)
+    # need more headroom than plain shell jobs.
     assert job_handle_a.wait(
-        timeout=60,
+        timeout=120,
         condition=ClusterState.all_terminal
     )
     assert job_handle_b.wait(
-        timeout=60,
+        timeout=120,
         condition=ClusterState.all_terminal
     )
 

--- a/src/condor_tests/test_cif_catalogs_fallback.py
+++ b/src/condor_tests/test_cif_catalogs_fallback.py
@@ -477,13 +477,14 @@ def completed_container_jobs(the_container_condor, the_container_user_dir, the_c
     (the_container_kill_dir / f"kill-cc-{job_handle_b.clusterid}.1").touch(exist_ok=True)
 
 
-    # Wait for them to finish.
+    # Wait for them to finish.  Container jobs (Singularity startup/teardown)
+    # need more headroom than plain shell jobs.
     assert job_handle_a.wait(
-        timeout=60,
+        timeout=120,
         condition=ClusterState.all_terminal
     )
     assert job_handle_b.wait(
-        timeout=60,
+        timeout=120,
         condition=ClusterState.all_terminal
     )
 


### PR DESCRIPTION
Seems like our docker network the tests run in occassionally gets very slow.  Let's up this timeout and see if it helps.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
