### PR TITLE
HTCONDOR-3688 CCBListener can now use a lambda to pass its callback

### DIFF
--- a/src/ccb/ccb_listener.cpp
+++ b/src/ccb/ccb_listener.cpp
@@ -157,8 +157,16 @@ CCBListener::SendMsgToCCB(ClassAd &msg,bool blocking)
 				return false;
 			}
 			m_waiting_for_connect = true;
-			incRefCount(); // do not let ourselves be deleted until called back
-			ccb.startCommand_nonblocking( cmd, m_sock, CCB_TIMEOUT, NULL, CCBListener::CCBConnectCallback, this, NULL, false, USE_TMP_SEC_SESSION );
+				// The lambda captures a classy_counted_ptr to us, keeping us
+				// alive until the callback fires (or the closure is destroyed).
+				// This replaces the old manual incRefCount()/decRefCount() pair.
+			classy_counted_ptr<CCBListener> self(this);
+			ccb.startCommand_nonblocking( cmd, m_sock, CCB_TIMEOUT, nullptr,
+				[self](bool success, Sock *sock, CondorError * /*errstack*/,
+						const std::string & /*trust_domain*/, bool /*should_try_token_auth*/) {
+					self->handleCCBConnect(success, sock);
+				},
+				nullptr, false, USE_TMP_SEC_SESSION );
 			return false;
 		}
 	}
@@ -183,26 +191,25 @@ CCBListener::WriteMsgToCCB(ClassAd &msg)
 }
 
 void
-CCBListener::CCBConnectCallback(bool success,Sock *sock,CondorError * /*errstack*/, const std::string & /*trust_domain*/, bool /*should_try_token_auth*/, void *misc_data)
+CCBListener::handleCCBConnect(bool success, Sock *sock)
 {
-	CCBListener *self = (CCBListener *)misc_data;
+	m_waiting_for_connect = false;
 
-	self->m_waiting_for_connect = false;
-
-	ASSERT( self->m_sock == sock );
+	ASSERT( m_sock == sock );
 
 	if( success ) {
-		ASSERT( self->m_sock->is_connected() );
-		self->Connected();
-		self->RegisterWithCCBServer();
+		ASSERT( m_sock->is_connected() );
+		Connected();
+		RegisterWithCCBServer();
 	}
 	else {
-		delete self->m_sock;
-		self->m_sock = NULL;
-		self->Disconnected();
+		delete m_sock;
+		m_sock = nullptr;
+		Disconnected();
 	}
 
-	self->decRefCount(); // remove ref count from when we started the connect
+	// Our refcount (held by the lambda that called us) drops when the lambda
+	// is destroyed after this returns.
 }
 
 void

--- a/src/ccb/ccb_listener.cpp
+++ b/src/ccb/ccb_listener.cpp
@@ -247,7 +247,6 @@ CCBListener::Disconnected()
 
 	if( m_waiting_for_connect ) {
 		m_waiting_for_connect = false;
-		decRefCount();
 	}
 
 	m_waiting_for_registration = false;

--- a/src/ccb/ccb_listener.h
+++ b/src/ccb/ccb_listener.h
@@ -67,7 +67,7 @@ class CCBListener: public Service, public ClassyCountedPtr {
 
 	bool SendMsgToCCB(ClassAd &msg,bool blocking);
 	bool WriteMsgToCCB(ClassAd &msg);
-	static void CCBConnectCallback(bool success,Sock *sock,CondorError *errstack, const std::string & /* trust_domain */, bool /* should_try_token_auth */, void *misc_data);
+	void handleCCBConnect(bool success, Sock *sock);
 	void ReconnectTime(int timerID = -1);
 	void Connected();
 	void Disconnected();


### PR DESCRIPTION
Replace the static CCBListener::CCBConnectCallback (which received the CCBListener via void *misc_data and manually balanced incRefCount / decRefCount) with a handleCCBConnect method invoked through a lambda that captures classy_counted_ptr<CCBListener>(this). The refcount is now held by the closure for exactly the lifetime of the pending startCommand, and the manual inc/dec pair is gone.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
