### PR TITLE
HTCONDOR-3665 classad cache singleton should not be sharedptr

### DIFF
--- a/src/classad/classadCache.cpp
+++ b/src/classad/classadCache.cpp
@@ -298,7 +298,17 @@ public:
 };
 
 
-static classad_shared_ptr<ClassAdCache> _cache;
+// The expression cache is a process-lifetime singleton.  It is intentionally
+// a never-freed raw pointer rather than a smart pointer with static storage
+// duration: other statics (e.g. SecMan::session_cache) own ClassAds whose
+// CachedExprEnvelopes hold strong refs to CacheEntries, and those ClassAds are
+// torn down by their own atexit destructors.  If the cache's destructor were
+// allowed to run, static-destruction order is unspecified and the cache could
+// be freed first; the subsequent CacheEntry destructors would then touch freed
+// memory (a use-after-free observed under ASan at daemon shutdown).  Leaking
+// the singleton keeps it valid for the entire process lifetime; it remains
+// reachable through this pointer, so it is not reported as a leak.
+static ClassAdCache * _cache = nullptr;
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -308,7 +318,7 @@ static classad_shared_ptr<ClassAdCache> _cache;
 
 CacheEntry::~CacheEntry()
 {
-	if (_cache && _cache.use_count()) {
+	if (_cache) {
 		_cache->flush(szName, szValue);
 	}
 	delete pData;
@@ -320,7 +330,7 @@ ExprTree * CachedExprEnvelope::cache (const std::string & pName, ExprTree * pTre
 {
 	ExprTree * pRet = pTree;
 	if (cacheable(pTree)) {
-		if ( ! _cache) { _cache.reset( new ClassAdCache() ); }
+		if ( ! _cache) { _cache = new ClassAdCache(); }
 		CachedExprEnvelope * pNewEnv = new CachedExprEnvelope();
 		pNewEnv->m_pLetter = _cache->cache(pName, szValue, pTree);
 		pRet = pNewEnv;
@@ -330,7 +340,7 @@ ExprTree * CachedExprEnvelope::cache (const std::string & pName, ExprTree * pTre
 
 ExprTree * CachedExprEnvelope::cache_lazy (const std::string & pName, const std::string & szValue)
 {
-	if ( ! _cache) { _cache.reset( new ClassAdCache() ); }
+	if ( ! _cache) { _cache = new ClassAdCache(); }
 	CachedExprEnvelope *pEnv = new CachedExprEnvelope();
 	pEnv->m_pLetter = _cache->insert_lazy(pName, szValue);
 	return pEnv;
@@ -360,7 +370,7 @@ CachedExprEnvelope * CachedExprEnvelope::check_hit(const std::string & szName, c
 
    if (!_cache)
    {
-	_cache.reset(new ClassAdCache());
+	_cache = new ClassAdCache();
    }
 
    pCacheData cache_check = _cache->cache( szName, szValue, 0);


### PR DESCRIPTION
Because of order of destruction of globals, this causes a segfault on shutdown on windows.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
