### PR TITLE
HTCONDOR-3665 Use strncpy instead of strcpy for peer IP buffer

### DIFF
--- a/src/condor_io/sock.cpp
+++ b/src/condor_io/sock.cpp
@@ -2479,7 +2479,8 @@ Sock::peer_ip_str() const
 {
 	if (!_peer_ip_buf[0]) {
 		std::string peer_ip = _who.to_ip_string();
-		strcpy(_peer_ip_buf, peer_ip.c_str());
+		strncpy(_peer_ip_buf, peer_ip.c_str(), IP_STRING_BUF_SIZE);
+		_peer_ip_buf[IP_STRING_BUF_SIZE - 1] = '\0';
 	}
 	return _peer_ip_buf;
 		/*


### PR DESCRIPTION
strcpy into the fixed-size _peer_ip_buf could overflow if the IP string exceeds IP_STRING_BUF_SIZE. Use strncpy with explicit null termination.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
