### PR TITLE
HTCONDOR-3784 Add a Pelican credmon for fetching OAuth2 tokens from Pelican federations

### DIFF
--- a/build/nmi-build/setup.sh
+++ b/build/nmi-build/setup.sh
@@ -355,6 +355,19 @@ fi
 # pelican-osdf-compat went to noarch. Unfortunately, the old arch specific RPM is also downloaded
 rm -f "$externals_dir"/pelican-osdf-compat-*64.rpm
 
+# Install the Pelican client and server for the Pelican credmon integration
+# test (src/condor_tests/test_pelican_credmon.py), which stands up a POSIXv2
+# federation with the embedded issuer and exercises the device-code flow,
+# RFC 8693 token exchange, and refresh.  The above only *downloads* pelican for
+# bundling into the tarball; the test needs the binaries on PATH.
+#
+# `pelican` (>= 7.25.0) is a normal HTCondor runtime dependency and is present
+# in the HTCondor repositories.  `pelican-server` provides the federation and
+# may not be mirrored in every repository, so its installation is best-effort:
+# when it is absent the integration test simply skips.
+$INSTALL pelican
+$INSTALL pelican-server || echo "WARNING: pelican-server unavailable; test_pelican_credmon will skip"
+
 # Clean up package caches
 if [ "$ID" = 'centos' ]; then
     yum clean all

--- a/build/packaging/debian/condor.install.in
+++ b/build/packaging/debian/condor.install.in
@@ -9,6 +9,7 @@ usr/bin/condor_check_config
 usr/bin/condor_check_userlogs
 usr/bin/condor_config_val
 usr/bin/condor_continue
+usr/bin/condor_credential_storer
 usr/bin/condor_dagman
 usr/bin/condor_dag_checker
 usr/bin/condor_docker_enter

--- a/build/packaging/rpm/condor.spec
+++ b/build/packaging/rpm/condor.spec
@@ -1276,6 +1276,7 @@ rm -rf %{buildroot}
 %files credmon-vault
 %doc examples/condor_credmon_oauth
 %_sbindir/condor_credmon_vault
+%_bindir/condor_credential_storer
 %_bindir/condor_vault_storer
 %_libexecdir/condor/credmon
 %config(noreplace) %_sysconfdir/condor/config.d/40-vault-credmon.conf
@@ -1283,6 +1284,7 @@ rm -rf %{buildroot}
 %ghost %_var/lib/condor/oauth_credentials/pid
 
 %files credmon-multi
+%_bindir/condor_credential_storer
 %_bindir/condor_vault_storer
 
 %files -n minicondor

--- a/build/packaging/rpm/condor.spec
+++ b/build/packaging/rpm/condor.spec
@@ -1273,6 +1273,7 @@ rm -rf %{buildroot}
 %files credmon-vault
 %doc examples/condor_credmon_oauth
 %_sbindir/condor_credmon_vault
+%_bindir/condor_credential_storer
 %_bindir/condor_vault_storer
 %_libexecdir/condor/credmon
 %config(noreplace) %_sysconfdir/condor/config.d/40-vault-credmon.conf
@@ -1280,6 +1281,7 @@ rm -rf %{buildroot}
 %ghost %_var/lib/condor/oauth_credentials/pid
 
 %files credmon-multi
+%_bindir/condor_credential_storer
 %_bindir/condor_vault_storer
 
 %files -n minicondor

--- a/docs/admin-manual/configuration/credd.rst
+++ b/docs/admin-manual/configuration/credd.rst
@@ -218,3 +218,59 @@ These macros affect the *condor_credd* and its credmon plugin.
     matches provider ``box``). When ``True``, underscores are permitted
     in provider names and credential files are matched exactly, disabling
     handle support.
+:macro-def:`PELICAN_CREDMON_PROVIDER_NAMES`
+    A comma or space separated list of provider names that the Pelican
+    credential monitor should handle.  When a job requests OAuth credentials
+    with a provider name in this list, the Pelican credmon obtains an initial
+    token (via the device-code flow run by ``condor_vault_storer``), exchanges
+    it for a refreshable token using the credmon's own client, and keeps it
+    renewed.  There is no default value; Pelican services must be enumerated
+    explicitly.  :macro:`SEC_CREDENTIAL_STORER` must also be configured to point
+    to ``condor_vault_storer``.  See :ref:`installing_credmon_pelican`.
+
+:macro-def:`<PelicanServiceName>_PELICAN_URL`
+    For a Pelican service (one named in :macro:`PELICAN_CREDMON_PROVIDER_NAMES`),
+    the federation URL the tokens are good for, for example
+    ``pelican://osg-htc.org``.  May be a ``pelican://``, ``osdf://``, or
+    ``https://`` URL.  Combined with :macro:`<PelicanServiceName>_PELICAN_PREFIX`
+    to form the resource the storer requests a token for.
+
+:macro-def:`<PelicanServiceName>_PELICAN_PREFIX`
+    The federation namespace prefix the service's tokens should cover, for
+    example ``/physics-data``.
+
+:macro-def:`<PelicanServiceName>_PELICAN_PERMISSIONS`
+    The capabilities the service's tokens should grant: a whitespace and/or
+    comma separated list of one or more of ``read``, ``write``, and ``modify``.
+    These do not imply one another (``modify`` does not imply ``read``), so list
+    every capability the service needs, for example ``read, modify``.  The
+    default is ``read``.
+
+:macro-def:`<PelicanServiceName>_PELICAN_TOKEN_URL`
+    Optional.  An explicit OAuth2 token endpoint for the service's issuer, used
+    for the token exchange and subsequent refreshes.  When unset (the default),
+    the credmon discovers the endpoint via OIDC metadata
+    (``.well-known/openid-configuration``) from the issuer that minted the token
+    -- the issuer the federation's director resolves the prefix to -- and
+    re-checks it periodically.  Set this only to override that discovery.
+
+:macro-def:`<PelicanServiceName>_PELICAN_CLIENT_ID`
+    The client ID of the credmon's own OAuth2 client, registered with the
+    federation's token issuer and permitted the ``refresh_token`` and
+    ``urn:ietf:params:oauth:grant-type:token-exchange`` grant types.  Note that
+    a Pelican service deliberately uses ``_PELICAN_CLIENT_ID`` rather than
+    ``_CLIENT_ID``; a service with a ``<ServiceName>_CLIENT_ID`` is instead
+    treated as an OAuth2-webserver service.
+
+:macro-def:`<PelicanServiceName>_PELICAN_CLIENT_SECRET_FILE`
+    The full path to a file, readable only by root, containing the client
+    secret that corresponds to :macro:`<PelicanServiceName>_PELICAN_CLIENT_ID`.
+
+:macro-def:`PELICAN_CREDMON_CA_FILE`
+    The path to a CA bundle the Pelican credmon should trust when contacting the
+    federation issuer.  The default (unset) uses the system trust store.
+
+:macro-def:`PELICAN_CREDMON_TLS_SKIP_VERIFY`
+    A boolean that, when ``true``, disables TLS verification for the Pelican
+    credmon's connection to the federation issuer.  Intended for testing only;
+    the default is ``false``.

--- a/docs/admin-manual/configuration/credd.rst
+++ b/docs/admin-manual/configuration/credd.rst
@@ -222,11 +222,11 @@ These macros affect the *condor_credd* and its credmon plugin.
     A comma or space separated list of provider names that the Pelican
     credential monitor should handle.  When a job requests OAuth credentials
     with a provider name in this list, the Pelican credmon obtains an initial
-    token (via the device-code flow run by ``condor_vault_storer``), exchanges
+    token (via the device-code flow run by ``condor_credential_storer``), exchanges
     it for a refreshable token using the credmon's own client, and keeps it
     renewed.  There is no default value; Pelican services must be enumerated
     explicitly.  :macro:`SEC_CREDENTIAL_STORER` must also be configured to point
-    to ``condor_vault_storer``.  See :ref:`installing_credmon_pelican`.
+    to ``condor_credential_storer``.  See :ref:`installing_credmon_pelican`.
 
 :macro-def:`<PelicanServiceName>_PELICAN_URL`
     For a Pelican service (one named in :macro:`PELICAN_CREDMON_PROVIDER_NAMES`),

--- a/docs/admin-manual/file-and-cred-transfer.rst
+++ b/docs/admin-manual/file-and-cred-transfer.rst
@@ -667,8 +667,10 @@ to see how to set up and configure the Vault server.
 Note that, when using the ``condor-credmon-multi`` package,
 in order to signal ``condor_submit`` to request *any* credentials via Vault,
 you will also need to set (or uncomment) :macro:`SEC_CREDENTIAL_STORER` in your configuration
-and point it to the location of ``condor_vault_storer`` (usually
-``/usr/bin/condor_vault_storer``).
+and point it to the location of ``condor_credential_storer`` (usually
+``/usr/bin/condor_credential_storer``).  This script was previously named
+``condor_vault_storer``; that name is still installed as a symlink, so existing
+configurations that reference it continue to work unchanged.
 To help HTCondor distinguish which credentials should be provided by
 Vault, you should set ``VAULT_CREDMON_PROVIDER_NAMES`` to the list of
 Vault-managed credential names.
@@ -707,7 +709,7 @@ long as the user has jobs in the queue.
 
 To enable it, install the ``condor-credmon-oauth`` RPM -- which provides the
 *condor_credmon_oauth* daemon, the *condor_credd*, and the
-``condor_vault_storer`` -- as well as the ``pelican`` client, then enable the
+``condor_credential_storer`` -- as well as the ``pelican`` client, then enable the
 credd and credmon with the ``use feature: oauth`` configuration template.
 
 Next, register an OAuth2 client for the access point with the federation's token
@@ -719,7 +721,7 @@ the secret in a file readable only by root.
 
 For each Pelican "service" you wish to offer, add its name to
 ``PELICAN_CREDMON_PROVIDER_NAMES``, point :macro:`SEC_CREDENTIAL_STORER` at
-``condor_vault_storer`` so that :tool:`condor_submit` routes the request through
+``condor_credential_storer`` so that :tool:`condor_submit` routes the request through
 the storer, and describe the service with the ``<ServiceName>_PELICAN_*``
 options.  The following example defines a service named ``physicsdata`` that
 grants read access to the ``/physics-data`` prefix in the OSDF:
@@ -727,7 +729,7 @@ grants read access to the ``/physics-data`` prefix in the OSDF:
 .. code-block:: condor-config
 
     # Route credential requests for Pelican services through the storer.
-    SEC_CREDENTIAL_STORER = /usr/bin/condor_vault_storer
+    SEC_CREDENTIAL_STORER = /usr/bin/condor_credential_storer
     PELICAN_CREDMON_PROVIDER_NAMES = physicsdata
 
     # What the tokens are good for: the federation and the namespace prefix.

--- a/docs/admin-manual/file-and-cred-transfer.rst
+++ b/docs/admin-manual/file-and-cred-transfer.rst
@@ -738,12 +738,12 @@ grants read access to the ``/physics-data`` prefix in the OSDF:
     PHYSICSDATA_PELICAN_PERMISSIONS = read
 
     PHYSICSDATA_PELICAN_CLIENT_ID          = ex4mpl3cl13nt1d
-    PHYSICSDATA_PELICAN_CLIENT_SECRET_FILE = /etc/condor/secrets/physicsdata_client_secret
+    PHYSICSDATA_PELICAN_CLIENT_SECRET_FILE = /etc/condor/.secrets/physicsdata_client_secret
 
 .. code-block:: console
 
     # ls -l /etc/condor/.secrets/physicsdata_client_secret
-    -r-------- 1 root root 33 Jan  1 10:10 /etc/condor/secrets/physicsdata_client_secret
+    -r-------- 1 root root 33 Jan  1 10:10 /etc/condor/.secrets/physicsdata_client_secret
 
 ``<ServiceName>_PELICAN_PERMISSIONS`` is a list of one or more of ``read``,
 ``write``, and ``modify`` (whitespace and/or comma separated); the token is

--- a/docs/admin-manual/file-and-cred-transfer.rst
+++ b/docs/admin-manual/file-and-cred-transfer.rst
@@ -315,7 +315,7 @@ and used by file transfer plugins and/or users' executables.
 The types of credentials that can be managed in this way by HTCondor
 depend on which credential monitors ("credmons") have been configured.
 
-HTCondor currently has three credmon options:
+HTCondor currently has four credmon options:
 
 #. The local SciTokens issuer credmon,
    which generates and renews SciTokens credentials
@@ -325,10 +325,15 @@ HTCondor currently has three credmon options:
    which sends users to a local webserver
    to go through OAuth2 authorization code flow
    in order to fetch refresh and access tokens
-   from configured credential issuers, and
+   from configured credential issuers,
 #. The Vault credmon,
    which fetches arbitrary credentials from a configured `HashiCorp Vault <https://www.vaultproject.io/>`_ service
-   by authenticating to the service with users' long-lived Vault credentials.
+   by authenticating to the service with users' long-lived Vault credentials, and
+#. The Pelican credmon,
+   which obtains and renews access tokens from a
+   `Pelican <https://pelicanplatform.org/>`_ federation (such as the OSDF)
+   by running the OAuth2 device-code flow and then exchanging the result for a
+   refreshable token using the credmon's own registered client credentials.
 
 As long as a user has jobs in the queue
 (and up to :macro:`SEC_CREDENTIAL_SWEEP_DELAY` additional seconds once the user has no jobs in the queue),
@@ -683,6 +688,91 @@ Set :macro:`CREDMON_ALLOW_SPECIAL_CHAR_NAMES` = ``True``
 only if existing provider names in your configuration contain underscores
 (or other non-alphanumeric/hyphen characters).
 Note that this setting disables support for user-supplied handles.
