### PR TITLE
HTCONDOR-3703 Robustify slow test on ubuntu 26

### DIFF
--- a/src/condor_tests/test_container_uni.py
+++ b/src/condor_tests/test_container_uni.py
@@ -128,9 +128,13 @@ def completed_test_job(condor, test_job_hash):
     ctj = condor.submit(
         {**test_job_hash}, count=1
     )
+    # Ubuntu 26 ships /bin/cat from the rust uutils package, which is ~11 MB
+    # vs. ~50 KB for GNU coreutils. The executable plus the empty ignored.sif
+    # gives an ~11 MB sandbox, and on loaded CI runners that file transfer
+    # can take 75-90s, so a 60s timeout flakes.
     assert ctj.wait(
         condition=ClusterState.all_terminal,
-        timeout=60,
+        timeout=300,
         verbose=True,
         fail_condition=ClusterState.any_held,
     )
@@ -147,9 +151,10 @@ def completed_test_job_with_target_dir(condor, test_job_hash_with_target_dir):
     ctj = condor.submit(
         {**test_job_hash_with_target_dir}, count=1
     )
+    # See comment in completed_test_job re: Ubuntu 26 rust uutils /bin/cat.
     assert ctj.wait(
         condition=ClusterState.all_terminal,
-        timeout=60,
+        timeout=300,
         verbose=True,
         fail_condition=ClusterState.any_held,
     )


### PR DESCRIPTION
Ubuntu 26 ships /bin/cat from the rust uutils package, which is ~11 MB vs. ~50 KB for GNU coreutils. The executable
gives an ~11 MB sandbox, and on loaded CI runners that file transfer can take 75-90s, so a 60s timeout flakes.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
