### PR TITLE
HTCONDOR-3688 dc_schedd can now use a lambda to pass its callback

### DIFF
--- a/src/condor_daemon_client/dc_schedd.cpp
+++ b/src/condor_daemon_client/dc_schedd.cpp
@@ -2036,7 +2036,7 @@ DCSchedd::reassignSlot( PROC_ID bid, ClassAd & reply, std::string & errorMessage
 }
 
 
-class ImpersonationTokenContinuation : Service {
+class ImpersonationTokenContinuation : public Service {
 
 public:
 	ImpersonationTokenContinuation(const std::string &identity,
@@ -2052,13 +2052,8 @@ public:
 	  m_misc_data(misc_data)
 	{}
 
-	static void startCommandCallback(bool success, Sock *sock, CondorError *errstack,
-		const std::string & /*trust_domain*/, bool /*should_try_token_request*/,
-		void *misc_data);
-
 	int finish(Stream*);
 
-private:
 	std::string m_identity;
 	std::vector<std::string> m_authz_bounding_set;
 	int m_lifetime{-1};
@@ -2102,69 +2097,6 @@ int ImpersonationTokenContinuation::finish(Stream *stream)
 }
 
 
-void
-ImpersonationTokenContinuation::startCommandCallback(bool success, Sock *sock, CondorError *errstack,
-	const std::string & /*trust_domain*/, bool /*should_try_token_request*/, void *misc_data)
-{
-		// Automatically free our callback data at function exit.
-	std::unique_ptr<class ImpersonationTokenContinuation> callback_ptr(
-		static_cast<class ImpersonationTokenContinuation*>(misc_data));
-	ImpersonationTokenContinuation &callback_data = *callback_ptr;
-
-	if (!success) {
-		callback_data.m_callback(false, "", *errstack, callback_data.m_misc_data);
-		return;
-	}
-		// Ok, we have successfully established a connection.  Let's build the request ad
-		// and shoot it off.
-	classad::ClassAd request_ad;
-	if (!request_ad.InsertAttr(ATTR_SEC_USER, callback_data.m_identity) ||
-		!request_ad.InsertAttr(ATTR_SEC_TOKEN_LIFETIME, callback_data.m_lifetime))
-	{
-		errstack->push("DCSCHEDD", 2, "Failed to create schedd request ad.");
-		callback_data.m_callback(false, "", *errstack, callback_data.m_misc_data);
-		return;
-	}
-	if (!callback_data.m_authz_bounding_set.empty()) {
-		std::string authz_bounding_set_str =
-			join(callback_data.m_authz_bounding_set, ",");
-
-		if (!request_ad.InsertAttr(ATTR_SEC_LIMIT_AUTHORIZATION, authz_bounding_set_str))
-		{
-			errstack->push("DCSCHEDD", 2, "Failed to create schedd request ad.");
-			callback_data.m_callback(false, "", *errstack, callback_data.m_misc_data);
-			return;
-		}
-	}
-
-	sock->encode();
-	if (!putClassAd(sock, request_ad) ||
-		!sock->end_of_message())
-	{
-		errstack->push("DCSCHEDD", 3, "Failed to send impersonation token request ad"
-			" to remote schedd.");
-		callback_data.m_callback(false, "", *errstack, callback_data.m_misc_data);
-		return;
-	}
-
-		// Now, we must register a callback to wait for a response.
-	auto rc = daemonCore->Register_Socket(sock, "Impersonation Token Request",
-		(SocketHandlercpp)&ImpersonationTokenContinuation::finish,
-		"Finish impersonation token request",
-		callback_ptr.get(), HANDLE_READ);
-	if (rc < 0) {
-		errstack->push("DCSCHEDD", 4, "Failed to register callback for schedd response");
-		callback_data.m_callback(false, "", *errstack, callback_data.m_misc_data);
-		return;
-	}
-
-		// At this point, the callback has been registered and DaemonCore owns the
-		// memory; release the unique_ptr to prevent it from deleting the callback
-		// object at exit.
-	callback_ptr.release();
-}
-
-
 bool
 DCSchedd::requestImpersonationTokenAsync(const std::string &identity,
 	const std::vector<std::string> &authz_bounding_set, int lifetime,
@@ -2193,11 +2125,70 @@ DCSchedd::requestImpersonationTokenAsync(const std::string &identity,
 	}
 
 		// Connect to the schedd (if necessary) and start a non-blocking command.
-		// The continuation object holds the state needed to make the request ad later.
-	auto continuation = new ImpersonationTokenContinuation(identity, authz_bounding_set,
+		// The continuation object holds the state needed to make the request ad
+		// later. The lambda captures a raw pointer and re-wraps it in a unique_ptr
+		// on entry: the continuation is either freed when the lambda returns, or
+		// released to DaemonCore when Register_Socket succeeds.
+	auto *continuation = new ImpersonationTokenContinuation(identity, authz_bounding_set,
 		lifetime, callback, misc_data);
 	auto result = startCommand_nonblocking(COLLECTOR_TOKEN_REQUEST, Stream::reli_sock, 20, &err,
-		ImpersonationTokenContinuation::startCommandCallback, continuation,
+		[continuation](bool success, Sock *sock, CondorError *errstack,
+				const std::string & /*trust_domain*/, bool /*should_try_token_request*/) {
+			std::unique_ptr<ImpersonationTokenContinuation> callback_ptr(continuation);
+			ImpersonationTokenContinuation &callback_data = *callback_ptr;
+
+			if (!success) {
+				callback_data.m_callback(false, "", *errstack, callback_data.m_misc_data);
+				return;
+			}
+				// Ok, we have successfully established a connection.  Let's build the request ad
+				// and shoot it off.
+			classad::ClassAd request_ad;
+			if (!request_ad.InsertAttr(ATTR_SEC_USER, callback_data.m_identity) ||
+				!request_ad.InsertAttr(ATTR_SEC_TOKEN_LIFETIME, callback_data.m_lifetime))
+			{
+				errstack->push("DCSCHEDD", 2, "Failed to create schedd request ad.");
+				callback_data.m_callback(false, "", *errstack, callback_data.m_misc_data);
+				return;
+			}
+			if (!callback_data.m_authz_bounding_set.empty()) {
+				std::string authz_bounding_set_str =
+					join(callback_data.m_authz_bounding_set, ",");
+
+				if (!request_ad.InsertAttr(ATTR_SEC_LIMIT_AUTHORIZATION, authz_bounding_set_str))
+				{
+					errstack->push("DCSCHEDD", 2, "Failed to create schedd request ad.");
+					callback_data.m_callback(false, "", *errstack, callback_data.m_misc_data);
+					return;
+				}
+			}
+
+			sock->encode();
+			if (!putClassAd(sock, request_ad) ||
+				!sock->end_of_message())
+			{
+				errstack->push("DCSCHEDD", 3, "Failed to send impersonation token request ad"
+					" to remote schedd.");
+				callback_data.m_callback(false, "", *errstack, callback_data.m_misc_data);
+				return;
+			}
+
+				// Now, we must register a callback to wait for a response.
+			auto rc = daemonCore->Register_Socket(sock, "Impersonation Token Request",
+				(SocketHandlercpp)&ImpersonationTokenContinuation::finish,
+				"Finish impersonation token request",
+				callback_ptr.get(), HANDLE_READ);
+			if (rc < 0) {
+				errstack->push("DCSCHEDD", 4, "Failed to register callback for schedd response");
+				callback_data.m_callback(false, "", *errstack, callback_data.m_misc_data);
+				return;
+			}
+
+				// At this point, the callback has been registered and DaemonCore owns the
+				// memory; release the unique_ptr to prevent it from deleting the callback
+				// object at exit.
+			callback_ptr.release();
+		},
 		"requestImpersonationToken");
 
 	if (result == StartCommandFailed) {


### PR DESCRIPTION
Convert ImpersonationTokenContinuation::startCommandCallback into an inline lambda passed to Daemon::startCommand_nonblocking. The former void *misc_data hand-off of the continuation pointer becomes a typed capture, and the static trampoline is gone. Class fields and the Service base become public so the non-member lambda can reach them.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