+
+.. _installing_credmon_pelican:
+
+Allowing users to fetch credentials from a Pelican federation such as the OSDF
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+HTCondor can natively obtain and renew access tokens for a
+`Pelican <https://pelicanplatform.org/>`_ federation -- for example the
+`OSDF <https://osg-htc.org/services/osdf/>`_ -- so that jobs can read and write
+federation objects using ``osdf://`` or ``pelican://`` URLs. At submit time the
+``pelican`` client runs the OAuth2 device-code flow against the federation's
+token issuer to obtain an initial *subject* token; the credmon then uses its own
+registered client credentials to perform an
+`RFC 8693 <https://www.rfc-editor.org/rfc/rfc8693>`_ token exchange, receiving an
+access token and a refresh token that it keeps renewed on the access point for as
+long as the user has jobs in the queue.
+
+To enable it, install the ``condor-credmon-oauth`` RPM -- which provides the
+*condor_credmon_oauth* daemon, the *condor_credd*, and the
+``condor_vault_storer`` -- as well as the ``pelican`` client, then enable the
+credd and credmon with the ``use feature: oauth`` configuration template.
+
+Next, register an OAuth2 client for the access point with the federation's token
+issuer.  The client must be permitted the ``refresh_token`` and
+``urn:ietf:params:oauth:grant-type:token-exchange`` grant types, and must be
+allowed the scopes the service will hand out (for example ``offline_access`` and
+``storage.read:/``).  The issuer returns a client ID and a client secret; store
+the secret in a file readable only by root.
+
+For each Pelican "service" you wish to offer, add its name to
+``PELICAN_CREDMON_PROVIDER_NAMES``, point :macro:`SEC_CREDENTIAL_STORER` at
+``condor_vault_storer`` so that :tool:`condor_submit` routes the request through
+the storer, and describe the service with the ``<ServiceName>_PELICAN_*``
+options.  The following example defines a service named ``physicsdata`` that
+grants read access to the ``/physics-data`` prefix in the OSDF:
+
+.. code-block:: condor-config
+
+    # Route credential requests for Pelican services through the storer.
+    SEC_CREDENTIAL_STORER = /usr/bin/condor_vault_storer
+    PELICAN_CREDMON_PROVIDER_NAMES = physicsdata
+
+    # What the tokens are good for: the federation and the namespace prefix.
+    PHYSICSDATA_PELICAN_URL         = pelican://osg-htc.org
+    PHYSICSDATA_PELICAN_PREFIX      = /physics-data
+    PHYSICSDATA_PELICAN_PERMISSIONS = read
+
+    PHYSICSDATA_PELICAN_CLIENT_ID          = ex4mpl3cl13nt1d
+    PHYSICSDATA_PELICAN_CLIENT_SECRET_FILE = /etc/condor/secrets/physicsdata_client_secret
+
+.. code-block:: console
+
+    # ls -l /etc/condor/.secrets/physicsdata_client_secret
+    -r-------- 1 root root 33 Jan  1 10:10 /etc/condor/secrets/physicsdata_client_secret
+
+``<ServiceName>_PELICAN_PERMISSIONS`` is a list of one or more of ``read``,
+``write``, and ``modify`` (whitespace and/or comma separated); the token is
+granted every listed capability.  Because these capabilities do not imply one
+another (in particular ``modify`` does not imply ``read``), a service that needs
+to both read and overwrite objects should request, for example,
+``PHYSICSDATA_PELICAN_PERMISSIONS = read, modify``.
+If the ``pelican`` client is not on the system ``PATH``, set the ``PELICAN_BIN``
+environment variable so the storer can find it.
+
+To use the service, a submitter lists its name under ``use_oauth_services`` and
+refers to federation objects with ``osdf://`` (or ``pelican://``) URLs.  For
+example:
+
+.. code-block:: condor-submit
+
+    executable = analyze.sh
+
+    # Request a token for the "physicsdata" service.
+    use_oauth_services = physicsdata
+
+    # Stage in an input object from /physics-data using that token.
+    transfer_input_files = osdf:///physics-data/runs/run42.root
+
+    queue
+
+The first time the credential is needed, :tool:`condor_submit` prints a URL that
+the user must visit in a browser and approve.  Once approved, the credmon
+performs the token exchange and the job's access token (delivered as
+``physicsdata.use`` in the job's ``_CONDOR_CREDS`` directory) is kept refreshed
+automatically.
 
 
 Using HTCondor with Kerberos and AFS

--- a/docs/version-history/v25-version.hist
+++ b/docs/version-history/v25-version.hist
@@ -74,6 +74,13 @@
   options; see :ref:`installing_credmon_pelican`.
   :jira:`3784`
 
+- The ``condor_vault_storer`` credential storer has been renamed to the
+  mode-neutral ``condor_credential_storer``, since it now services Vault and
+  Pelican credentials (and can be extended to others).  The old name is still
+  installed as a symlink, so existing :macro:`SEC_CREDENTIAL_STORER`
+  configurations continue to work.
+  :jira:`3784`
+
 *** 25.13.2 bugs
 
 - Fixed a bug where the *condor_credmon_oauth* would not create and/or

--- a/docs/version-history/v25-version.hist
+++ b/docs/version-history/v25-version.hist
@@ -38,6 +38,13 @@
   options; see :ref:`installing_credmon_pelican`.
   :jira:`3784`
 
+- The ``condor_vault_storer`` credential storer has been renamed to the
+  mode-neutral ``condor_credential_storer``, since it now services Vault and
+  Pelican credentials (and can be extended to others).  The old name is still
+  installed as a symlink, so existing :macro:`SEC_CREDENTIAL_STORER`
+  configurations continue to work.
+  :jira:`3784`
+
 *** 25.13.0 bugs
 
 - Fixed a bug where the *condor_credmon_oauth* would not create and/or

--- a/docs/version-history/v25-version.hist
+++ b/docs/version-history/v25-version.hist
@@ -30,6 +30,13 @@
 - Add a helpful "how to monitor jobs" tip to stderr after
   :tool:`condor_submit` runs.
   :jira:`3173`
+- The credmon can now obtain and renew OAuth2 access tokens from a
+  `Pelican <https://pelicanplatform.org/>`_ federation (such as the OSDF), so
+  that jobs can read and write federation objects with ``osdf://`` and
+  ``pelican://`` URLs.  Services are declared with
+  ``PELICAN_CREDMON_PROVIDER_NAMES`` and a set of ``<ServiceName>_PELICAN_*``
+  options; see :ref:`installing_credmon_pelican`.
+  :jira:`3784`
 
 *** 25.13.0 bugs
 

--- a/docs/version-history/v25-version.hist
+++ b/docs/version-history/v25-version.hist
@@ -66,6 +66,13 @@
 - Add a helpful "how to monitor jobs" tip to stderr after
   :tool:`condor_submit` runs.
   :jira:`3173`
+- The credmon can now obtain and renew OAuth2 access tokens from a
+  `Pelican <https://pelicanplatform.org/>`_ federation (such as the OSDF), so
+  that jobs can read and write federation objects with ``osdf://`` and
+  ``pelican://`` URLs.  Services are declared with
+  ``PELICAN_CREDMON_PROVIDER_NAMES`` and a set of ``<ServiceName>_PELICAN_*``
+  options; see :ref:`installing_credmon_pelican`.
+  :jira:`3784`
 
 *** 25.13.2 bugs
 

--- a/docs/version-history/v25-version.hist
+++ b/docs/version-history/v25-version.hist
@@ -27,6 +27,21 @@
   all cases.
   :jira:`3873`
 
+- The credmon can now obtain and renew OAuth2 access tokens from a
+  `Pelican <https://pelicanplatform.org/>`_ federation (such as the OSDF), so
+  that jobs can read and write federation objects with ``osdf://`` and
+  ``pelican://`` URLs.  Services are declared with
+  ``PELICAN_CREDMON_PROVIDER_NAMES`` and a set of ``<ServiceName>_PELICAN_*``
+  options; see :ref:`installing_credmon_pelican`.
+  :jira:`3784`
+
+- The ``condor_vault_storer`` credential storer has been renamed to the
+  mode-neutral ``condor_credential_storer``, since it now services Vault and
+  Pelican credentials (and can be extended to others).  The old name is still
+  installed as a symlink, so existing :macro:`SEC_CREDENTIAL_STORER`
+  configurations continue to work.
+  :jira:`3784`
+
 *** 25.14.0 bugs
 
 - Fixed a bug where a job with streaming output or error would not be
@@ -66,20 +81,6 @@
 - Add a helpful "how to monitor jobs" tip to stderr after
   :tool:`condor_submit` runs.
   :jira:`3173`
-- The credmon can now obtain and renew OAuth2 access tokens from a
-  `Pelican <https://pelicanplatform.org/>`_ federation (such as the OSDF), so
-  that jobs can read and write federation objects with ``osdf://`` and
-  ``pelican://`` URLs.  Services are declared with
-  ``PELICAN_CREDMON_PROVIDER_NAMES`` and a set of ``<ServiceName>_PELICAN_*``
-  options; see :ref:`installing_credmon_pelican`.
-  :jira:`3784`
-
-- The ``condor_vault_storer`` credential storer has been renamed to the
-  mode-neutral ``condor_credential_storer``, since it now services Vault and
-  Pelican credentials (and can be extended to others).  The old name is still
-  installed as a symlink, so existing :macro:`SEC_CREDENTIAL_STORER`
-  configurations continue to work.
-  :jira:`3784`
 
 *** 25.13.2 bugs
 

--- a/src/condor_credd/condor_credmon_oauth/CMakeLists.txt
+++ b/src/condor_credd/condor_credmon_oauth/CMakeLists.txt
@@ -1,6 +1,11 @@
 install ( FILES condor_credmon_oauth condor_credmon_vault DESTINATION ${C_SBIN} PERMISSIONS ${CONDOR_SCRIPT_PERMS} )
 install ( FILES scitokens_credential_producer DESTINATION ${C_SBIN} PERMISSIONS ${CONDOR_SCRIPT_PERMS} )
-install ( FILES condor_vault_storer DESTINATION ${C_BIN} PERMISSIONS ${CONDOR_SCRIPT_PERMS} )
+install ( FILES condor_credential_storer DESTINATION ${C_BIN} PERMISSIONS ${CONDOR_SCRIPT_PERMS} )
+# condor_vault_storer was renamed to the mode-neutral condor_credential_storer
+# (it now serves Vault, Pelican, ... services).  Keep a symlink under the old
+# name so existing SEC_CREDENTIAL_STORER = .../condor_vault_storer configs and
+# any scripts calling it directly keep working.
+install ( CODE "EXECUTE_PROCESS(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink condor_credential_storer \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${C_BIN}/condor_vault_storer)" )
 install ( FILES condor_credmon_oauth.wsgi DESTINATION ${C_LIBEXEC} )
 install ( DIRECTORY credmon DESTINATION ${C_LIBEXEC} )
 install ( DIRECTORY examples/ DESTINATION ${C_ETC_EXAMPLES}/condor_credmon_oauth )

--- a/src/condor_credd/condor_credmon_oauth/condor_credential_storer
+++ b/src/condor_credd/condor_credmon_oauth/condor_credential_storer
@@ -321,20 +321,39 @@ for REQUEST; do
 
     # Route each requested service to the credmon that owns it, so a single
     # storer can serve a mix of Vault and Pelican providers on one access point.
-    if service_in_list "$SERVICE" "$PELICANPROVIDERS" || \
-       service_in_list "$ISSUER" "$PELICANPROVIDERS"; then
+    #
+    # condor_submit tells us which kind of credential these services are via
+    # CONDOR_CREDENTIAL_STORER_MODE (it groups a submit's services by kind and
+    # runs us once per kind).  Trust that when set; otherwise -- e.g. when
+    # invoked by an older condor_submit, or by hand -- fall back to detecting the
+    # owner from the configured provider-name lists.
+    SERVICEMODE="$CONDOR_CREDENTIAL_STORER_MODE"
+    if [ -z "$SERVICEMODE" ]; then
+        if service_in_list "$SERVICE" "$PELICANPROVIDERS" || \
+           service_in_list "$ISSUER" "$PELICANPROVIDERS"; then
+            SERVICEMODE=pelican
+        elif service_in_list "$SERVICE" "$LOCALPROVIDERS" || \
+             service_in_list "$ISSUER" "$LOCALPROVIDERS" || \
+             service_in_list "$SERVICE" "$OAUTH2PROVIDERS" || \
+             service_in_list "$SERVICE" "$CLIENTPROVIDERS"; then
+            SERVICEMODE=other
+        else
+            SERVICEMODE=vault
+        fi
+    fi
+
+    case "$SERVICEMODE" in
+    pelican)
         store_pelican_service "$REQUEST" "$SERVICE"
         continue
-    fi
-    if service_in_list "$SERVICE" "$LOCALPROVIDERS" || \
-       service_in_list "$ISSUER" "$LOCALPROVIDERS" || \
-       service_in_list "$SERVICE" "$OAUTH2PROVIDERS" || \
-       service_in_list "$SERVICE" "$CLIENTPROVIDERS"; then
+        ;;
+    other)
         # Managed by the local/oauth2/client credmons; never delivered through
         # this storer.  Skip defensively.
         verbose "Service $SERVICE is managed by another credmon; skipping"
         continue
-    fi
+        ;;
+    esac
 
     # Otherwise this is a Vault-managed service, which needs htgettoken options.
     if ! $GETTOKENOPTS_SET; then

