### PR TITLE
HTCONDOR-3665 Guard against null return from tokenizer in is_dag_command

### DIFF
--- a/src/condor_utils/submit_utils.cpp
+++ b/src/condor_utils/submit_utils.cpp
@@ -8480,7 +8480,8 @@ bool SubmitHash::is_dag_command(const char * line) {
 	};
 
 	StringTokenIterator l(line, " \t");
-	return dag_commands.contains(l.first());
+	const char * first = l.first();
+	return first && dag_commands.contains(first);
 }
 
 


### PR DESCRIPTION
StringTokenIterator::first() can return nullptr for empty input. Passing NULL to std::set::contains() constructs a std::string from a null pointer, which is undefined behavior.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
