### PR TITLE
(HTCONDOR-3796)  Cherry-pick HTCONDOR-3554 fixes.

### DIFF
--- a/docs/version-history/v24-version.hist
+++ b/docs/version-history/v24-version.hist
@@ -1,5 +1,9 @@
 *** 24.0.22 bugs
 
+- Evaluating ClassAd expressions of the form ``list_of_ads.attribute_name``
+  in :tool:`classad_eval` no longer causes a segfault.
+  :jira:`3554`
+
 - When using trust-on-first-use (TOFU), tools can go into an infinite
   loop if they have no valid standard input file to read.
   :jira:`3754`

--- a/src/classad/attrrefs.cpp
+++ b/src/classad/attrrefs.cpp
@@ -208,6 +208,14 @@ _Evaluate (EvalState &state, Value &val) const
 
 			state.depth_remaining++;
 
+			// I think this is indicative of a more serious problem.
+			if( state.depth_remaining > 0 ) {
+				ExprList * el = nullptr;
+				if( val.IsListValue(el) && el == tree ) {
+					state.TakeFromDeletionCache(tree);
+				}
+			}
+
 			state.curAd = curAd;
 
 			return rval;

--- a/src/classad/attrrefs.cpp
+++ b/src/classad/attrrefs.cpp
@@ -208,14 +208,6 @@ _Evaluate (EvalState &state, Value &val) const
 
 			state.depth_remaining++;
 
-			// I think this is indicative of a more serious problem.
-			if( state.depth_remaining > 0 ) {
-				ExprList * el = nullptr;
-				if( val.IsListValue(el) && el == tree ) {
-					state.TakeFromDeletionCache(tree);
-				}
-			}
-
 			state.curAd = curAd;
 
 			return rval;

--- a/src/classad/exprTree.cpp
+++ b/src/classad/exprTree.cpp
@@ -219,7 +219,9 @@ Evaluate( Value& val, ExprTree*& sig ) const
 	EvalState 	state;
 
 	state.SetScopes( GetParentScope() );
-	return( Evaluate( state, val, sig  ) );
+	auto r = Evaluate( state, val, sig  );
+	val.MakeSelfContained( state );
+	return r;
 }
 
 
@@ -229,7 +231,9 @@ Flatten( Value& val, ExprTree *&tree ) const
 	EvalState state;
 
 	state.SetScopes( GetParentScope() );
-	return( Flatten( state, val, tree ) );
+	auto r = Flatten( state, val, tree );
+	val.MakeSelfContained( state );
+	return r;
 }
 
 

--- a/src/classad/exprTree.cpp
+++ b/src/classad/exprTree.cpp
@@ -207,7 +207,9 @@ Evaluate( Value& val ) const
 	EvalState 	state;
 
 	state.SetScopes( GetParentScope() );
-	return( Evaluate( state, val ) );
+	auto r = Evaluate( state, val );
+	val.MakeSelfContained( state );
+    return r;
 }
 
 


### PR DESCRIPTION
I haven't verified that the `class_eval` problem actually happens, but the code clearly hasn't changed since 24.0.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