--- a/src/condor_credd/condor_credmon_oauth/condor_credential_storer
+++ b/src/condor_credd/condor_credmon_oauth/condor_credential_storer
@@ -1,8 +1,14 @@
 #!/bin/bash
 #
-# Obtain and store condor credentials for each given oath_service 
+# Obtain and store condor credentials for each given oauth_service.
+# A single storer services credentials of multiple kinds, detecting the kind
+# of each service from the configured provider-name lists (Vault via htgettoken,
+# Pelican via the pelican client, ...).
 # Can be run automatically from condor_submit when configured as
 #   SEC_CREDENTIAL_STORER.
+#
+# Formerly named condor_vault_storer; that name is still installed as a symlink
+# for backward compatibility.
 
 ME="${0##*/}"
 

--- a/src/condor_credd/condor_credmon_oauth/condor_credential_storer
+++ b/src/condor_credd/condor_credmon_oauth/condor_credential_storer
@@ -365,10 +365,14 @@ for REQUEST; do
     OPTS+=("-i" "$ISSUER")
     if [ "$SERVICE" != "$ISSUER" ]; then
         ROLE="${SERVICE#*_}"
-        OPTS+=("-r" "$ROLE")
-        if [ "$SERVICE" != "${ISSUER}_$ROLE" ]; then
+        # With ISSUER as everything before the first underscore and ROLE as
+        # everything after it, keep enforcing the historical rule that a Vault
+        # service name has at most one underscore: a ROLE containing another
+        # underscore means the name was malformed.
+        if [ "$ROLE" != "${ROLE#*_}" ]; then
             fatal "Only one underscore allowed in use_oauth_services name"
         fi
+        OPTS+=("-r" "$ROLE")
     fi
     STOREOPTS=()
     if [ -n "$SEC_CREDENTIAL_STORECRED_OPTS" ]; then

--- a/src/condor_credd/condor_credmon_oauth/condor_credential_storer
+++ b/src/condor_credd/condor_credmon_oauth/condor_credential_storer
@@ -317,7 +317,7 @@ for REQUEST; do
     fi
     IFS="&" read -r -a PARTS <<< "$REQUEST"
     SERVICE="${PARTS[0]}"
-    ISSUER="${SERVICE%_*}"
+    ISSUER="${SERVICE%%_*}"
 
     # Route each requested service to the credmon that owns it, so a single
     # storer can serve a mix of Vault and Pelican providers on one access point.

--- a/src/condor_credd/condor_credmon_oauth/condor_credmon_oauth
+++ b/src/condor_credd/condor_credmon_oauth/condor_credmon_oauth
@@ -33,6 +33,10 @@ try:
     from credmon.CredentialMonitors.VaultCredmon import VaultCredmon
 except ImportError:
     VaultCredmon = None
+try:
+    from credmon.CredentialMonitors.PelicanCredmon import PelicanCredmon
+except ImportError:
+    PelicanCredmon = None
 
 from credmon.utils import parse_args, setup_logging, get_cred_dir, drop_pid, credmon_incomplete, credmon_complete, create_credentials, is_valid_provider_name
 
@@ -126,6 +130,9 @@ def start_credmon_process(q, cred_dir, args):
         local_provider_names = {htcondor.param.get("LOCAL_CREDMON_PROVIDER_NAME", "scitokens")}
     oauth2_provider_names = set(filter(None, re.compile(r"[\s,]+").split(htcondor.param.get("OAUTH2_CREDMON_PROVIDER_NAMES", "*"))))
     client_provider_names = set(filter(None, re.compile(r"[\s,]+").split(htcondor.param.get("CLIENT_CREDMON_PROVIDER_NAMES", ""))))
+    # Pelican services are explicitly enumerated by the administrator; there is
+    # no wildcard fallback because the Vault credmon claims unlisted services.
+    pelican_provider_names = set(filter(None, re.compile(r"[\s,]+").split(htcondor.param.get("PELICAN_CREDMON_PROVIDER_NAMES", ""))))
 
 
     credmons = []
@@ -137,6 +144,8 @@ def start_credmon_process(q, cred_dir, args):
     if ClientCredmon is not None:
         for provider in client_provider_names:
             credmons.append(ClientCredmon(provider=provider, cred_dir=cred_dir, args=args))
+    if PelicanCredmon is not None and pelican_provider_names:
+        credmons.append(PelicanCredmon(providers=pelican_provider_names, cred_dir=cred_dir, args=args))
 
     vault_provider_names = set(filter(None, re.compile(r"[\s,]+").split(htcondor.param.get("VAULT_CREDMON_PROVIDER_NAMES", "*"))))
     if VaultCredmon is None and vault_provider_names and vault_provider_names != {"*"}:
@@ -150,6 +159,7 @@ def start_credmon_process(q, cred_dir, args):
         "local": local_provider_names,
         "oauth2": oauth2_provider_names,
         "client": client_provider_names,
+        "pelican": pelican_provider_names,
         "vault": vault_provider_names,
     }
     checked_credmon_provider_names = {}

--- a/src/condor_credd/condor_credmon_oauth/condor_vault_storer
+++ b/src/condor_credd/condor_credmon_oauth/condor_vault_storer
@@ -81,9 +81,29 @@ if [ "" != "$VERBOSE" ]; then
 fi
 
 CONDOROPTS="`condor_config_val SEC_CREDENTIAL_GETTOKEN_OPTS 2>/dev/null`"
+# The htgettoken options are only required for Vault-managed services.  A single
+# storer may serve Vault and Pelican services side by side (and ignore services
+# owned by the local/oauth2/client credmons), so defer this check until we
+# actually need to fetch a Vault token below.
+GETTOKENOPTS_SET=true
 if [ -z "$CONDOROPTS" ] && [ -z "$HTGETTOKENOPTS" ]; then
-    fatal 'Neither SEC_CREDENTIAL_GETTOKEN_OPTS condor value nor $HTGETTOKENOPTS environment set'
+    GETTOKENOPTS_SET=false
 fi
+
+# Provider lists used to decide which credmon owns each requested service.
+PELICANPROVIDERS="`condor_config_val PELICAN_CREDMON_PROVIDER_NAMES 2>/dev/null`"
+LOCALPROVIDERS="`condor_config_val LOCAL_CREDMON_PROVIDER_NAMES 2>/dev/null`"
+if [ -z "$LOCALPROVIDERS" ]; then
+    LOCALPROVIDERS="`condor_config_val LOCAL_CREDMON_PROVIDER_NAME 2>/dev/null`"
+fi
+OAUTH2PROVIDERS="`condor_config_val OAUTH2_CREDMON_PROVIDER_NAMES 2>/dev/null`"
+CLIENTPROVIDERS="`condor_config_val CLIENT_CREDMON_PROVIDER_NAMES 2>/dev/null`"
+
+# The Pelican client used to mint subject tokens for Pelican services; override
+# with the PELICAN_BIN environment variable.  It must not require a TTY since it
+# runs as a non-interactive subprocess of condor_submit.
+PELICAN="${PELICAN_BIN:-pelican}"
+export PELICAN_SKIP_TERMINAL_CHECK=1
 
 # make sure we can find condor_store_cred
 PATH=/usr/sbin:$PATH
@@ -152,7 +172,139 @@ storecred() {
     fi
 }
 
