### PR TITLE
HTCONDOR-3688 DCMessenger can now use a lambda to pass its callback

### DIFF
--- a/src/condor_daemon_client/dc_message.cpp
+++ b/src/condor_daemon_client/dc_message.cpp
@@ -352,14 +352,20 @@ void DCMessenger::startCommand( classy_counted_ptr<DCMsg> msg )
 		}
 	}
 
-	incRefCount();
+		// Keep ourselves alive for the duration of the startCommand by
+		// capturing a classy_counted_ptr in the callback closure. This
+		// replaces the manual incRefCount()/decRefCount() pair plus the
+		// void *misc_data = this handoff.
+	classy_counted_ptr<DCMessenger> self(this);
 	m_daemon->startCommand_nonblocking (
 		msg->m_cmd,
 		m_callback_sock,
 		msg->getTimeout(),
 		&msg->m_errstack,
-		&DCMessenger::connectCallback,
-		this,
+		[self](bool success, Sock *sock, CondorError * /*errstack*/,
+				const std::string &trust_domain, bool should_try_token_request) {
+			self->handleConnect(success, sock, trust_domain, should_try_token_request);
+		},
 		msg->name(),
 		msg->getRawProtocol(),
 		msg->getSecSessionId(),
@@ -407,32 +413,30 @@ DCMessenger::doneWithSock(Stream *sock)
 }
 
 void
-DCMessenger::connectCallback(bool success, Sock *sock, CondorError *, const std::string &trust_domain, bool should_try_token_request, void *misc_data)
+DCMessenger::handleConnect(bool success, Sock *sock, const std::string &trust_domain, bool should_try_token_request)
 {
-	ASSERT(misc_data);
+	classy_counted_ptr<DCMsg> msg = m_callback_msg;
 
-	DCMessenger *self = (DCMessenger *)misc_data;
-	classy_counted_ptr<DCMsg> msg = self->m_callback_msg;
-
-	self->m_callback_msg = NULL;
-	self->m_callback_sock = NULL;
-	self->m_pending_operation = NOTHING_PENDING;
-	self->m_daemon->m_trust_domain = trust_domain;
-	self->m_daemon->m_should_try_token_request = should_try_token_request;
+	m_callback_msg = nullptr;
+	m_callback_sock = nullptr;
+	m_pending_operation = NOTHING_PENDING;
+	m_daemon->m_trust_domain = trust_domain;
+	m_daemon->m_should_try_token_request = should_try_token_request;
 
 	if(!success) {
 		if( sock->deadline_expired() ) {
 			msg->addError( CEDAR_ERR_DEADLINE_EXPIRED, "deadline expired" );
 		}
-		msg->callMessageSendFailed( self );
-		self->doneWithSock(sock);
+		msg->callMessageSendFailed( this );
+		doneWithSock(sock);
 	}
 	else {
 		ASSERT(sock);
-		self->writeMsg( msg, sock );
+		writeMsg( msg, sock );
 	}
 
-	self->decRefCount();
+	// Our refcount (held by the lambda that called us) drops when the lambda
+	// is destroyed after this returns.
 }
 
 void DCMessenger::writeMsg( classy_counted_ptr<DCMsg> msg, Sock *sock )

--- a/src/condor_daemon_client/dc_message.h
+++ b/src/condor_daemon_client/dc_message.h
@@ -349,8 +349,9 @@ public:
 
 	friend class DCMsg;
 private:
-		// This is called by DaemonClient when startCommand has finished.
-	static void connectCallback(bool success, Sock *sock, CondorError *errstack, const std::string &trust_domain, bool should_try_token_request, void *misc_data);
+		// This is called by DaemonClient when startCommand has finished,
+		// via a lambda whose closure owns a classy_counted_ptr back to us.
+	void handleConnect(bool success, Sock *sock, const std::string &trust_domain, bool should_try_token_request);
 
 		// This is called by DaemonCore when the sock has data.
 	int receiveMsgCallback(Stream *sock);


### PR DESCRIPTION
Replace the static DCMessenger::connectCallback (which received DCMessenger via void *misc_data and manually balanced incRefCount/decRefCount) with a handleConnect method invoked through a lambda. The lambda captures a classy_counted_ptr<DCMessenger>(this), so the refcount is held for exactly the lifetime of the callback closure, and the manual inc/dec pair is gone.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
