### PR TITLE
HTCONDOR-3247 Join two dprintf D_NOHEADER into one for atomicity

### DIFF
--- a/src/condor_daemon_core.V6/daemon_core_main.cpp
+++ b/src/condor_daemon_core.V6/daemon_core_main.cpp
@@ -4040,11 +4040,15 @@ int dc_main( int argc, char** argv )
 			);
 	dprintf(D_ALWAYS,"** %s\n", CondorVersion());
 	dprintf(D_ALWAYS,"** %s\n", CondorPlatform());
-	dprintf(D_ALWAYS,"** PID = %lu", (unsigned long) daemonCore->getpid());
+	// Emit the whole line in a single dprintf so it lands in one atomic
+	// write().  When many daemons (e.g. shadows) share a log file, splitting
+	// this across two dprintf calls lets another process's message interleave
+	// between them, tearing the banner line.
 #ifdef WIN32
-	dprintf(D_ALWAYS | D_NOHEADER,"\n");
+	dprintf(D_ALWAYS,"** PID = %lu\n", (unsigned long) daemonCore->getpid());
 #else
-	dprintf(D_ALWAYS | D_NOHEADER, " RealUID = %u\n", getuid());
+	dprintf(D_ALWAYS,"** PID = %lu RealUID = %u\n",
+			(unsigned long) daemonCore->getpid(), getuid());
 #endif
 
 	time_t log_last_mod_time = dprintf_last_modification();


### PR DESCRIPTION
Without this, multiple shadows can tear writes into the dprintf log, which can break tests and confuse users and administrators.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [x] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