-for REQUEST; do 
+# ---------------------------------------------------------------------------
+# Pelican service support
+#
+# A Pelican service is owned by the PelicanCredmon (listed in
+# PELICAN_CREDMON_PROVIDER_NAMES).  Instead of htgettoken/Vault, we run the
+# Pelican client's device-code flow to obtain a subject access token and store
+# it as the service's .top credential; the PelicanCredmon then performs the
+# RFC 8693 token exchange and ongoing refreshes.
+# ---------------------------------------------------------------------------
+
+# service_in_list <name> <list>: succeed if <name> appears in the whitespace or
+# comma separated <list>.
+service_in_list() {
+    local name="$1" list="$2" item
+    local IFS=', '
+    for item in $list; do
+        if [ "$item" = "$name" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+store_pelican_service() {
+    local REQUEST="$1" SERVICE="$2"
+    local -a PPARTS
+    IFS="&" read -r -a PPARTS <<< "$REQUEST"
+    local HANDLE="" REQ_SCOPE="" REQ_AUDIENCE="" PART VAL
+    for PART in "${PPARTS[@]:1}"; do
+        VAL="${PART#*=}"
+        case "$PART" in
+            handle=*)         HANDLE="$VAL" ;;
+            scope=*|scopes=*) REQ_SCOPE="$VAL" ;;
+            audience=*)       REQ_AUDIENCE="$VAL" ;;
+        esac
+    done
+
+    local STORENAME="$SERVICE"
+    if [ -n "$HANDLE" ]; then
+        STORENAME="${SERVICE}_${HANDLE}"
+    fi
+
+    # If the credd already holds a credential for this service, the credmon
+    # keeps it refreshed; nothing to do.
+    if condor_store_cred query-oauth$STOREUSER -s "$STORENAME" >/dev/null 2>&1; then
+        verbose "Credentials for $STORENAME already stored; nothing to do"
+        return
+    fi
+
+    if ! command -v "$PELICAN" >/dev/null 2>&1; then
+        fatal "Pelican client '$PELICAN' not found (set PELICAN_BIN)"
+    fi
+
+    local PELICAN_URL PREFIX PERMS
+    PELICAN_URL="`condor_config_val ${SERVICE}_PELICAN_URL 2>/dev/null`"
+    PREFIX="`condor_config_val ${SERVICE}_PELICAN_PREFIX 2>/dev/null`"
+    PERMS="`condor_config_val ${SERVICE}_PELICAN_PERMISSIONS 2>/dev/null`"
+    if [ -z "$PERMS" ]; then
+        PERMS="read"
+    fi
+    if [ -z "$PELICAN_URL" ]; then
+        fatal "Service $SERVICE: ${SERVICE}_PELICAN_URL is not configured"
+    fi
+
+    # Build the pelican:// resource URL from the federation URL + prefix.
+    local RESOURCE="$PELICAN_URL"
+    case "$PELICAN_URL" in
+        pelican://*|osdf://*) : ;;
+        https://*) RESOURCE="pelican://${PELICAN_URL#https://}" ;;
+        http://*)  RESOURCE="pelican://${PELICAN_URL#http://}" ;;
+    esac
+    if [ -n "$PREFIX" ]; then
+        RESOURCE="${RESOURCE%/}/${PREFIX#/}"
+    fi
+
+    # The permissions are a list (whitespace and/or comma separated); a token
+    # may carry several capabilities at once, since they do not imply one
+    # another (e.g. modify does not imply read).  Map each to a Pelican client
+    # capability flag.
+    local -a FETCH_FLAGS=()
+    local PERM
+    for PERM in ${PERMS//,/ }; do
+        case "$PERM" in
+            read)          FETCH_FLAGS+=("--read") ;;
+            write|create)  FETCH_FLAGS+=("--write") ;;
+            modify|delete) FETCH_FLAGS+=("--modify") ;;
+            "") ;;
+            *) fatal "Service $SERVICE: unsupported permission '$PERM' (use read, write, and/or modify)" ;;
+        esac
+    done
+    if [ ${#FETCH_FLAGS[@]} -eq 0 ]; then
+        fatal "Service $SERVICE: ${SERVICE}_PELICAN_PERMISSIONS lists no usable permission"
+    fi
+
+    newlineifneeded
+    echo "$ME: Obtaining a Pelican token for service '$SERVICE' ($RESOURCE, $PERMS)" >&2
+
+    # Run the device-code flow.  The token is printed to stdout; the "navigate
+    # to this URL" prompt goes to stderr (relayed to the user by condor_submit).
+    local SUBJECT_TOKEN
+    SUBJECT_TOKEN="`"$PELICAN" token fetch "${FETCH_FLAGS[@]}" "$RESOURCE"`"
+    if [ $? != 0 ] || [ -z "$SUBJECT_TOKEN" ]; then
+        fatal "Failed to obtain a Pelican token for service '$SERVICE'"
+    fi
+    # Keep only the JWT (last non-empty line) in case extra text is printed.
+    SUBJECT_TOKEN="`printf '%s\n' "$SUBJECT_TOKEN" | awk 'NF{line=$0} END{print line}'`"
+
+    local -a PSTOREOPTS=()
+    if [ -n "$REQ_SCOPE" ]; then
+        PSTOREOPTS+=("-S" "$REQ_SCOPE")
+    fi
+    if [ -n "$REQ_AUDIENCE" ]; then
+        PSTOREOPTS+=("-A" "$REQ_AUDIENCE")
+    fi
+
+    if $SHOWSTORING; then
+        echo "Storing condor credentials for $STORENAME" >&2
+    fi
+
+    # Hand the subject token to the credd as the .top credential.  The
+    # PelicanCredmon discovers the issuer's token endpoint from this token, so we
+    # record only the token itself.  No "vault_url" is included so the credd does
+    # not treat it as a Vault token.
+    {
+        printf '{ "access_token": "%s" }\n' "$SUBJECT_TOKEN"
+    } | condor_store_cred add-oauth$STOREUSER -s "$STORENAME" "${PSTOREOPTS[@]}" -i - >$STOREOUT
+    if [ $? != 0 ]; then
+        fatal "Failed to store Pelican credentials for '$STORENAME'"
+    fi
+    verbose "Stored subject token for $STORENAME"
+}
+
+for REQUEST; do
     SHOWSTORING=false
     if [ -n "$VERBOSE" ]; then
         SHOWSTORING=true
@@ -160,6 +312,29 @@ for REQUEST; do
     IFS="&" read -r -a PARTS <<< "$REQUEST"
     SERVICE="${PARTS[0]}"
     ISSUER="${SERVICE%_*}"
+
+    # Route each requested service to the credmon that owns it, so a single
+    # storer can serve a mix of Vault and Pelican providers on one access point.
+    if service_in_list "$SERVICE" "$PELICANPROVIDERS" || \
+       service_in_list "$ISSUER" "$PELICANPROVIDERS"; then
+        store_pelican_service "$REQUEST" "$SERVICE"
+        continue
+    fi
+    if service_in_list "$SERVICE" "$LOCALPROVIDERS" || \
+       service_in_list "$ISSUER" "$LOCALPROVIDERS" || \
+       service_in_list "$SERVICE" "$OAUTH2PROVIDERS" || \
+       service_in_list "$SERVICE" "$CLIENTPROVIDERS"; then
+        # Managed by the local/oauth2/client credmons; never delivered through
+        # this storer.  Skip defensively.
+        verbose "Service $SERVICE is managed by another credmon; skipping"
+        continue
+    fi
+
+    # Otherwise this is a Vault-managed service, which needs htgettoken options.
+    if ! $GETTOKENOPTS_SET; then
+        fatal 'Neither SEC_CREDENTIAL_GETTOKEN_OPTS condor value nor $HTGETTOKENOPTS environment set'
+    fi
+
     # using arrays for options works better for quoting
     read -r -a OPTS <<< "$CONDOROPTS"
     OPTS+=("-i" "$ISSUER")

--- a/src/condor_credd/condor_credmon_oauth/credmon/CredentialMonitors/PelicanCredmon.py
+++ b/src/condor_credd/condor_credmon_oauth/credmon/CredentialMonitors/PelicanCredmon.py
@@ -4,7 +4,7 @@ PelicanCredmon -- an HTCondor credential monitor for Pelican federations.
 This credmon mirrors the Vault credmon's division of labor but speaks to a
 Pelican federation's embedded OAuth2 issuer instead of HashiCorp Vault:
 
-  * A SEC_CREDENTIAL_STORER script (pelican_credential_storer) runs the Pelican
+  * A SEC_CREDENTIAL_STORER script (condor_credential_storer) runs the Pelican
     client's device-code flow at submit time and stores the resulting *subject*
     access token (which carries `offline_access` and storage scopes) into the
     credmon directory as `<service>.top`.

--- a/src/condor_credd/condor_credmon_oauth/credmon/CredentialMonitors/PelicanCredmon.py
+++ b/src/condor_credd/condor_credmon_oauth/credmon/CredentialMonitors/PelicanCredmon.py
@@ -1,0 +1,399 @@
+"""
+PelicanCredmon -- an HTCondor credential monitor for Pelican federations.
+
+This credmon mirrors the Vault credmon's division of labor but speaks to a
+Pelican federation's embedded OAuth2 issuer instead of HashiCorp Vault:
+
+  * A SEC_CREDENTIAL_STORER script (pelican_credential_storer) runs the Pelican
+    client's device-code flow at submit time and stores the resulting *subject*
+    access token (which carries `offline_access` and storage scopes) into the
+    credmon directory as `<service>.top`.
+
+  * This credmon notices the `.top` file and performs an RFC 8693 OAuth2 token
+    exchange using *its own* client credentials (configured by the admin),
+    receiving a fresh access token and a refresh token bound to the credmon's
+    client.  The access token is written to `<service>.use` (JSON) and the
+    refresh token replaces the subject token in `<service>.top`.
+
+  * On subsequent scans the credmon refreshes the access token with the
+    refresh-token grant.  If the storer replaces `.top` with a newer subject
+    token, the exchange is performed again.
+
+Configuration knobs (read from the HTCondor config; SERVICE is the token name):
+
+    PELICAN_CREDMON_PROVIDER_NAMES   space/comma separated list of services
+    <SERVICE>_PELICAN_CLIENT_ID          credmon's OAuth2 client id
+    <SERVICE>_PELICAN_CLIENT_SECRET_FILE  path to a file holding the credmon's
+                                          client secret. NOTE: the secret must
+                                          never be placed inline in the config,
+                                          which is world-readable; only a file
+                                          path (readable solely by the credmon)
+                                          is supported.
+    <SERVICE>_PELICAN_TOKEN_URL          OPTIONAL override of the issuer token
+                                          endpoint.  Normally discovered via OIDC
+                                          metadata from the token's issuer.
+    PELICAN_CREDMON_CA_FILE              CA bundle to trust for the issuer (opt.)
+    PELICAN_CREDMON_TLS_SKIP_VERIFY      "true" to disable TLS verification (opt.)
+    CREDMON_OAUTH_TOKEN_MINIMUM          access token lifetime floor, seconds
+
+Only the `requests` library is required (no requests_oauthlib dependency).
+"""
+
+from credmon.CredentialMonitors.AbstractCredentialMonitor import AbstractCredentialMonitor
+from credmon.utils import atomic_rename
+import os
+import re
+import time
+import json
+import glob
+import base64
+import tempfile
+
+try:
+    import requests
+except ImportError:
+    requests = None
+
+try:
+    import htcondor2 as htcondor
+except ImportError:
+    htcondor = None
+
+
+TOKEN_EXCHANGE_GRANT = "urn:ietf:params:oauth:grant-type:token-exchange"
+ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token"
+
+
+class PelicanCredmon(AbstractCredentialMonitor):
+
+    # Fraction of an access token's lifetime that must elapse before we refresh.
+    refresh_fraction = 0.5
+
+    @property
+    def credmon_name(self):
+        return "PELICAN"
+
+    # Re-run OIDC discovery for an issuer at least this often (seconds), so a
+    # token endpoint that moves is eventually picked up.
+    discovery_ttl = 3600
+
+    def __init__(self, *args, **kw):
+        super(PelicanCredmon, self).__init__(*args, **kw)
+        # The set of service/provider names this credmon is responsible for.
+        self.providers = set(kw.get("providers", set()))
+        # Cache of issuer URL -> (token_endpoint, fetched_at) for OIDC discovery.
+        self._discovery_cache = {}
+
+    # ------------------------------------------------------------------
+    # Configuration helpers
+    # ------------------------------------------------------------------
+    def _param(self, key, default=None):
+        if htcondor is None:
+            return default
+        return htcondor.param.get(key, default)
+
+    def _provider_for(self, token_name):
+        """Return the configured provider name that owns this token, or None.
+
+        A token name may carry a `_<handle>` suffix added for reduced scopes;
+        the credentials/config live under the base service name.
+        """
+        if token_name in self.providers:
+            return token_name
+        if "_" in token_name:
+            base = token_name.rsplit("_", 1)[0]
+            if base in self.providers:
+                return base
+        return None
+
+    def _client_credentials(self, provider):
+        client_id = self._param("%s_PELICAN_CLIENT_ID" % provider)
+        client_secret = None
+        secret_file = self._param("%s_PELICAN_CLIENT_SECRET_FILE" % provider)
+        if secret_file:
+            try:
+                with open(secret_file, "r") as f:
+                    client_secret = f.read().strip()
+            except IOError as ie:
+                self.log.error("Could not read client secret file %s: %s", secret_file, str(ie))
+                return (None, None)
+        return (client_id, client_secret)
+
+    @staticmethod
+    def _jwt_issuer(token):
+        """Return the `iss` claim of a JWT without verifying it, or None."""
+        try:
+            payload = token.split(".")[1]
+            payload += "=" * (-len(payload) % 4)
+            claims = json.loads(base64.urlsafe_b64decode(payload.encode("ascii")))
+            return claims.get("iss")
+        except Exception:
+            return None
+
+    def _discover_token_endpoint(self, issuer, verify):
+        """Discover an issuer's OAuth2 token endpoint via OIDC metadata.
+
+        Results are cached per-issuer and refreshed every `discovery_ttl`
+        seconds so the credmon tracks a token endpoint that moves.  On a
+        discovery failure the most recent cached value (if any) is returned.
+        """
+        if not issuer:
+            return None
+        now = time.time()
+        cached = self._discovery_cache.get(issuer)
+        if cached and (now - cached[1]) < self.discovery_ttl:
+            return cached[0]
+        well_known = issuer.rstrip("/") + "/.well-known/openid-configuration"
+        try:
+            resp = requests.get(well_known, verify=verify, timeout=30,
+                               headers={"Accept": "application/json"})
+            if resp.status_code != 200:
+                self.log.warning("OIDC discovery at %s returned HTTP %d", well_known, resp.status_code)
+                return cached[0] if cached else None
+            token_endpoint = resp.json().get("token_endpoint")
+        except Exception as e:
+            self.log.warning("OIDC discovery at %s failed: %s", well_known, str(e))
+            return cached[0] if cached else None
+        if token_endpoint:
+            self._discovery_cache[issuer] = (token_endpoint, now)
+        return token_endpoint
+
+    def _resolve_token_url(self, provider, issuer, top_data, verify):
+        """Determine the token endpoint for a service.
+
+        Resolution order:
+          1. the explicit `<SERVICE>_PELICAN_TOKEN_URL` override, if set;
+          2. OIDC discovery from the issuer that minted the token we hold
+             (the federation's director resolves the prefix to this issuer); and
+          3. whatever token URL was previously recorded in the .top file.
+        """
+        url = self._param("%s_PELICAN_TOKEN_URL" % provider)
+        if url:
+            return url
+        discovered = self._discover_token_endpoint(issuer, verify)
+        if discovered:
+            return discovered
+        return top_data.get("token_url") if isinstance(top_data, dict) else None
+
+    def _tls_verify(self):
+        skip = (self._param("PELICAN_CREDMON_TLS_SKIP_VERIFY", "") or "").strip().lower()
+        if skip in ("1", "true", "yes", "on"):
+            return False
+        ca_file = self._param("PELICAN_CREDMON_CA_FILE")
+        if ca_file:
+            return ca_file
+        return True
+
+    def _minimum_seconds(self):
+        val = self._param("CREDMON_OAUTH_TOKEN_MINIMUM")
+        if val:
+            try:
+                return int(val)
+            except ValueError:
+                pass
+        return 20 * 60
+
+    # ------------------------------------------------------------------
+    # Renewal logic
+    # ------------------------------------------------------------------
+    def should_renew(self, username, token_name):
+        access_token_path = os.path.join(self.cred_dir, username, token_name + ".use")
+        top_path = os.path.join(self.cred_dir, username, token_name + ".top")
+
+        # No access token yet: must mint one from the subject token.
+        if not os.path.exists(access_token_path):
+            return True
+
+        # If the storer dropped a newer .top (e.g. a fresh subject token), the
+        # access token must be regenerated.
+        try:
+            use_ctime = os.path.getctime(access_token_path)
+            if os.path.exists(top_path) and os.path.getctime(top_path) > use_ctime:
+                return True
+        except OSError:
+            return True
+
+        # Refresh once the access token is past a fraction of its lifetime.
+        try:
+            with open(access_token_path, "r") as f:
+                access_token = json.load(f)
+        except (IOError, ValueError) as e:
+            self.log.warning("Could not parse access token %s: %s", access_token_path, str(e))
+            return True
+
+        try:
+            expires_in = float(access_token.get("expires_in", 0))
+        except (TypeError, ValueError):
+            expires_in = 0
+        if expires_in <= 0:
+            return True
+        refresh_time = use_ctime + (expires_in * self.refresh_fraction)
+        return time.time() > refresh_time
+
+    # ------------------------------------------------------------------
+    # The OAuth2 exchanges
+    # ------------------------------------------------------------------
+    def _post_token(self, token_url, data, verify):
+        resp = requests.post(token_url, data=data, verify=verify, timeout=30,
+                             headers={"Accept": "application/json"})
+        if resp.status_code != 200:
+            raise RuntimeError("token endpoint %s returned HTTP %d: %s"
+                               % (token_url, resp.status_code, resp.text[:512]))
+        return resp.json()
+
+    def refresh_access_token(self, username, token_name):
+        if requests is None:
+            self.log.error("The 'requests' module is required by PelicanCredmon")
+            return False
+
+        provider = self._provider_for(token_name)
+        if provider is None:
+            return False
+
+        top_path = os.path.join(self.cred_dir, username, token_name + ".top")
+        try:
+            with open(top_path, "r") as f:
+                top_data = json.load(f)
+        except (IOError, ValueError) as e:
+            self.log.error("Could not read %s: %s", top_path, str(e))
+            return False
+
+        client_id, client_secret = self._client_credentials(provider)
+        if not client_id:
+            self.log.error("Provider %s is missing %s_PELICAN_CLIENT_ID", provider, provider)
+            return False
+
+        verify = self._tls_verify()
+
+        # Decide whether to refresh an existing grant or to exchange a freshly
+        # delivered subject token.
+        refresh_token = top_data.get("refresh_token")
+        subject_token = top_data.get("access_token") or top_data.get("subject_token")
+
+        # The token endpoint is normally discovered from the issuer that minted
+        # the token we hold (recorded in .top after the first exchange, or read
+        # from the subject token before that), rather than configured by hand.
+        issuer = top_data.get("iss")
+        if not issuer and subject_token:
+            issuer = self._jwt_issuer(subject_token)
+        token_url = self._resolve_token_url(provider, issuer, top_data, verify)
+        if not token_url:
+            self.log.error("Provider %s: could not determine a token endpoint "
+                           "(no %s_PELICAN_TOKEN_URL override, issuer discovery failed, "
+                           "and no cached URL)", provider, provider)
+            return False
+
+        try:
+            if refresh_token:
+                self.log.debug("Refreshing %s for %s via refresh_token grant", token_name, username)
+                new_token = self._post_token(token_url, {
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                    "client_id": client_id,
+                    "client_secret": client_secret or "",
+                }, verify)
+            elif subject_token:
+                self.log.debug("Exchanging subject token for %s (%s) via RFC 8693", token_name, username)
+                exchange_req = {
+                    "grant_type": TOKEN_EXCHANGE_GRANT,
+                    "subject_token": subject_token,
+                    "subject_token_type": ACCESS_TOKEN_TYPE,
+                    "client_id": client_id,
+                    "client_secret": client_secret or "",
+                }
+                # Carry forward any scopes/audience the storer recorded so the
+                # exchanged token keeps the capabilities of the subject token.
+                if top_data.get("scope"):
+                    exchange_req["scope"] = top_data["scope"]
+                if top_data.get("audience"):
+                    exchange_req["audience"] = top_data["audience"]
+                new_token = self._post_token(token_url, exchange_req, verify)
+            else:
+                self.log.error("%s contains neither a refresh_token nor a subject access_token", top_path)
+                return False
+        except Exception as e:
+            self.log.error("Token operation for %s (%s) failed: %s", token_name, username, str(e))
+            return False
+
+        access_token = new_token.get("access_token")
+        if not access_token:
+            self.log.error("No access_token in response for %s (%s)", token_name, username)
+            return False
+
+        # Persist the (possibly rotated) refresh token back into .top FIRST so
+        # future scans use the refresh grant.  Writing .top before .use is
+        # important: should_renew() treats a .top newer than .use as a signal
+        # that the storer delivered a fresh subject token, so .use must end up
+        # being the newest file after a successful renewal.
+        new_refresh = new_token.get("refresh_token")
+        if new_refresh:
+            # Record the issuer so future refreshes can re-discover the token
+            # endpoint, and the resolved token_url as a fallback if discovery is
+            # ever unavailable.
+            new_top = {"refresh_token": new_refresh, "token_url": token_url}
+            if issuer:
+                new_top["iss"] = issuer
+            for key in ("scope", "audience"):
+                if top_data.get(key):
+                    new_top[key] = top_data[key]
+            if not self._atomic_write_json(username, token_name + ".top", new_top):
+                return False
+        elif subject_token and not refresh_token:
+            # We just consumed a subject token but the issuer returned no refresh
+            # token.  Leave the subject token in place so a later scan retries,
+            # but warn loudly because periodic refresh will not work.
+            self.log.warning("Exchange for %s (%s) returned no refresh_token; "
+                             "periodic refresh is disabled for this credential",
+                             token_name, username)
+
+        # Persist the new access token (.use) as JSON so both the Pelican client
+        # and our own should_renew() can read expires_in.  This is written last
+        # so that .use is the newest file in the steady state.
+        use_obj = {
+            "access_token": access_token,
+            "token_type": new_token.get("token_type", "Bearer"),
+            "expires_in": int(new_token.get("expires_in", self._minimum_seconds())),
+        }
+        if not self._atomic_write_json(username, token_name + ".use", use_obj):
+            return False
+        return True
+
+    def _atomic_write_json(self, username, filename, obj):
+        target = os.path.join(self.cred_dir, username, filename)
+        try:
+            (tmp_fd, tmp_path) = tempfile.mkstemp(dir=self.cred_dir)
+            with os.fdopen(tmp_fd, "w") as f:
+                json.dump(obj, f)
+            atomic_rename(tmp_path, target)
+        except OSError as e:
+            self.log.error("Failed to write %s: %s", target, str(e))
+            return False
+        return True
+
+    # ------------------------------------------------------------------
+    # Scan loop
+    # ------------------------------------------------------------------
+    def check_access_token(self, top_path):
+        (basename, top_filename) = os.path.split(top_path)
+        (_cred_dir, username) = os.path.split(basename)
+        token_name = os.path.splitext(top_filename)[0]  # strip .top
+
+        if self._provider_for(token_name) is None:
+            return
+
+        if self.should_renew(username, token_name):
+            self.log.info("Renewing %s token for user %s", token_name, username)
+            if self.refresh_access_token(username, token_name):
+                self.log.info("Successfully renewed %s token for user %s", token_name, username)
+            else:
+                self.log.error("Failed to renew %s token for user %s", token_name, username)
+
+    def scan_tokens(self):
+        top_files = glob.glob(os.path.join(self.cred_dir, "*", "*.top"))
+        self.log.debug("Found %d possible tokens to check", len(top_files))
+        for top_file in top_files:
+            self.log.debug("Checking %s", top_file)
+            try:
+                self.check_access_token(top_file)
+            except Exception:
+                self.log.exception("Error while checking %s", top_file)

--- a/src/condor_credd/condor_credmon_oauth/credmon/CredentialMonitors/PelicanCredmon.py
+++ b/src/condor_credd/condor_credmon_oauth/credmon/CredentialMonitors/PelicanCredmon.py
@@ -42,7 +42,6 @@ Only the `requests` library is required (no requests_oauthlib dependency).
 from credmon.CredentialMonitors.AbstractCredentialMonitor import AbstractCredentialMonitor
 from credmon.utils import atomic_rename
 import os
-import re
 import time
 import json
 import glob

--- a/src/condor_credd/condor_credmon_oauth/credmon/CredentialMonitors/PelicanCredmon.py
+++ b/src/condor_credd/condor_credmon_oauth/credmon/CredentialMonitors/PelicanCredmon.py
@@ -82,6 +82,9 @@ class PelicanCredmon(AbstractCredentialMonitor):
         self.providers = set(kw.get("providers", set()))
         # Cache of issuer URL -> (token_endpoint, fetched_at) for OIDC discovery.
         self._discovery_cache = {}
+        self.allow_special_chars = False
+        if htcondor is not None:
+            self.allow_special_chars = htcondor.param.get("CREDMON_ALLOW_SPECIAL_CHAR_NAMES", False) is True
 
     # ------------------------------------------------------------------
     # Configuration helpers
@@ -94,15 +97,20 @@ class PelicanCredmon(AbstractCredentialMonitor):
     def _provider_for(self, token_name):
         """Return the configured provider name that owns this token, or None.
 
-        A token name may carry a `_<handle>` suffix added for reduced scopes;
-        the credentials/config live under the base service name.
+        When CREDMON_ALLOW_SPECIAL_CHAR_NAMES is False (the default), a token
+        name may carry a `_<handle>` suffix added for reduced scopes; the
+        credentials/config live under the base provider name (everything
+        before the first underscore).
         """
-        if token_name in self.providers:
-            return token_name
-        if "_" in token_name:
-            base = token_name.rsplit("_", 1)[0]
-            if base in self.providers:
-                return base
+        if token_name.endswith("_"):
+            self.log.warning("Skipping credential with trailing underscore: %s", token_name)
+            return None
+        if not self.allow_special_chars and "_" in token_name:
+            provider_name = token_name.split("_", 1)[0]
+        else:
+            provider_name = token_name
+        if provider_name in self.providers:
+            return provider_name
         return None
 
     def _client_credentials(self, provider):

--- a/src/condor_credd/condor_credmon_oauth/credmon/CredentialMonitors/VaultCredmon.py
+++ b/src/condor_credd/condor_credmon_oauth/credmon/CredentialMonitors/VaultCredmon.py
@@ -314,7 +314,8 @@ class VaultCredmon(AbstractCredentialMonitor):
                 provider_name == htcondor.param.get("LOCAL_CREDMON_PROVIDER_NAME") or
                 provider_name in re.compile(r"[\s,]+").split(htcondor.param.get("LOCAL_CREDMON_PROVIDER_NAMES", "")) or
                 provider_name in re.compile(r"[\s,]+").split(htcondor.param.get("OAUTH2_CREDMON_PROVIDER_NAMES", "")) or
-                provider_name in re.compile(r"[\s,]+").split(htcondor.param.get("CLIENT_CREDMON_PROVIDER_NAMES", ""))
+                provider_name in re.compile(r"[\s,]+").split(htcondor.param.get("CLIENT_CREDMON_PROVIDER_NAMES", "")) or
+                provider_name in re.compile(r"[\s,]+").split(htcondor.param.get("PELICAN_CREDMON_PROVIDER_NAMES", ""))
                 ):
                 self.log.warning('Ignoring "%s" tokens (matches another provider name)', token_name)
                 return

