### PR TITLE
HTCONDOR-3794 Fix thread race segfault on Windows

### DIFF
--- a/src/condor_daemon_core.V6/daemon_core.cpp
+++ b/src/condor_daemon_core.V6/daemon_core.cpp
@@ -9810,16 +9810,26 @@ pidWatcherThread( void* arg )
 	// which exited.
 	if ( (result < numentries) && (result >= 0) ) {
 
+		// Cache the PidEntry we are processing.  For a pipe that becomes
+		// ready, we must signal the PipeEnd's watched-event (watcher_done())
+		// as the very last thing we do, because that signal is what releases
+		// a concurrent Cancel_Pipe to delete this PidEntry.  post_wait() used
+		// to signal it directly, but the watcher then went on to write the
+		// PidEntry's pipeReady/watcherEvent fields, racing with that delete
+		// (a use-after-free seen at daemon/starter shutdown).
+		DaemonCore::PidEntry *pidentry = entry->pidentries[result];
+		bool signal_watcher_done = false;
+
 		last_pidentry_exited = result;
-		InterlockedExchange(&(entry->pidentries[result]->process_exited), true);
+		InterlockedExchange(&(pidentry->process_exited), true);
 
 		// notify our main thread which process exited
 		// note: if it was a thread which exited, the entry's
 		// pid contains the tid.  if we are talking about a pipe,
 		// set the exited_pid to be zero.
-		if ( entry->pidentries[result]->pipeEnd ) {
+		if ( pidentry->pipeEnd ) {
 			exited_pid = 0;
-			if (entry->pidentries[result]->deallocate) {
+			if (pidentry->deallocate) {
 				// this entry should be deallocated.  set things up so
 				// it will be done at the top of the loop; no need to send
 				// a signal to break out of select in the main thread, so we
@@ -9827,10 +9837,14 @@ pidWatcherThread( void* arg )
 				last_pidentry_exited = MAXIMUM_WAIT_OBJECTS + 5;
 			} else {
 				// pipe is ready and has not been deallocated.
-				if (entry->pidentries[result]->pipeEnd->post_wait()) {
+				if (pidentry->pipeEnd->post_wait()) {
 					// the handler is ready to be fired
-					InterlockedExchange(&(entry->pidentries[result]->pipeReady),1L);
+					InterlockedExchange(&(pidentry->pipeReady),1L);
 					must_send_signal = true;
+					// post_wait() reported ready but (unlike before) did not
+					// signal the watched-event; we must do that via
+					// watcher_done() once we are done with the PidEntry.
+					signal_watcher_done = true;
 				}
 				else {
 					// not ready yet...
@@ -9838,12 +9852,12 @@ pidWatcherThread( void* arg )
 				}
 			}
 		} else {
-			exited_pid = entry->pidentries[result]->pid;
+			exited_pid = pidentry->pid;
 		}
 
 		if ( exited_pid ) {
 			// a pid exited.  add it to MyExitedQueue, which is a queue of
-			// exited pids local to our thread that are waiting to be 
+			// exited pids local to our thread that are waiting to be
 			// added to the main thread WaitpidQueue.
 			wait_entry.child_pid = exited_pid;
 			wait_entry.exit_status = 0;  // we'll get the status later
@@ -9853,7 +9867,15 @@ pidWatcherThread( void* arg )
 
 		// we will no longer be watching this PidEntry, so detach
 		// it from our watcherEvent
-		entry->pidentries[result]->watcherEvent = NULL;
+		pidentry->watcherEvent = NULL;
+
+		// If the pipe became ready, this is the last point at which we touch
+		// the PidEntry.  Signal the watched-event now so that a concurrent
+		// Cancel_Pipe (blocked in PipeEnd::cancel()) may safely delete it.
+		// WARNING: after this call we must not reference pidentry again.
+		if ( signal_watcher_done ) {
+			pidentry->pipeEnd->watcher_done();
+		}
 
 	} else {
 		// no pid/thread/pipe was signaled; we were signaled because our

--- a/src/condor_daemon_core.V6/pipe.WINDOWS.cpp
+++ b/src/condor_daemon_core.V6/pipe.WINDOWS.cpp
@@ -100,6 +100,19 @@ void PipeEnd::set_unregistered()
 	SetEvent(m_watched_event);
 }
 
+// Called by the PID-watcher thread as its final action on a PidEntry after
+// post_wait() reported the pipe ready.  Signaling m_watched_event releases a
+// main thread that may be blocked in cancel(), which is then free to delete
+// the PidEntry.  It is therefore essential that the watcher does NOT touch the
+// PidEntry (or this PipeEnd) again after calling this.  Previously post_wait()
+// itself signaled the event, but the watcher then went on to write the
+// PidEntry's pipeReady/watcherEvent fields, racing with that deletion (an
+// observed use-after-free at daemon/starter shutdown).
+void PipeEnd::watcher_done()
+{
+	SetEvent(m_watched_event);
+}
+
 // this is called from Cancel_Pipe - it returns
 // when we know that there is no longer a PID-watcher
 // thread watching this PipeEnd and this PipeEnd
@@ -179,10 +192,10 @@ bool ReadPipeEnd::post_wait()
 
 	ASSERT(m_async_io_state == IO_DONE);
 
-	// tell the main thread that the PID-watcher is done with
-	// this object
-	SetEvent(m_watched_event);
-
+	// The pipe is ready.  We do NOT signal m_watched_event here: the
+	// watcher still has to update the PidEntry (pipeReady/watcherEvent).
+	// It signals via watcher_done() once it is finished, so that a
+	// concurrent Cancel_Pipe cannot free the PidEntry before then.
 	return true;
 }
 
@@ -394,10 +407,10 @@ bool WritePipeEnd::post_wait()
 		return false;
 	}
 	else {
-		// the write is complete! signal the Event object that the
-		// PID-watcher is done with this thread
-		SetEvent(m_watched_event);
-
+		// the write is complete!  We do NOT signal m_watched_event here:
+		// the watcher still has to update the PidEntry and will signal via
+		// watcher_done() once finished, so that a concurrent Cancel_Pipe
+		// cannot free the PidEntry out from under the watcher.
 		return true;
 	}
 }

--- a/src/condor_daemon_core.V6/pipe.WINDOWS.h
+++ b/src/condor_daemon_core.V6/pipe.WINDOWS.h
@@ -57,12 +57,22 @@ public:
 	// longer registered
 	void cancel();
 
+	// called from the PID-watcher thread as the very last action on a
+	// PidEntry once post_wait() has reported the pipe ready. Signals the
+	// main thread (which may be blocked in cancel()) that the watcher is
+	// completely done touching the PidEntry, so it is now safe to delete.
+	// This MUST be the watcher's final access to the PidEntry: once it
+	// returns, Cancel_Pipe may free the PidEntry out from under us.
+	void watcher_done();
+
 	// called from PID-watcher thread before WaitForMultipleObjects
 	virtual HANDLE pre_wait() = 0;
 
 	// called from PID-watcher thread after the overlapped I/O's event
 	// object is signaled. returns true if the handler is ready to be
-	// fired, false if not
+	// fired, false if not. NOTE: this no longer signals m_watched_event;
+	// the watcher must call watcher_done() after it has finished updating
+	// the PidEntry (see pidWatcherThread).
 	virtual bool post_wait() = 0;
 
 	// checked from DaemonCore::Driver to ensure the pipe is ready


### PR DESCRIPTION
On Windows, DaemonCore uses a pool of PID-watcher threads that block in WaitForMultipleObjects() on the events of the PidEntries they watch. When a watched pipe becomes ready, the watcher called PipeEnd::post_wait(), which itself signaled the PidEntry's m_watched_event. That signal is the handshake Cancel_Pipe()/PipeEnd::cancel() waits on to learn that no watcher is touching the PidEntry anymore, after which it is free to delete it.

However, post_wait() signaled the event too early. After post_wait() returned, the watcher thread continued to write the PidEntry's pipeReady and watcherEvent fields. If a concurrent Cancel_Pipe was blocked in cancel(), the early signal released it and it could delete the PidEntry while the watcher was still writing to it, causing an ASAN reported use-after free, and often a crash.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
