### PR TITLE
(HTCONDOR-3701)  Improve code readability

### DIFF
--- a/src/condor_starter.V6.1/docker_proc.cpp
+++ b/src/condor_starter.V6.1/docker_proc.cpp
@@ -218,7 +218,7 @@ DockerProc::LaunchContainer() {
 	std::string innerdir("/test/execute/");
 	starter->SetInnerWorkingDir(innerdir.c_str());
 	#else
-	const char * outerdir = starter->GetWorkingDir(false);
+	const char * outerdir = starter->GetWorkingDir(WD::OUTER);
 	std::string innerdir(outerdir);
 	const char * tmp = strstr(outerdir, "\\execute\\");
 	if (tmp) {
@@ -269,7 +269,7 @@ DockerProc::LaunchContainer() {
 	int childFDs[3] = { 0, 0, 0 };
 	{
 	TemporaryPrivSentry sentry(PRIV_USER);
-	std::string workingDir = starter->GetWorkingDir(0);
+	std::string workingDir = starter->GetWorkingDir(WD::OUTER);
 	//std::string DockerOutputFile = workingDir + "/docker_stdout";
 
 	//childFDs[1] = open(DockerOutputFile.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0666);
@@ -331,7 +331,7 @@ DockerProc::PullImage() {
 	CondorError err;
 	int pullReaperId = daemonCore->Register_Reaper("PullReaper", (ReaperHandlercpp)&DockerProc::PullReaper,
 			"PullReaper", this);
-	int r = DockerAPI::pullImage(imageName, credentials_dir(), starter->GetWorkingDir(0), *JobAd, pullReaperId, err);
+	int r = DockerAPI::pullImage(imageName, credentials_dir(), starter->GetWorkingDir(WD::OUTER), *JobAd, pullReaperId, err);
 	if (r == 0) {
 		return TRUE;
 	} else {
@@ -709,8 +709,8 @@ DockerProc::SetupDockerSsh() {
 	pipe_addr.sun_family = AF_UNIX;
 	unsigned pipe_addr_len;
 
-	std::string workingDir = starter->GetWorkingDir(0);
-	std::string pipeName = workingDir + "/.docker_sock";	
+	std::string workingDir = starter->GetWorkingDir(WD::OUTER);
+	std::string pipeName = workingDir + "/.docker_sock";
 
 	strncpy(pipe_addr.sun_path, pipeName.c_str(), sizeof(pipe_addr.sun_path)-1);
 	pipe_addr_len = SUN_LEN(&pipe_addr);
@@ -1001,7 +1001,7 @@ DockerProc::getStats( int /* timerID */ ) {
 
 			// Append serviceAd to the sandbox's copy of the job ad.
 			std::string jobAdFileName;
-			formatstr( jobAdFileName, "%s/.job.ad", starter->GetWorkingDir(0) );
+			formatstr( jobAdFileName, "%s/.job.ad", starter->GetWorkingDir(WD::OUTER) );
 			{
 				TemporaryPrivSentry sentry(PRIV_ROOT);
 				// ... sigh ...
@@ -1156,7 +1156,7 @@ static void buildExtraVolumes(std::list<std::string> &extras, ClassAd &machAd, C
 #endif
 
 	if (scratchNames.length() > 0) {
-		std::string workingDir = starter->GetWorkingDir(0);
+		std::string workingDir = starter->GetWorkingDir(WD::OUTER);
 			// Foreach scratch name...
 		for (const auto &scratchName: StringTokenIterator(scratchNames)) {
 			std::string hostdirbuf;

--- a/src/condor_starter.V6.1/docker_proc.h
+++ b/src/condor_starter.V6.1/docker_proc.h
@@ -44,8 +44,8 @@ class DockerProc : public VanillaProc {
 		static bool Detect();
 		static bool Version( std::string & version );
 
-		std::string DockerErrorFile() { 
-			return std::string(starter->GetWorkingDir(0)) + "/.docker_stderror";
+		std::string DockerErrorFile() {
+			return std::string(starter->GetWorkingDir(WD::OUTER)) + "/.docker_stderror";
 		}
 	protected:
 		virtual bool restartCheckpointedJob();

--- a/src/condor_starter.V6.1/jic_local.cpp
+++ b/src/condor_starter.V6.1/jic_local.cpp
@@ -359,8 +359,8 @@ JICLocal::initJobInfo( void )
 		// stash the iwd name in orig_job_iwd
 	if( ! job_ad->LookupString(ATTR_JOB_IWD, orig_job_iwd) ) {
 		dprintf(D_ALWAYS, "%s not found in job ad, setting to %s\n",
-				ATTR_JOB_IWD, starter->GetWorkingDir(0));
-		job_ad->Assign(ATTR_JOB_IWD, starter->GetWorkingDir(0));
+				ATTR_JOB_IWD, starter->GetWorkingDir(WD::OUTER));
+		job_ad->Assign(ATTR_JOB_IWD, starter->GetWorkingDir(WD::OUTER));
 	} else {
 			// put the orig job iwd in class ad
 		dprintf(D_ALWAYS, "setting the orig job iwd in starter\n");
@@ -549,7 +549,7 @@ JICLocal::initUserCredentials()
 
 	// setup .condor_creds directory in sandbox (may already exist).
 	std::string sandbox_dir_name;
-	dircat(starter->GetWorkingDir(0), ".condor_creds", sandbox_dir_name);
+	dircat(starter->GetWorkingDir(WD::OUTER), ".condor_creds", sandbox_dir_name);
 
 	htcondor::LocalUnivCredDirCreator creds(*job_ad, sandbox_dir_name);
 	CondorError err;

--- a/src/condor_starter.V6.1/jic_shadow.cpp
+++ b/src/condor_starter.V6.1/jic_shadow.cpp
@@ -587,7 +587,7 @@ JICShadow::transferOutputStart(bool& transient_failure, bool& in_progress)
 
 	// if we are writing a sandbox starter log, flush and temporarily close it before we make the manifest
 	if (job_ad->Lookup(ATTR_JOB_STARTER_DEBUG)) {
-		dprintf_close_logs_in_directory(starter->GetWorkingDir(false), false);
+		dprintf_close_logs_in_directory(starter->GetWorkingDir(WD::OUTER), false);
 	}
 
 	std::string dummy;
@@ -1219,7 +1219,7 @@ JICShadow::updateStartd( ClassAd *ad, bool final_update )
 		// Send the effect scratch dir path to starter, we already sent it to the shadow in the starter ad
 		// and we *don't* want to send it to the shadow to be incorporated into the job ad.
 		// TODO figure out a way to only send this once? maybe we should have an initial_update as well as a final update?
-		const char * sandbox_dir = starter->GetWorkingDir(false);
+		const char * sandbox_dir = starter->GetWorkingDir(WD::OUTER);
 		if (sandbox_dir && sandbox_dir[0]) {
 			ad->Assign(ATTR_CONDOR_SCRATCH_DIR, sandbox_dir);
 		}
@@ -1263,7 +1263,7 @@ JICShadow::notifyStarterError( const char* err_msg, bool critical, int hold_reas
 	// else to go if this is a recurring problem.
 	if( starter->WorkingDirExists() && job_universe != CONDOR_UNIVERSE_LOCAL ) {
 		struct stat si = {};
-		if (stat(starter->GetWorkingDir(false), &si) != 0 && errno == ENOENT &&
+		if (stat(starter->GetWorkingDir(WD::OUTER), &si) != 0 && errno == ENOENT &&
 		    shouldHoldJobBasedOnCodes(hold_reason_code, hold_reason_subcode))
 		{
 			dprintf(D_ALWAYS, "Scratch execute directory disappeared unexpectedly, declining to put job on hold.\n");
@@ -1351,7 +1351,7 @@ JICShadow::publishStarterInfo( ClassAd* ad )
 
 	ad->Assign(ATTR_STARTER_IP_ADDR, daemonCore->InfoCommandSinfulString() );
 
-	const char * sandbox_dir = starter->GetWorkingDir(false);
+	const char * sandbox_dir = starter->GetWorkingDir(WD::OUTER);
 	if (sandbox_dir && sandbox_dir[0]) {
 		ad->Assign(ATTR_CONDOR_SCRATCH_DIR, sandbox_dir);
 	}
@@ -1884,7 +1884,7 @@ JICShadow::initWithFileTransfer()
 
 	wants_file_transfer = true;
 	change_iwd = true;
-	job_iwd = strdup( starter->GetWorkingDir(0) );
+	job_iwd = strdup( starter->GetWorkingDir(WD::OUTER) );
 	job_ad->Assign( ATTR_JOB_IWD, job_iwd );
 
 		// now that we've got the iwd we're using and all our
@@ -2308,11 +2308,11 @@ JICShadow::publishStartdUpdates( ClassAd* ad ) {
 
 		std::string updateAdPath;
 		formatstr( updateAdPath, "%s/%s",
-			starter->GetWorkingDir(0), ".update.ad"
+			starter->GetWorkingDir(WD::OUTER), ".update.ad"
 		);
 		if (param_boolean("STARTER_NESTED_SCRATCH", true)) {
 			formatstr( updateAdPath, "%s/%s",
-				starter->GetWorkingDir(0), "../htcondor/.update.ad"
+				starter->GetWorkingDir(WD::OUTER), "../htcondor/.update.ad"
 			);
 		}
 		FILE * updateAdFile = NULL;
@@ -2363,7 +2363,7 @@ JICShadow::publishUpdateAd( ClassAd* ad )
 		// Let's also send the stdout/stderr mtime, as a way for
 		// users to guess if their jobs are hung
 		struct stat buf;
-		const char* scratch_dir_ptr = starter->GetWorkingDir(0);
+		const char* scratch_dir_ptr = starter->GetWorkingDir(WD::OUTER);
 		if (scratch_dir_ptr) {
 			TemporaryPrivSentry p( PRIV_USER );
 
@@ -2683,10 +2683,10 @@ JICShadow::beginInputTransfer( void )
 		}
 
 		std::string job_ad_path, machine_ad_path;
-		formatstr(job_ad_path, "%s%c%s", starter->GetWorkingDir(0),
+		formatstr(job_ad_path, "%s%c%s", starter->GetWorkingDir(WD::OUTER),
 			DIR_DELIM_CHAR,
 			JOB_AD_FILENAME);
-		formatstr(machine_ad_path, "%s%c%s", starter->GetWorkingDir(0),
+		formatstr(machine_ad_path, "%s%c%s", starter->GetWorkingDir(WD::OUTER),
 			DIR_DELIM_CHAR,
 			MACHINE_AD_FILENAME);
 		filetrans->setRuntimeAds(job_ad_path, machine_ad_path);
@@ -2741,7 +2741,7 @@ JICShadow::beginInputTransfer( void )
 	else if ( wants_x509_proxy ) {
 		
 			// Get scratch directory path
-		const char* scratch_dir = starter->GetWorkingDir(0);
+		const char* scratch_dir = starter->GetWorkingDir(WD::OUTER);
 
 			// Get source path to proxy file on the submit machine
 		std::string proxy_source_path;
@@ -2889,7 +2889,7 @@ JICShadow::transferInputStatus(FileTransfer *ftrans)
 		int checkpointNumber = -1;
 		std::string manifestFileName;
 		const char * currentFile = nullptr;
-		// Should this be starter->getWorkingDir(false)?
+		// Should this be starter->getWorkingDir(WD::OUTER)?
 		Directory sandboxDirectory( "." );
 		while( (currentFile = sandboxDirectory.Next()) ) {
 			checkpointNumber = manifest::getNumberFromFileName( currentFile );
@@ -2976,7 +2976,7 @@ JICShadow::transferInputStatus(FileTransfer *ftrans)
 		TemporaryPrivSentry _(PRIV_USER);
 
 		std::string cmd_basename = condor_basename(cmd.c_str());
-		std::string cmd_in_scratch_dir = std::string(starter->GetWorkingDir(false)) + 
+		std::string cmd_in_scratch_dir = std::string(starter->GetWorkingDir(WD::OUTER)) + 
 			DIR_DELIM_CHAR	 + cmd_basename;
 		if (chmod(cmd_in_scratch_dir.c_str(), 0755) == -1) {
 			if (errno != ENOENT) {
@@ -3447,7 +3447,7 @@ JICShadow::refreshSandboxCredentialsKRB()
 	//
 	// securely copy the cc to sandbox.
 	//
-	sandboxccfilename = dircat(starter->GetWorkingDir(0), user, ".cc", sandboxccfile);
+	sandboxccfilename = dircat(starter->GetWorkingDir(WD::OUTER), user, ".cc", sandboxccfile);
 
 	// as user, write tmp file securely
 	priv = set_user_priv();
@@ -3532,7 +3532,7 @@ JICShadow::refreshSandboxCredentialsOAuth()
 
 	// setup .condor_creds directory in sandbox (may already exist).
 	std::string sandbox_dir_name;
-	dircat(starter->GetWorkingDir(0), ".condor_creds", sandbox_dir_name);
+	dircat(starter->GetWorkingDir(WD::OUTER), ".condor_creds", sandbox_dir_name);
 
 	ShadowCredDirCreator creds(*job_ad, sandbox_dir_name);
 	CondorError err;
@@ -3788,9 +3788,9 @@ JICShadow::recordSandboxContents( const char * filename, bool add_to_output ) {
 	// copying from OpenManifestFile(), let's do everything right.
 	std::string errMsg;
 	TmpDir tmpDir;
-	if (!tmpDir.Cd2TmpDir(starter->GetWorkingDir(0),errMsg)) {
+	if (!tmpDir.Cd2TmpDir(starter->GetWorkingDir(WD::OUTER),errMsg)) {
 		dprintf( D_ERROR, "OpenManifestFile(%s): failed to cd to job sandbox %s\n",
-			filename, starter->GetWorkingDir(0));
+			filename, starter->GetWorkingDir(WD::OUTER));
 		fclose(file);
 		return;
 	}

--- a/src/condor_starter.V6.1/job_info_communicator.cpp
+++ b/src/condor_starter.V6.1/job_info_communicator.cpp
@@ -521,7 +521,7 @@ JobInfoCommunicator::initOutputAdFile( void )
 		if( job_output_ad_file[0] == '-' && job_output_ad_file[1] == '\0' ) {
 			job_output_ad_is_stdout = true;
 		} else if( ! fullpath(job_output_ad_file) ) {
-			std::string path = starter->GetWorkingDir(0);
+			std::string path = starter->GetWorkingDir(WD::OUTER);
 			path += DIR_DELIM_CHAR;
 			path += job_output_ad_file;
 			free( job_output_ad_file );
@@ -532,7 +532,7 @@ JobInfoCommunicator::initOutputAdFile( void )
 	}
 	if( ! m_job_update_ad_file.empty() ) {
 		if( ! fullpath(m_job_update_ad_file.c_str()) ) {
-			std::string path = starter->GetWorkingDir(0);
+			std::string path = starter->GetWorkingDir(WD::OUTER);
 			path += DIR_DELIM_CHAR;
 			path += m_job_update_ad_file;
 			m_job_update_ad_file = path;

--- a/src/condor_starter.V6.1/os_proc.cpp
+++ b/src/condor_starter.V6.1/os_proc.cpp
@@ -109,7 +109,7 @@ OsProc::canonicalizeJobPath(/* not const */ std::string &JobName, const char *jo
 		}
 		else if ( starter->jic->usingFileTransfer() && transfer_exe ) {
 			formatstr( JobName, "%s%c%s",
-					starter->GetWorkingDir(0),
+					starter->GetWorkingDir(WD::OUTER),
 					DIR_DELIM_CHAR,
 					condor_basename(JobName.c_str()) );
 		}
@@ -467,7 +467,7 @@ OsProc::StartJob(FamilyInfo* family_info, FilesystemRemap* fs_remap=NULL)
 			if (param_boolean("SINGULARITY_USE_LAUNCHER", false)) {
 				launcher = htcondor::Singularity::USE_LAUNCHER;
 			}
-			sing_result = htcondor::Singularity::setup(*starter->jic->machClassAd(), *JobAd, JobName, args, starter->GetSlotDir(), job_iwd ? job_iwd : "", starter->GetWorkingDir(0), job_env, launcher);
+			sing_result = htcondor::Singularity::setup(*starter->jic->machClassAd(), *JobAd, JobName, args, starter->GetSlotDir(), job_iwd ? job_iwd : "", starter->GetWorkingDir(WD::OUTER), job_env, launcher);
 		} else {
 			sing_result = htcondor::Singularity::DISABLE;
 		}
@@ -745,7 +745,7 @@ OsProc::JobReaper( int pid, int status )
 			if (droppedContainerLaunched) {
 				TemporaryPrivSentry sentry(PRIV_USER);
 				
-				std::string launchFilePath = starter->GetWorkingDir(0);
+				std::string launchFilePath = starter->GetWorkingDir(WD::OUTER);
 				launchFilePath += "/.condor_container_launched";
 				struct stat unused;
 				int r = stat(launchFilePath.c_str(), &unused);
@@ -1110,8 +1110,8 @@ OsProc::SetupSingularitySsh() {
 	pipe_addr.sun_family = AF_UNIX;
 	unsigned pipe_addr_len;
 
-	std::string workingDir = starter->GetWorkingDir(0);
-	std::string pipeName = workingDir + "/.docker_sock";	
+	std::string workingDir = starter->GetWorkingDir(WD::OUTER);
+	std::string pipeName = workingDir + "/.docker_sock";
 
 	strncpy(pipe_addr.sun_path, pipeName.c_str(), sizeof(pipe_addr.sun_path)-1);
 	pipe_addr_len = SUN_LEN(&pipe_addr);

--- a/src/condor_starter.V6.1/remote_proc.cpp
+++ b/src/condor_starter.V6.1/remote_proc.cpp
@@ -51,7 +51,7 @@ int RemoteProc::StartJob()
 	InitWorkerArgs(args, env, "submit_wait_stageout");
 
 	std::string sandbox_dir = starter->jic->jobRemoteIWD();
-	std::string scratch_dir = starter->GetWorkingDir(0);
+	std::string scratch_dir = starter->GetWorkingDir(WD::OUTER);
 
 	std::string job_ad_file = scratch_dir + ".job.ad";
 	args.AppendArg(job_ad_file.c_str());
@@ -119,7 +119,7 @@ ReapResult RemoteProc::JobReaper( int pid, int status )
 			// remote location.
 			// TODO For now, we're assuming tool's entire stdout/err
 			//   makes a suitable hold reason message.
-			std::string scratch_dir = starter->GetWorkingDir(0);
+			std::string scratch_dir = starter->GetWorkingDir(WD::OUTER);
 			std::string message;
 
 			char buf[512];
@@ -305,7 +305,7 @@ RemoteProc::getStats( int /* timerID */ ) {
 bool RemoteProc::PublishUpdateAd( ClassAd * ad ) {
 	// TODO Use data from .status.ad file
 
-	std::string status_file = starter->GetWorkingDir(0);
+	std::string status_file = starter->GetWorkingDir(WD::OUTER);
 	status_file += "/.job.ad.out";
 	FILE *status_fp = safe_fopen_wrapper_follow(status_file.c_str(), "r");
 	if ( status_fp != NULL ) {

--- a/src/condor_starter.V6.1/script_proc.cpp
+++ b/src/condor_starter.V6.1/script_proc.cpp
@@ -84,7 +84,7 @@ ScriptProc::StartJob()
 		// path to the binary, and don't try to chmod it.
 	std::string exe_path = "";
 	if( tmp != NULL && !fullpath( tmp ) ) {
-		exe_path += starter->GetWorkingDir(0);
+		exe_path += starter->GetWorkingDir(WD::OUTER);
 		exe_path += DIR_DELIM_CHAR;
 	}
 

--- a/src/condor_starter.V6.1/starter.cpp
+++ b/src/condor_starter.V6.1/starter.cpp
@@ -960,7 +960,7 @@ Starter::peek(int /*cmd*/, Stream *sock)
 	ssize_t max_xfer = -1;
 	input.EvaluateAttrInt(ATTR_MAX_TRANSFER_BYTES, max_xfer);
 
-	const char *jic_iwd = GetWorkingDir(0);
+	const char *jic_iwd = GetWorkingDir(WD::OUTER);
 	if (!jic_iwd) return PeekFailed(s, "Unknown job remote IWD.");
 	std::string iwd = jic_iwd;
 	char real_iwd[MAXPATHLEN+1];
@@ -1447,7 +1447,7 @@ Starter::startSSHD( int /*cmd*/, Stream* s )
 
 	ArgList setup_args;
 	setup_args.AppendArg(ssh_to_job_sshd_setup.c_str());
-	setup_args.AppendArg(GetWorkingDir(0));
+	setup_args.AppendArg(GetWorkingDir(WD::OUTER));
 	setup_args.AppendArg(ssh_to_job_shell_setup.c_str());
 	setup_args.AppendArg(sshd_config_template.c_str());
 	setup_args.AppendArg(ssh_keygen_cmd.c_str());
@@ -1466,7 +1466,7 @@ Starter::startSSHD( int /*cmd*/, Stream* s )
 			.wantCommandPort(FALSE)
 			.wantUDPCommandPort(FALSE)
 			.env(&setup_env)
-			.cwd(GetWorkingDir(0))
+			.cwd(GetWorkingDir(WD::OUTER))
 			.std(setup_std_fds)
 			.jobOptMask(setup_opt_mask));
 
@@ -3423,9 +3423,9 @@ Starter::OpenManifestFile( const char * filename, bool add_to_output )
 	// so set cwd to the sandbox (but reset the cwd when we return)
 	std::string errMsg;
 	TmpDir tmpDir;
-	if (!tmpDir.Cd2TmpDir(GetWorkingDir(0),errMsg)) {
+	if (!tmpDir.Cd2TmpDir(GetWorkingDir(WD::OUTER),errMsg)) {
 		dprintf( D_ERROR, "OpenManifestFile(%s): failed to cd to job sandbox %s\n",
-			filename, GetWorkingDir(0));
+			filename, GetWorkingDir(WD::OUTER));
 		return NULL;
 
 	}
@@ -3674,11 +3674,11 @@ Starter::PublishToEnv( Env* proc_env )
 		// job scratch space
 	env_name = base;
 	env_name += "SCRATCH_DIR";
-	proc_env->SetEnv( env_name.c_str(), GetWorkingDir(true) );
+	proc_env->SetEnv( env_name.c_str(), GetWorkingDir(WD::INNER) );
 
 		// Apptainer/Singlarity scratch dir
-	proc_env->SetEnv("APPTAINER_CACHEDIR", GetWorkingDir(true));
-	proc_env->SetEnv("SINGULARITY_CACHEDIR", GetWorkingDir(true));
+	proc_env->SetEnv("APPTAINER_CACHEDIR", GetWorkingDir(WD::INNER));
+	proc_env->SetEnv("SINGULARITY_CACHEDIR", GetWorkingDir(WD::INNER));
 
 		// slot identifier
 	env_name = base;
@@ -3708,7 +3708,7 @@ Starter::PublishToEnv( Env* proc_env )
 		// Condor will clean these up on job exits, and there's
 		// no chance of file collisions with other running slots
 
-	std::string tmpdirenv = this->tmpdir.empty() ? GetWorkingDir(true) : this->tmpdir;
+	std::string tmpdirenv = this->tmpdir.empty() ? GetWorkingDir(WD::INNER) : this->tmpdir;
 	proc_env->SetEnv("TMPDIR", tmpdirenv);
 	proc_env->SetEnv("TEMP",tmpdirenv);
 	proc_env->SetEnv("TMP", tmpdirenv);
@@ -3747,7 +3747,7 @@ Starter::PublishToEnv( Env* proc_env )
 			// setenv only if wrapper actually exists
 		if ( access(wrapper,X_OK) >= 0 ) {
 			std::string wrapper_err;
-			formatstr(wrapper_err, "%s%c%s", GetWorkingDir(0),
+			formatstr(wrapper_err, "%s%c%s", GetWorkingDir(WD::OUTER),
 						DIR_DELIM_CHAR,
 						JOB_WRAPPER_FAILURE_FILE);
 			proc_env->SetEnv("_CONDOR_WRAPPER_ERROR_FILE", wrapper_err);
@@ -3760,7 +3760,7 @@ Starter::PublishToEnv( Env* proc_env )
 		// so they will also appear in ssh_to_job environments.
 
 	std::string path;
-	formatstr(path, "%s%c%s", GetWorkingDir(true),
+	formatstr(path, "%s%c%s", GetWorkingDir(WD::INNER),
 			 	DIR_DELIM_CHAR,
 				MACHINE_AD_FILENAME);
 	if( ! proc_env->SetEnv("_CONDOR_MACHINE_AD", path) ) {
@@ -3773,7 +3773,7 @@ Starter::PublishToEnv( Env* proc_env )
 		dprintf( D_ALWAYS, "Failed to set _CONDOR_CHIRP_CONFIG environment variable.\n");
 	}
 
-	formatstr(path, "%s%c%s", GetWorkingDir(true),
+	formatstr(path, "%s%c%s", GetWorkingDir(WD::INNER),
 			 	DIR_DELIM_CHAR,
 				JOB_AD_FILENAME);
 	if( ! proc_env->SetEnv("_CONDOR_JOB_AD", path) ) {
@@ -3805,7 +3805,7 @@ Starter::PublishToEnv( Env* proc_env )
 
 	// Many jobs need an absolute path into the scratch directory in an environment var
 	// expand a magic string in an env var to the scratch dir
-	proc_env->Walk(&expandScratchDirInEnv, (void *)const_cast<char *>(GetWorkingDir(true)));
+	proc_env->Walk(&expandScratchDirInEnv, (void *)const_cast<char *>(GetWorkingDir(WD::INNER)));
 }
 
 // parse an environment prototype string of the form  key[[=/regex/replace/] key2=/regex2/replace2/]
@@ -4176,7 +4176,7 @@ Starter::WriteAdFiles() const
 {
 
 	ClassAd* ad;
-	const char* dir = this->GetWorkingDir(0);
+	const char* dir = this->GetWorkingDir(WD::OUTER);
 	std::string filename;
 	FILE* fp;
 	bool ret_val = true;

--- a/src/condor_starter.V6.1/starter.h
+++ b/src/condor_starter.V6.1/starter.h
@@ -26,13 +26,17 @@
 #include "execute_dir_monitor.h"
 #include "exit.h"
 
+enum class WD : bool {
+	INNER = true,
+	OUTER = false,
+};
+
 #if defined(LINUX) || defined(DARWIN)
     // We don't test on BSD, so don't claim the hardlink code works there.
     #define CFT_VERSION 2
 #else
     #define CFT_VERSION 0
 #endif
-
 
 #if defined(LINUX)
 #include "../condor_startd.V6/VolumeManager.h"
@@ -226,8 +230,8 @@ public:
 		/** Return the temporary directory under Execute for this job.
 		 *  If file transfer is used, this will also be the job's IWD.
 		 */
-	const char *GetWorkingDir(bool inner) const {
-		if (inner && ! InnerWorkingDir.empty()) {
+	const char *GetWorkingDir(WD which) const {
+		if (which == WD::INNER && ! InnerWorkingDir.empty()) {
 			return InnerWorkingDir.c_str();
 		}
 		return WorkingDir.c_str();

--- a/src/condor_starter.V6.1/starter_guidance.cpp
+++ b/src/condor_starter.V6.1/starter_guidance.cpp
@@ -911,8 +911,7 @@ Starter::handleJobSetupCommand(
 			// s->jic->getCommonFilesLocation( cifName, location );
 
 			dprintf( D_ZKM, "Will map common files %s at %s\n", cifName.c_str(), location.string().c_str() );
-			const bool OUTER = false;
-			std::filesystem::path sandbox( s->GetWorkingDir(OUTER) );
+			std::filesystem::path sandbox( s->GetWorkingDir(WD::OUTER) );
 			dprintf( D_ALWAYS, "Mapping common files into job's initial working directory...\n" );
 			bool result = mapContentsOfDirectoryInto( location, sandbox );
 

--- a/src/condor_starter.V6.1/tool_daemon_proc.cpp
+++ b/src/condor_starter.V6.1/tool_daemon_proc.cpp
@@ -75,7 +75,7 @@ ToolDaemonProc::StartJob()
 	const char* base = NULL;
 	base = condor_basename( tmp );
 	if( starter->jic->iwdIsChanged() ) {
-		formatstr( DaemonNameStr, "%s%c%s", starter->GetWorkingDir(0),
+		formatstr( DaemonNameStr, "%s%c%s", starter->GetWorkingDir(WD::OUTER),
 							   DIR_DELIM_CHAR, base );
 	} else if( ! fullpath(tmp) ) {
 		formatstr( DaemonNameStr, "%s%c%s", job_iwd, DIR_DELIM_CHAR, tmp );

--- a/src/condor_starter.V6.1/user_proc.cpp
+++ b/src/condor_starter.V6.1/user_proc.cpp
@@ -123,7 +123,7 @@ UserProc::JobReaper(int pid, int status)
 	std::string line;
 	std::string error_txt;
 	std::string filename;
-	const char* dir = starter->GetWorkingDir(0);
+	const char* dir = starter->GetWorkingDir(WD::OUTER);
 	FILE* fp;
 
 	dprintf( D_FULLDEBUG, "Inside UserProc::JobReaper()\n" );

--- a/src/condor_starter.V6.1/vanilla_proc.cpp
+++ b/src/condor_starter.V6.1/vanilla_proc.cpp
@@ -474,7 +474,7 @@ VanillaProc::StartJob()
 
 	// mount_under_scratch only works with rootly powers
 	if (! mount_under_scratch.empty() && can_switch_ids() && has_sysadmin_cap() && (job_universe != CONDOR_UNIVERSE_LOCAL)) {
-		const char* working_dir = starter->GetWorkingDir(0);
+		const char* working_dir = starter->GetWorkingDir(WD::OUTER);
 
 		if (IsDirectory(working_dir)) {
 			if (!fs_remap) {
@@ -551,7 +551,7 @@ VanillaProc::StartJob()
 			std::string arg_errors;
 			std::string filename;
 
-			filename = starter->GetWorkingDir(0);
+			filename = starter->GetWorkingDir(WD::OUTER);
 			filename += "/.condor_pid_ns_status";
 
 			if (!env.MergeFrom(JobAd,  env_errors)) {

--- a/src/condor_starter.V6.1/vm_proc.cpp
+++ b/src/condor_starter.V6.1/vm_proc.cpp
@@ -359,7 +359,7 @@ VMProc::StartJob()
 	if ( strcasecmp( m_vm_type.c_str(), CONDOR_VM_UNIVERSE_KVM ) == MATCH ||
 		 strcasecmp( m_vm_type.c_str(), CONDOR_VM_UNIVERSE_XEN ) == MATCH ) {
 		priv_state oldpriv = set_user_priv();
-		if ( chmod( starter->GetWorkingDir(0), 0755 ) == -1 ) {
+		if ( chmod( starter->GetWorkingDir(WD::OUTER), 0755 ) == -1 ) {
 			set_priv( oldpriv );
 			dprintf( D_ALWAYS, "Failed to chmod execute directory for Xen/KVM job: %s\n", strerror( errno ) );
 			return false;
@@ -373,7 +373,7 @@ VMProc::StartJob()
 		 strcasecmp( m_vm_type.c_str(), CONDOR_VM_UNIVERSE_XEN ) == MATCH ) {
 		ASSERT( create_name_for_VM( JobAd, vm_name ) );
 	} else {
-		vm_name = starter->GetWorkingDir(0);
+		vm_name = starter->GetWorkingDir(WD::OUTER);
 	}
 	recovery_ad.Assign( "JobVMId", vm_name );
 	starter->WriteRecoveryFile( &recovery_ad );
@@ -391,7 +391,7 @@ VMProc::StartJob()
 	ASSERT(m_vmgahp);
 
 	m_vmgahp->start_err_msg = "";
-	if( m_vmgahp->startUp(&job_env, starter->GetWorkingDir(0), nice_inc,
+	if( m_vmgahp->startUp(&job_env, starter->GetWorkingDir(WD::OUTER), nice_inc,
 				&fi) == false ) {
 		JobPid = -1;
 		err_msg = "Failed to start vm-gahp server";
@@ -428,7 +428,7 @@ VMProc::StartJob()
 				break;
 			case 1:
 			default:
-				p_result = new_req->vmStart( m_vm_type.c_str(), starter->GetWorkingDir(0) );
+				p_result = new_req->vmStart( m_vm_type.c_str(), starter->GetWorkingDir(WD::OUTER) );
 				break;
 			case 2:
 				p_result = VMGAHP_REQ_COMMAND_TIMED_OUT;
@@ -444,7 +444,7 @@ VMProc::StartJob()
 				break;
 		}
 	} else {
-		p_result = new_req->vmStart( m_vm_type.c_str(), starter->GetWorkingDir(0) );
+		p_result = new_req->vmStart( m_vm_type.c_str(), starter->GetWorkingDir(WD::OUTER) );
 	}
 
 


### PR DESCRIPTION
`GetWorkingDir(false)` never made very much sense, but `GetWorkingDir(0)` was even worse.  Refactor so that `GetWorkingDir()` now takes the `which` parameter, an enumeration of `WD::INNER` and `WD::OUTER`.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