--- a/src/condor_credd/condor_credmon_oauth/examples/config/condor/40-oauth-credmon.conf
+++ b/src/condor_credd/condor_credmon_oauth/examples/config/condor/40-oauth-credmon.conf
@@ -25,11 +25,11 @@ use feature : OAUTH
 
 # MANDATORY when requiring users to use the Vault credmon by default
 # Tell condor_submit to route token requests through htgettoken
-# SEC_CREDENTIAL_STORER = /usr/bin/condor_vault_storer
+# SEC_CREDENTIAL_STORER = /usr/bin/condor_credential_storer
 
 # Set the time in seconds that credd will wait after jobs are
 # finished before deleting the user's credential directory. Don't
-# set this lower than 7 days because condor_vault_storer only stores
+# set this lower than 7 days because condor_credential_storer only stores
 # credentials in credd once a week.
 # SEC_CREDENTIAL_SWEEP_DELAY = 604800
 

--- a/src/condor_credd/condor_credmon_oauth/examples/config/condor/40-pelican-credmon.conf
+++ b/src/condor_credd/condor_credmon_oauth/examples/config/condor/40-pelican-credmon.conf
@@ -4,7 +4,7 @@
 # The Pelican credmon obtains and renews OAuth2 access tokens for a Pelican
 # federation (for example the OSDF) so that jobs can read/write federation
 # objects with osdf:// or pelican:// URLs.  At submit time the merged
-# condor_vault_storer runs the Pelican client's device-code flow to obtain an
+# condor_credential_storer runs the Pelican client's device-code flow to obtain an
 # initial subject token; the credmon then exchanges it (RFC 8693) for a token
 # bound to its own client and keeps it refreshed.
 
@@ -17,9 +17,9 @@ use feature : OAUTH
 SEC_DEFAULT_ENCRYPTION = REQUIRED
 
 # MANDATORY: Route credential requests for Pelican services (and, if present,
-# Vault services) through the storer.  A single condor_vault_storer detects the
+# Vault services) through the storer.  A single condor_credential_storer detects the
 # service type and switches between Pelican and Vault automatically.
-SEC_CREDENTIAL_STORER = /usr/bin/condor_vault_storer
+SEC_CREDENTIAL_STORER = /usr/bin/condor_credential_storer
 
 # MANDATORY: The list of Pelican service names handled by this credmon.
 PELICAN_CREDMON_PROVIDER_NAMES = physicsdata

--- a/src/condor_credd/condor_credmon_oauth/examples/config/condor/40-pelican-credmon.conf
+++ b/src/condor_credd/condor_credmon_oauth/examples/config/condor/40-pelican-credmon.conf
@@ -1,0 +1,71 @@
+#####################################################################################
+# Example configuration for the Pelican credmon.
+#
+# The Pelican credmon obtains and renews OAuth2 access tokens for a Pelican
+# federation (for example the OSDF) so that jobs can read/write federation
+# objects with osdf:// or pelican:// URLs.  At submit time the merged
+# condor_vault_storer runs the Pelican client's device-code flow to obtain an
+# initial subject token; the credmon then exchanges it (RFC 8693) for a token
+# bound to its own client and keeps it refreshed.
+
+#####################################################################################
+# MANDATORY: To setup the credmon, you must uncomment these lines:
+use feature : OAUTH
+
+# MANDATORY for enabling the transfer of credentials from the submit host
+# to execute hosts, if encryption is not already enabled.
+SEC_DEFAULT_ENCRYPTION = REQUIRED
+
+# MANDATORY: Route credential requests for Pelican services (and, if present,
+# Vault services) through the storer.  A single condor_vault_storer detects the
+# service type and switches between Pelican and Vault automatically.
+SEC_CREDENTIAL_STORER = /usr/bin/condor_vault_storer
+
+# MANDATORY: The list of Pelican service names handled by this credmon.
+PELICAN_CREDMON_PROVIDER_NAMES = physicsdata
+
+#####################################################################################
+#
+# Per-service configuration.  Repeat this block (with a new prefix) for each
+# name listed in PELICAN_CREDMON_PROVIDER_NAMES.
+#
+# In this example, the "physicsdata" service grants read access to the
+# /physics-data prefix in the OSDF.
+#
+
+# What the tokens are good for: the federation URL and the namespace prefix.
+PHYSICSDATA_PELICAN_URL         = pelican://osg-htc.org
+PHYSICSDATA_PELICAN_PREFIX      = /physics-data
+# A list of one or more of read, write, modify (whitespace/comma separated).
+# These do not imply one another, so e.g. to both read and overwrite objects
+# use "read, modify".
+PHYSICSDATA_PELICAN_PERMISSIONS = read
+
+# The credmon's own OAuth2 client, registered with the federation's token issuer
+# and permitted the refresh_token and token-exchange grant types.  Store the
+# secret in a file readable only by root.
+PHYSICSDATA_PELICAN_CLIENT_ID          = ex4mpl3cl13nt1d
+PHYSICSDATA_PELICAN_CLIENT_SECRET_FILE = /etc/condor/.secrets/physicsdata_client_secret
+
+#####################################################################################
+#
+# OPTIONAL: These are rarely customized.
+#
+
+# If the pelican client is not on the system PATH, tell the storer where it is.
+# (Set in the storer's environment rather than the HTCondor config.)
+# PELICAN_BIN = /usr/bin/pelican
+
+# The issuer's token endpoint is normally discovered automatically (via OIDC
+# metadata from the issuer that minted the token).  Set this only to override
+# that discovery.
+# PHYSICSDATA_PELICAN_TOKEN_URL = https://origin.example.edu:8443/api/v1.0/issuer/ns/physics-data/token
+
+# Trust settings for the credmon's connection to the federation issuer.  Only
+# needed for issuers using a CA the credmon does not already trust.
+# PELICAN_CREDMON_CA_FILE = /etc/grid-security/certificates/federation-ca.pem
+# PELICAN_CREDMON_TLS_SKIP_VERIFY = false
+
+# Minimum lifetime (seconds) an access token must have when fetched; the credmon
+# refreshes once a token passes half of this value.
+CREDMON_OAUTH_TOKEN_MINIMUM = 2400

--- a/src/condor_credd/condor_credmon_oauth/examples/config/condor/40-vault-credmon.conf
+++ b/src/condor_credd/condor_credmon_oauth/examples/config/condor/40-vault-credmon.conf
@@ -26,7 +26,7 @@ SEC_DEFAULT_ENCRYPTION = REQUIRED
 SEC_CREDENTIAL_DIRECTORY_OAUTH = /var/lib/condor/oauth_credentials
 TRUST_CREDENTIAL_DIRECTORY = True
 CREDMON_OAUTH = /usr/sbin/condor_credmon_vault
-SEC_CREDENTIAL_STORER = /usr/bin/condor_vault_storer
+SEC_CREDENTIAL_STORER = /usr/bin/condor_credential_storer
 SEC_CREDENTIAL_MONITOR_OAUTH_LOG = $(LOG)/CredMonOAuthLog
 
 # This is the minimum time in seconds that access tokens must have
@@ -39,7 +39,7 @@ CREDMON_OAUTH_TOKEN_MINIMUM=2400
 CREDMON_OAUTH_TOKEN_REFRESH=1200
 # This is the time in seconds that credd will wait after jobs are
 #   finished before deleting the user's credential directory.  Don't
-#   set this lower than 7 days because condor_vault_storer only stores
+#   set this lower than 7 days because condor_credential_storer only stores
 #   credentials in credd once a week and we can't inspect a
 #   credential's expiration date to know when it needs renewal.
 SEC_CREDENTIAL_SWEEP_DELAY=604800

--- a/src/condor_credd/condor_credmon_oauth/examples/submit/pelican_example/osdf_physics_data.submit
+++ b/src/condor_credd/condor_credmon_oauth/examples/submit/pelican_example/osdf_physics_data.submit
@@ -1,0 +1,16 @@
+executable = analyze.sh
+arguments  = run42.root
+
+# Request a token for the "physicsdata" Pelican service configured on the
+# access point (see 40-pelican-credmon.conf).  The first time the credential is
+# needed, condor_submit prints a URL to visit and approve in a browser.
+use_oauth_services = physicsdata
+
+# Stage in an object from the /physics-data prefix in the OSDF, using the token
+# fetched above.  The pelican file-transfer plugin reads physicsdata.use from
+# $_CONDOR_CREDS.
+transfer_input_files = osdf:///physics-data/runs/run42.root
+
+# Successful submission will result in run42.root being downloaded to the job
+# sandbox and the token delivered as $_CONDOR_CREDS/physicsdata.use.
+queue

--- a/src/condor_tests/CMakeLists.txt
+++ b/src/condor_tests/CMakeLists.txt
@@ -549,6 +549,9 @@ endif()
 			condor_pl_test(test_issue_credentials "Test issue_credentials()" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 			condor_pl_test(test_dagman_produce_creds "Test DAGMan creates job credentials" "dagman;quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 			condor_pl_test(test_htcondor_credential "Test the htcondor credential" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
+			# Skips unless `pelican` and `pelican-server` are in PATH and the
+			# credmon/storer implement the Pelican integration (see the test).
+			condor_pl_test(test_pelican_credmon "Test Pelican federation credmon + storer integration" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 
 			# The AES test depends on strace'ing the condor_shadow binary.  Strace isn't supported under 
 			# qemu, which is where we run our ppc and arm tests. 

--- a/src/condor_tests/CMakeLists.txt
+++ b/src/condor_tests/CMakeLists.txt
@@ -640,6 +640,9 @@ endif()
 			condor_pl_test(test_issue_credentials "Test issue_credentials()" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 			condor_pl_test(test_dagman_produce_creds "Test DAGMan creates job credentials" "dagman;quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 			condor_pl_test(test_htcondor_credential "Test the htcondor credential" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
+			# Skips unless `pelican` and `pelican-server` are in PATH and the
+			# credmon/storer implement the Pelican integration (see the test).
+			condor_pl_test(test_pelican_credmon "Test Pelican federation credmon + storer integration" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 
 			# The AES test depends on strace'ing the condor_shadow binary.  Strace isn't supported under 
 			# qemu, which is where we run our ppc and arm tests. 

--- a/src/condor_tests/test_pelican_credmon.py
+++ b/src/condor_tests/test_pelican_credmon.py
@@ -1,0 +1,586 @@
+#!/usr/bin/env pytest
+#
+# Integration test for the native HTCondor <-> Pelican credmon integration.
+#
+# This is the HTCondor/ornithology counterpart to Pelican's Go integration test
+# (cmd/plugin_htcondor_credmon_test.go).  It exercises the same end-to-end flow:
+#
+#   1. Stand up a self-contained Pelican federation (POSIXv2 origin with the
+#      embedded OIDC issuer) using the `pelican-server` binary.
+#   2. Create the credmon's OAuth2 client (with the token-exchange grant) via the
+#      issuer's admin REST API.
+#   3. Submit a job whose credentials are obtained by the merged
+#      condor_vault_storer, which detects the Pelican service and runs the
+#      Pelican client's device-code flow.  The test scrapes the verification URL
+#      from condor_submit's output and approves it over HTTP.
+#   4. The PelicanCredmon performs the RFC 8693 token exchange; the job stages in
+#      an input file via `transfer_input_files = pelican://...` (the Pelican
+#      binary acts as an HTCondor file-transfer plugin when named pelican_plugin)
+#      using the exchanged token.
+#   5. The access token is backdated and the credmon is SIGHUP'd to force a
+#      refresh.
+#
+# Both the exchange and the refresh are verified by inspecting the token's `jti`
+# claim: the exchanged token's jti differs from the subject token's, and the
+# refreshed token's jti differs from the exchanged token's.
+#
+# This test ships as part of the credmon, so the PelicanCredmon and the merged
+# condor_vault_storer are always present when it runs.  It SKIPS only when the
+# external Pelican binaries it needs to stand up a federation are unavailable:
+# `pelican` or `pelican-server` not in PATH (a POSIXv2 federation cannot be
+# started), or the `requests` module / a bcrypt implementation is missing.
+
+import base64
+import json
+import logging
+import os
+import re
+import secrets
+import shutil
+import signal
+import subprocess
+import time
+from getpass import getuser
+from pathlib import Path
+from urllib.parse import urlparse, parse_qs
+
+import pytest
+
+try:
+    import requests
+
+    requests.packages.urllib3.disable_warnings()
+except Exception:
+    requests = None
+
+from ornithology import standup, action, Condor
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+USER = getuser()
+SERVICE = "pelicantest"
+FED_PREFIX = "/credmon-test"
+PAYLOAD = "credmon integration test payload\n"
+
+PELICAN = shutil.which("pelican")
+PELICAN_SERVER = shutil.which("pelican-server")
+
+
+# ---------------------------------------------------------------------------
+# Locate the condor_vault_storer that ships in the credmon package.  (The
+# credmon daemon is found via the default CREDMON_OAUTH config knob and loads
+# its Python package from LIBEXEC automatically -- no extra wiring needed.)
+# ---------------------------------------------------------------------------
+def find_storer():
+    storer = shutil.which("condor_vault_storer")
+    if storer:
+        return storer
+    try:
+        out = subprocess.run(
+            ["condor_config_val", "BIN"], capture_output=True, text=True
+        )
+        if out.returncode == 0:
+            candidate = Path(out.stdout.strip()) / "condor_vault_storer"
+            if candidate.exists():
+                return str(candidate)
+    except Exception:
+        pass
+    return None
+
+
+# Module-level skips that do not need a live federation.
+pytestmark = pytest.mark.skipif(
+    PELICAN is None or PELICAN_SERVER is None or requests is None,
+    reason="requires the `pelican` and `pelican-server` binaries in PATH and the python `requests` module",
+)
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers (admin client creation + device-code approval)
+# ---------------------------------------------------------------------------
+def _new_session():
+    s = requests.Session()
+    s.verify = False
+    return s
+
+
+def create_credmon_client(session, server_url, admin_user, admin_password):
+    """Create an OAuth2 client with the token-exchange + refresh_token grants."""
+    r = session.post(
+        server_url + "/api/v1.0/auth/login",
+        data={"user": admin_user, "password": admin_password},
+    )
+    assert r.status_code == 200, f"admin login failed: {r.status_code} {r.text}"
+
+    r = session.post(
+        server_url + "/api/v1.0/issuer/admin/ns" + FED_PREFIX + "/clients",
+        json={
+            "client_name": "pelican-credmon",
+            "grant_types": [
+                "urn:ietf:params:oauth:grant-type:token-exchange",
+                "refresh_token",
+            ],
+            "scopes": [
+                "openid", "offline_access", "wlcg",
+                "storage.read:/", "storage.modify:/", "storage.create:/",
+            ],
+        },
+    )
+    assert r.status_code == 201, f"admin client creation failed: {r.status_code} {r.text}"
+    body = r.json()
+    return body["client_id"], body["client_secret"]
+
+
+def approve_device_code(server_url, verify_url, user, password):
+    """Log in as `user` and approve the device code named by verify_url."""
+    parsed = urlparse(verify_url)
+    qs = parse_qs(parsed.query)
+    user_code = qs["user_code"][0]
+    namespace = "/" + qs.get("namespace", [""])[0].lstrip("/")
+    origin = f"{parsed.scheme}://{parsed.netloc}"
+    ns_base = origin + "/api/v1.0/issuer/ns" + namespace
+
+    session = _new_session()
+    r = session.post(
+        server_url + "/api/v1.0/auth/login", data={"user": user, "password": password}
+    )
+    assert r.status_code == 200, f"approver login failed: {r.status_code} {r.text}"
+
+    r = session.get(ns_base + "/device", params={"user_code": user_code})
+    assert r.status_code == 200, f"device GET failed: {r.status_code} {r.text}"
+    csrf = r.json()["csrf_token"]
+
+    r = session.post(
+        ns_base + "/device",
+        json={"user_code": user_code, "action": "approve", "csrf_token": csrf},
+    )
+    assert r.status_code == 200, f"device approval failed: {r.status_code} {r.text}"
+    logger.info("Approved device code %s as %s", user_code, user)
+
+
+# ---------------------------------------------------------------------------
+# JWT / credential helpers
+# ---------------------------------------------------------------------------
+def jwt_claims(token):
+    payload = token.split(".")[1]
+    payload += "=" * (-len(payload) % 4)
+    return json.loads(base64.urlsafe_b64decode(payload))
+
+
+def access_token_from_use(text):
+    text = text.strip()
+    if text.startswith("{"):
+        return json.loads(text).get("access_token", "")
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+def _bcrypt_hash(pw):
+    """Return a bcrypt ($2*$) hash that Pelican's go-htpasswd accepts, or None.
+
+    Prefers the `bcrypt` module; falls back to the stdlib `crypt` blowfish method
+    (present through Python 3.12).  Pelican parses the file with
+    htpasswd.AcceptBcrypt, which accepts $2a$/$2b$/$2y$.
+    """
+    try:
+        import bcrypt
+
+        return bcrypt.hashpw(pw.encode(), bcrypt.gensalt()).decode()
+    except Exception:
+        pass
+    try:
+        import crypt
+
+        if getattr(crypt, "METHOD_BLOWFISH", None):
+            return crypt.crypt(pw, crypt.mksalt(crypt.METHOD_BLOWFISH))
+    except Exception:
+        pass
+    return None
+
+
+@standup
+def credentials(test_dir):
+    """An htpasswd file with an admin and a 'testuser' approver."""
+    htpasswd = test_dir / "htpasswd"
+    admin_pw = secrets.token_urlsafe(12)
+    user_pw = secrets.token_urlsafe(12)
+
+    admin_hash = _bcrypt_hash(admin_pw)
+    user_hash = _bcrypt_hash(user_pw)
+    if not admin_hash or not user_hash:
+        pytest.skip("no bcrypt implementation available to build the htpasswd file")
+
+    htpasswd.write_text(f"admin:{admin_hash}\ntestuser:{user_hash}\n")
+    htpasswd.chmod(0o644)
+    return {"file": htpasswd, "admin_pw": admin_pw, "user_pw": user_pw}
+
+
+@standup
+def federation(test_dir, credentials):
+    """Launch a self-contained Pelican federation and yield its coordinates."""
+    storage_dir = test_dir / "fed-storage"
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    config_dir = test_dir / "pelican-config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    runtime_dir = test_dir / "pelican-runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+
+    # Pre-create the file the job will download.
+    (storage_dir / "payload.txt").write_text(PAYLOAD)
+
+    config_file = test_dir / "pelican.yaml"
+    config_file.write_text(f"""
+Server:
+  EnableUI: true
+  UIPasswordFile: {credentials['file']}
+Origin:
+  StorageType: posixv2
+  EnableIssuer: true
+  IssuerMode: embedded
+  Exports:
+    - FederationPrefix: {FED_PREFIX}
+      StoragePrefix: {storage_dir}
+      Capabilities: ["Reads", "Writes", "Listings"]
+Issuer:
+  AuthorizationTemplates:
+    - prefix: /
+      actions: ["read", "write", "create"]
+""")
+
+    env = dict(os.environ)
+    env.update({
+        "PELICAN_CONFIGDIR": str(config_dir),
+        "PELICAN_RUNTIMEDIR": str(runtime_dir),
+        "PELICAN_TLSSKIPVERIFY": "true",
+        "PELICAN_SERVER_WEBPORT": "0",
+        "PELICAN_SERVER_DBLOCATION": str(config_dir / "registry.sqlite"),
+    })
+
+    log_file = open(test_dir / "pelican-server.log", "w")
+    proc = subprocess.Popen(
+        [PELICAN_SERVER, "--config", str(config_file), "serve",
+         "--module", "director", "--module", "registry", "--module", "origin",
+         "--port", "0", "-d"],
+        env=env, stdout=log_file, stderr=subprocess.STDOUT,
+    )
+
+    # Wait for the address file, then poll the health endpoint.
+    addr_file = runtime_dir / "pelican.addresses"
+    server_url = None
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError("pelican-server exited early; see pelican-server.log")
+        if addr_file.exists():
+            for line in addr_file.read_text().splitlines():
+                if line.startswith("SERVER_EXTERNAL_WEB_URL="):
+                    server_url = line.split("=", 1)[1].strip().strip('"')
+            if server_url:
+                break
+        time.sleep(0.5)
+    assert server_url, "pelican-server did not publish SERVER_EXTERNAL_WEB_URL"
+
+    deadline = time.time() + 60
+    healthy = False
+    while time.time() < deadline:
+        try:
+            r = requests.get(server_url + "/api/v1.0/health", verify=False, timeout=5)
+            if r.status_code == 200:
+                healthy = True
+                break
+        except Exception:
+            pass
+        time.sleep(0.5)
+    assert healthy, "pelican federation did not become healthy"
+
+    parsed = urlparse(server_url)
+    info = {
+        "url": server_url,
+        "hostname": parsed.hostname,
+        "port": parsed.port,
+        "storage_dir": storage_dir,
+    }
+    logger.info("Federation ready at %s", server_url)
+    yield info
+
+    proc.send_signal(signal.SIGINT)
+    try:
+        proc.wait(timeout=20)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+    log_file.close()
+
+
+@standup
+def credmon_client(test_dir, federation, credentials):
+    session = _new_session()
+    client_id, client_secret = create_credmon_client(
+        session, federation["url"], "admin", credentials["admin_pw"]
+    )
+    secret_file = test_dir / "credmon_client_secret"
+    secret_file.write_text(client_secret)
+    secret_file.chmod(0o600)
+    logger.info("Created credmon client %s", client_id)
+    return {"client_id": client_id, "secret_file": secret_file}
+
+
+@standup
+def the_condor(test_dir, federation, credmon_client):
+    cred_dir = test_dir / "oauth_credentials"
+    cred_dir.mkdir(parents=True, exist_ok=True)
+    cred_dir.chmod(0o2770)
+
+    storer = find_storer()
+    assert storer, "condor_vault_storer (shipped with the credmon) was not found"
+
+    plugin_path = test_dir / "pelican_plugin"
+    shutil.copyfile(PELICAN, plugin_path)
+    plugin_path.chmod(0o755)
+
+    token_url = federation["url"] + "/api/v1.0/issuer/ns" + FED_PREFIX + "/token"
+
+    with Condor(
+        local_dir=test_dir / "condor",
+        config={
+            "SEC_DEFAULT_AUTHENTICATION":        "REQUIRED",
+            "SEC_DEFAULT_AUTHENTICATION_METHODS": "FS, PASSWORD",
+            "SEC_DEFAULT_ENCRYPTION":            "REQUIRED",
+            "SEC_DEFAULT_INTEGRITY":             "REQUIRED",
+
+            "SEC_CREDENTIAL_DIRECTORY_OAUTH":    str(cred_dir),
+            # CREDMON_OAUTH defaults to the installed condor_credmon_oauth, which
+            # loads its `credmon` package (including PelicanCredmon) from LIBEXEC.
+            "CREDMON_OAUTH_LOG":                 "$(LOG)/CredMonOAuthLog",
+            "SEC_CREDENTIAL_MONITOR_OAUTH_LOG":  "$(LOG)/CredMonOAuthLog",
+            "DAEMON_LIST":                       "$(DAEMON_LIST) CREDD CREDMON_OAUTH",
+            "AUTO_INCLUDE_CREDD_IN_DAEMON_LIST": "True",
+            "TRUST_CREDENTIAL_DIRECTORY":        "True",
+            "CREDD_OAUTH_MODE":                  "True",
+            "SEC_CREDENTIAL_STORER":             storer,
+            "CREDMON_OAUTH_TOKEN_MINIMUM":       "600",
+
+            "FILETRANSFER_PLUGINS":              str(plugin_path),
+
+            # The Pelican token service.
+            "PELICAN_CREDMON_PROVIDER_NAMES":            SERVICE,
+            "PELICAN_CREDMON_TLS_SKIP_VERIFY":           "true",
+            f"{SERVICE.upper()}_PELICAN_URL":            federation["url"],
+            f"{SERVICE.upper()}_PELICAN_PREFIX":         FED_PREFIX,
+            f"{SERVICE.upper()}_PELICAN_PERMISSIONS":    "read",
+            f"{SERVICE.upper()}_PELICAN_TOKEN_URL":      token_url,
+            f"{SERVICE.upper()}_PELICAN_CLIENT_ID":      credmon_client["client_id"],
+            f"{SERVICE.upper()}_PELICAN_CLIENT_SECRET_FILE": str(credmon_client["secret_file"]),
+        },
+    ) as condor:
+        yield condor
+
+
+# ---------------------------------------------------------------------------
+# Job submission + device approval + refresh helpers
+# ---------------------------------------------------------------------------
+def submit_with_device_approval(condor, submit_file, env, server_url, user, password):
+    """Run condor_submit, approving the device code that appears on its output."""
+    with condor.use_config():
+        proc = subprocess.Popen(
+            ["condor_submit", str(submit_file)],
+            env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, bufsize=1,
+        )
+        url_re = re.compile(r"https?://\S+")
+        cluster = None
+        approved = False
+        captured = []
+        for line in proc.stdout:
+            line = line.rstrip("\n")
+            captured.append(line)
+            logger.info("[condor_submit] %s", line)
+            if not approved:
+                m = url_re.search(line)
+                if m and ("user_code=" in m.group(0) or "/device" in m.group(0)):
+                    verify_url = m.group(0).rstrip(".)\"'")
+                    logger.info("Approving device code at %s", verify_url)
+                    approve_device_code(server_url, verify_url, user, password)
+                    approved = True
+            m2 = re.search(r"submitted to cluster (\d+)", line)
+            if m2:
+                cluster = m2.group(1)
+        proc.wait()
+    assert proc.returncode == 0, "condor_submit failed:\n" + "\n".join(captured)
+    assert approved, "no device verification URL appeared:\n" + "\n".join(captured)
+    return cluster
+
+
+def wait_for_job(condor, cluster, timeout=300):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        rv = condor.run_command(
+            ["condor_q", cluster, "-af", "JobStatus"], echo=False, suppress=True
+        )
+        statuses = rv.stdout.split()
+        if any(s == "5" for s in statuses):
+            return False, "job held"
+        if not statuses or all(s == "4" for s in statuses):
+            return True, ""
+        time.sleep(2)
+    return False, "timed out"
+
+
+def read_credmon_pid(cred_dir):
+    return int((cred_dir / "pid").read_text().strip())
+
+
+def sighup_credmon(cred_dir, timeout=30):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if (cred_dir / "pid").exists():
+            break
+        time.sleep(0.5)
+    os.kill(read_credmon_pid(cred_dir), signal.SIGHUP)
+
+
+@action
+def scenario(test_dir, the_condor, federation, credentials):
+    """Run the full submit -> exchange -> job -> refresh scenario once."""
+    cred_dir = test_dir / "oauth_credentials"
+    top_path = cred_dir / USER / f"{SERVICE}.top"
+    use_path = cred_dir / USER / f"{SERVICE}.use"
+
+    # ----- Job that prints the delivered token and the staged-in payload -----
+    script = test_dir / "job.sh"
+    script.write_text(
+        "#!/bin/bash\n"
+        'echo "=== TOKEN BEGIN ==="\n'
+        f'cat "$_CONDOR_CREDS/{SERVICE}.use"\n'
+        'echo ""\n'
+        'echo "=== TOKEN END ==="\n'
+        'echo "=== PAYLOAD BEGIN ==="\n'
+        "cat payload.txt || echo MISSING\n"
+        'echo "=== PAYLOAD END ==="\n'
+    )
+    script.chmod(0o755)
+
+    out_file = test_dir / "job.out"
+    fed_url = f"pelican://{federation['hostname']}:{federation['port']}"
+    submit_file = test_dir / "job.sub"
+    submit_file.write_text(f"""
+executable = {script}
+output = {out_file}
+error = {test_dir / "job.err"}
+log = {test_dir / "job.log"}
+use_oauth_services = {SERVICE}
+transfer_input_files = {fed_url}{FED_PREFIX}/payload.txt
+should_transfer_files = YES
+when_to_transfer_output = ON_EXIT
++PelicanCfg_TLSSkipVerify = true
+queue
+""")
+
+    env = dict(os.environ)
+    env.update({
+        "CONDOR_CONFIG": str(the_condor.config_file),
+        "PELICAN_BIN": PELICAN,
+        "PELICAN_SKIP_TERMINAL_CHECK": "1",
+        "PELICAN_TLSSKIPVERIFY": "true",
+        "PELICAN_FEDERATION_DISCOVERYURL": federation["url"],
+    })
+
+    cluster = submit_with_device_approval(
+        the_condor, submit_file, env, federation["url"], "testuser", credentials["user_pw"]
+    )
+
+    # Capture the storer's subject token (still in .top) before the credmon runs.
+    subject_jti = None
+    try:
+        top = json.loads(top_path.read_text())
+        if "access_token" in top:
+            subject_jti = jwt_claims(top["access_token"]).get("jti")
+    except Exception:
+        pass
+
+    # Kick the credmon so the exchange happens promptly.
+    sighup_credmon(cred_dir)
+
+    ok, why = wait_for_job(the_condor, cluster)
+    assert ok, f"job did not complete: {why}"
+
+    job_out = out_file.read_text()
+    use_after_exchange = json.loads(use_path.read_text())
+    exchanged_token = use_after_exchange["access_token"]
+    exchanged_jti = jwt_claims(exchanged_token).get("jti")
+    top_after_exchange = json.loads(top_path.read_text())
+
+    # ----- Force a refresh by backdating the access token -----
+    use_path.write_text(json.dumps({
+        "access_token": exchanged_token,
+        "token_type": "Bearer",
+        "expires_in": 1,
+    }))
+    time.sleep(2)
+    sighup_credmon(cred_dir)
+
+    refreshed_jti = None
+    deadline = time.time() + 90
+    while time.time() < deadline:
+        cur = json.loads(use_path.read_text())
+        cur_token = cur.get("access_token", "")
+        if cur_token and cur_token != exchanged_token:
+            refreshed_jti = jwt_claims(cur_token).get("jti")
+            break
+        time.sleep(3)
+
+    return {
+        "job_out": job_out,
+        "subject_jti": subject_jti,
+        "exchanged_token": exchanged_token,
+        "exchanged_jti": exchanged_jti,
+        "exchanged_claims": jwt_claims(exchanged_token),
+        "top_after_exchange": top_after_exchange,
+        "refreshed_jti": refreshed_jti,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Assertions
+# ---------------------------------------------------------------------------
+class TestPelicanCredmon:
+
+    def test_job_received_token_and_payload(self, scenario):
+        assert PAYLOAD in scenario["job_out"], "job should have staged in the federation payload"
+        token = access_token_from_use(
+            re.search(r"=== TOKEN BEGIN ===\n(.*?)\n=== TOKEN END ===",
+                      scenario["job_out"], re.S).group(1)
+        )
+        assert token, "job should have received a token in $_CONDOR_CREDS"
+
+    def test_token_is_exchanged_wlcg_token(self, scenario):
+        claims = scenario["exchanged_claims"]
+        assert claims.get("sub") == "testuser"
+        scope = claims.get("scope", "")
+        if isinstance(scope, list):
+            scope = " ".join(scope)
+        assert "storage.read:/" in scope
+        assert "offline_access" in scope
+
+    def test_exchange_replaced_subject_token(self, scenario):
+        # The credmon consumes the storer's subject token and stores a refresh
+        # token in its place -- direct evidence the RFC 8693 exchange happened.
+        top = scenario["top_after_exchange"]
+        assert "refresh_token" in top, f"expected a refresh_token in .top, got keys {list(top)}"
+        assert "access_token" not in top
+
+    def test_exchanged_jti_differs_from_subject(self, scenario):
+        # The exchanged token is a distinct token from the subject token.
+        if scenario["subject_jti"] is None:
+            pytest.skip("could not capture the subject token's jti before the exchange")
+        assert scenario["exchanged_jti"]
+        assert scenario["exchanged_jti"] != scenario["subject_jti"]
+
+    def test_refresh_changed_jti(self, scenario):
+        assert scenario["refreshed_jti"], "credmon did not refresh the access token after SIGHUP"
+        assert scenario["refreshed_jti"] != scenario["exchanged_jti"], \
+            "refreshed token should have a new jti"

--- a/src/condor_tests/test_pelican_credmon.py
+++ b/src/condor_tests/test_pelican_credmon.py
@@ -10,7 +10,7 @@
 #   2. Create the credmon's OAuth2 client (with the token-exchange grant) via the
 #      issuer's admin REST API.
 #   3. Submit a job whose credentials are obtained by the merged
-#      condor_vault_storer, which detects the Pelican service and runs the
+#      condor_credential_storer, which detects the Pelican service and runs the
 #      Pelican client's device-code flow.  The test scrapes the verification URL
 #      from condor_submit's output and approves it over HTTP.
 #   4. The PelicanCredmon performs the RFC 8693 token exchange; the job stages in
@@ -25,7 +25,7 @@
 # refreshed token's jti differs from the exchanged token's.
 #
 # This test ships as part of the credmon, so the PelicanCredmon and the merged
-# condor_vault_storer are always present when it runs.  It SKIPS only when the
+# condor_credential_storer are always present when it runs.  It SKIPS only when the
 # external Pelican binaries it needs to stand up a federation are unavailable:
 # `pelican` or `pelican-server` not in PATH (a POSIXv2 federation cannot be
 # started), or the `requests` module / a bcrypt implementation is missing.
@@ -70,22 +70,29 @@ PELICAN_SERVER = shutil.which("pelican-server")
 
 
 # ---------------------------------------------------------------------------
-# Locate the condor_vault_storer that ships in the credmon package.  (The
-# credmon daemon is found via the default CREDMON_OAUTH config knob and loads
-# its Python package from LIBEXEC automatically -- no extra wiring needed.)
+# Locate the condor_credential_storer that ships in the credmon package.  (It
+# was formerly named condor_vault_storer, still installed as a symlink, so
+# accept either name.  The credmon daemon is found via the default CREDMON_OAUTH
+# config knob and loads its Python package from LIBEXEC automatically -- no extra
+# wiring needed.)
 # ---------------------------------------------------------------------------
+STORER_NAMES = ("condor_credential_storer", "condor_vault_storer")
+
+
 def find_storer():
-    storer = shutil.which("condor_vault_storer")
-    if storer:
-        return storer
+    for name in STORER_NAMES:
+        storer = shutil.which(name)
+        if storer:
+            return storer
     try:
         out = subprocess.run(
             ["condor_config_val", "BIN"], capture_output=True, text=True
         )
         if out.returncode == 0:
-            candidate = Path(out.stdout.strip()) / "condor_vault_storer"
-            if candidate.exists():
-                return str(candidate)
+            for name in STORER_NAMES:
+                candidate = Path(out.stdout.strip()) / name
+                if candidate.exists():
+                    return str(candidate)
     except Exception:
         pass
     return None
@@ -336,7 +343,7 @@ def the_condor(test_dir, federation, credmon_client):
     cred_dir.chmod(0o2770)
 
     storer = find_storer()
-    assert storer, "condor_vault_storer (shipped with the credmon) was not found"
+    assert storer, "condor_credential_storer (shipped with the credmon) was not found"
 
     plugin_path = test_dir / "pelican_plugin"
     shutil.copyfile(PELICAN, plugin_path)

--- a/src/condor_utils/store_cred.cpp
+++ b/src/condor_utils/store_cred.cpp
@@ -2785,6 +2785,13 @@ void CredSorter::Init()
 			m_vault_names.clear();
 		}
 	}
+	// Pelican services must be enumerated explicitly; unlike Vault, an empty or
+	// unset list means there are no Pelican services (no wildcard).  Naming a
+	// service here keeps the Vault wildcard below from claiming it, and lets the
+	// submit side tell the storer to run in Pelican mode.
+	if (!param(m_pelican_names, "PELICAN_CREDMON_PROVIDER_NAMES")) {
+		m_pelican_names.clear();
+	}
 	std::string storer;
 	if (param(storer, "SEC_CREDENTIAL_STORER")) {
 		m_vault_enabled = true;
@@ -2815,6 +2822,13 @@ CredSorter::CredType CredSorter::Sort(const std::string& cred_name) const
 			return VaultType;
 		}
 	}
+	// Explicitly-named Pelican services are claimed here, before the Vault
+	// wildcard below, so they are not misclassified as Vault.
+	for (const auto& str: StringTokenIterator(m_pelican_names)) {
+		if (cred_name == str) {
+			return PelicanType;
+		}
+	}
 	formatstr(param_name, "%s_CLIENT_ID", cred_name.c_str());
 	bool client_id_defined = param(param_val, param_name.c_str());
 	if (m_oauth2_names.empty() && client_id_defined) {
@@ -2824,4 +2838,13 @@ CredSorter::CredType CredSorter::Sort(const std::string& cred_name) const
 		return VaultType;
 	}
 	return UnknownType;
+}
+
+const char *CredSorter::StorerMode(CredType type)
+{
+	switch (type) {
+	case VaultType:   return "vault";
+	case PelicanType: return "pelican";
+	default:          return nullptr;
+	}
 }

--- a/src/condor_utils/store_cred.h
+++ b/src/condor_utils/store_cred.h
@@ -180,15 +180,21 @@ class CredSorter
 	CredSorter() { Init(); }
 	void Init();
 
-	enum CredType { OAuth2Type, LocalIssuerType, LocalClientType, VaultType, UnknownType };
+	enum CredType { OAuth2Type, LocalIssuerType, LocalClientType, VaultType, PelicanType, UnknownType };
 
 	CredType Sort(const std::string& cred_name) const;
+
+	// Map a CredType to the mode string passed to the credential storer via
+	// the _CONDOR_CREDENTIAL_STORER_MODE environment variable.  Returns nullptr
+	// for types the storer does not handle.
+	static const char *StorerMode(CredType type);
 
  private:
 	std::string m_local_names;
 	std::string m_client_names;
 	std::string m_oauth2_names;
 	std::string m_vault_names;
+	std::string m_pelican_names;
 	bool m_vault_enabled{false};
 };
 

--- a/src/condor_utils/store_cred.h
+++ b/src/condor_utils/store_cred.h
@@ -185,7 +185,7 @@ class CredSorter
 	CredType Sort(const std::string& cred_name) const;
 
 	// Map a CredType to the mode string passed to the credential storer via
-	// the _CONDOR_CREDENTIAL_STORER_MODE environment variable.  Returns nullptr
+	// the CONDOR_CREDENTIAL_STORER_MODE environment variable.  Returns nullptr
 	// for types the storer does not handle.
 	static const char *StorerMode(CredType type);
 

--- a/src/condor_utils/submit_utils.cpp
+++ b/src/condor_utils/submit_utils.cpp
@@ -10005,26 +10005,27 @@ process_job_credentials(
 		// SEC_CREDENTIAL_STORER is a script to run that calls
 		// condor_store_cred when it has new credentials to store.
 		// Pass it parameters of the service requests needed as
-		// defined in the submit file.
-		// It's used for Vault-managed tokens, so ignore other token
-		// types.
-		bool call_storer = false;
-		ArgList storer_args;
-
-		storer_args.AppendArg(storer);
+		// defined in the submit file.  A single storer handles credentials
+		// of several kinds (Vault, Pelican, ...); group the requests by kind
+		// and invoke the storer once per kind, telling it which mode to run in
+		// via the CONDOR_CREDENTIAL_STORER_MODE environment variable.  Older or
+		// custom storers ignore that variable and detect the kind themselves,
+		// so this remains backward compatible.  Services owned by the
+		// local/oauth2/client credmons are not handled by the storer.
+		std::map<std::string, std::vector<std::string>> requests_by_mode;
 
 		for (const auto& request: token_ads) {
-			std::string request_arg;
 			std::string str;
 			request.LookupString("Service", str);
 			if (str.empty()) {
 				continue;
 			}
-			if (sorter.Sort(str) != CredSorter::VaultType) {
+			const char *mode = CredSorter::StorerMode(sorter.Sort(str));
+			if (!mode) {
 				continue;
 			}
 
-			request_arg = str;
+			std::string request_arg = str;
 			std::string keys[] = { "handle", "scopes", "audience", "options" };
 			for (const auto& key : keys) {
 				if (!request.LookupString(key, str) || str.empty()) {
@@ -10043,12 +10044,24 @@ process_job_credentials(
 				}
 				request_arg += "&" + key + "=" + str;
 			}
-			call_storer = true;
-			storer_args.AppendArg(request_arg);
+			requests_by_mode[mode].push_back(request_arg);
 		}
 
-		if (call_storer) {
-			int rc = my_system(storer_args);
+		for (const auto& mode_requests : requests_by_mode) {
+			const std::string& mode = mode_requests.first;
+			ArgList storer_args;
+			storer_args.AppendArg(storer);
+			for (const auto& request_arg : mode_requests.second) {
+				storer_args.AppendArg(request_arg);
+			}
+
+			// Tell the storer which kind of credential these services are.
+			// Old/custom storers ignore this and fall back to self-detection.
+			Env storer_env;
+			storer_env.Import();
+			storer_env.SetEnv("CONDOR_CREDENTIAL_STORER_MODE", mode.c_str());
+
+			int rc = my_system(storer_args, &storer_env);
 			if (rc < 0) {
 				formatstr(error_string, "Failed to run '%s': errno %d (%s)", storer.c_str(), errno, strerror(errno));
 				return false;

--- a/src/condor_utils/submit_utils.cpp
+++ b/src/condor_utils/submit_utils.cpp
@@ -10065,26 +10065,27 @@ process_job_credentials(
 		// SEC_CREDENTIAL_STORER is a script to run that calls
 		// condor_store_cred when it has new credentials to store.
 		// Pass it parameters of the service requests needed as
-		// defined in the submit file.
-		// It's used for Vault-managed tokens, so ignore other token
-		// types.
-		bool call_storer = false;
-		ArgList storer_args;
-
-		storer_args.AppendArg(storer);
+		// defined in the submit file.  A single storer handles credentials
+		// of several kinds (Vault, Pelican, ...); group the requests by kind
+		// and invoke the storer once per kind, telling it which mode to run in
+		// via the CONDOR_CREDENTIAL_STORER_MODE environment variable.  Older or
+		// custom storers ignore that variable and detect the kind themselves,
+		// so this remains backward compatible.  Services owned by the
+		// local/oauth2/client credmons are not handled by the storer.
+		std::map<std::string, std::vector<std::string>> requests_by_mode;
 
 		for (const auto& request: token_ads) {
-			std::string request_arg;
 			std::string str;
 			request.LookupString("Service", str);
 			if (str.empty()) {
 				continue;
 			}
-			if (sorter.Sort(str) != CredSorter::VaultType) {
+			const char *mode = CredSorter::StorerMode(sorter.Sort(str));
+			if (!mode) {
 				continue;
 			}
 
-			request_arg = str;
+			std::string request_arg = str;
 			std::string keys[] = { "handle", "scopes", "audience", "options" };
 			for (const auto& key : keys) {
 				if (!request.LookupString(key, str) || str.empty()) {
@@ -10103,12 +10104,24 @@ process_job_credentials(
 				}
 				request_arg += "&" + key + "=" + str;
 			}
-			call_storer = true;
-			storer_args.AppendArg(request_arg);
+			requests_by_mode[mode].push_back(request_arg);
 		}
 
-		if (call_storer) {
-			int rc = my_system(storer_args);
+		for (const auto& mode_requests : requests_by_mode) {
+			const std::string& mode = mode_requests.first;
+			ArgList storer_args;
+			storer_args.AppendArg(storer);
+			for (const auto& request_arg : mode_requests.second) {
+				storer_args.AppendArg(request_arg);
+			}
+
+			// Tell the storer which kind of credential these services are.
+			// Old/custom storers ignore this and fall back to self-detection.
+			Env storer_env;
+			storer_env.Import();
+			storer_env.SetEnv("CONDOR_CREDENTIAL_STORER_MODE", mode.c_str());
+
+			int rc = my_system(storer_args, &storer_env);
 			if (rc < 0) {
 				formatstr(error_string, "Failed to run '%s': errno %d (%s)", storer.c_str(), errno, strerror(errno));
 				return false;


### PR DESCRIPTION
Add native support for obtaining and renewing OAuth2 access tokens from a Pelican federation (such as the OSDF), so jobs can read and write federation objects with osdf:// and pelican:// URLs.

At submit time the condor_vault_storer detects a Pelican service (listed in PELICAN_CREDMON_PROVIDER_NAMES) and runs the pelican client's OAuth2 device-code flow to obtain a subject token, which it stores as the service's .top credential.  The new PelicanCredmon then performs an RFC 8693 token exchange using the credmon's own registered client credentials, receiving a refreshable token that it keeps renewed via the refresh-token grant.  The issuer's token endpoint is discovered from the token via OIDC metadata rather than being configured by hand.

  - credmon/CredentialMonitors/PelicanCredmon.py: the new credmon
  - condor_credmon_oauth: instantiate PelicanCredmon for the providers named in PELICAN_CREDMON_PROVIDER_NAMES
  - VaultCredmon.py: skip Pelican-owned providers in wildcard mode
  - condor_vault_storer: a single storer routes Vault vs Pelican services
  - docs (file-and-cred-transfer, credd config macros), an example 40-pelican-credmon.conf, and a release note
  - src/condor_tests/test_pelican_credmon.py: an ornithology integration test (skips unless pelican/pelican-server are in PATH)
  - build/nmi-build/setup.sh: install pelican/pelican-server in the build container for the integration test

HTCONDOR-3784