### PR TITLE
HTCONDOR-3805: CCB streaming (proxy) mode for private-to-private connections

### DIFF
--- a/build/packaging/debian/condor-test.install.in
+++ b/build/packaging/debian/condor-test.install.in
@@ -1,6 +1,7 @@
 #if defined(UW_BUILD)
 usr/lib/condor/condor_tests-*.tar.gz
 #endif
+usr/libexec/condor/ccb_proxy_bench
 usr/libexec/condor/condor_sinful
 usr/libexec/condor/condor_testingd
 usr/libexec/condor/test_user_mapping

--- a/build/packaging/rpm/condor.spec
+++ b/build/packaging/rpm/condor.spec
@@ -1224,6 +1224,7 @@ rm -rf %{buildroot}
 #################
 %files test
 %defattr(-,root,root,-)
+%_libexecdir/condor/ccb_proxy_bench
 %_libexecdir/condor/condor_sinful
 %_libexecdir/condor/condor_testingd
 %_libexecdir/condor/test_user_mapping

--- a/docs/admin-manual/configuration/global.rst
+++ b/docs/admin-manual/configuration/global.rst
@@ -1944,6 +1944,42 @@ More information about networking in HTCondor can be found in
     need to go through CCB. For more information about CCB, see
     :ref:`admin-manual/networking:htcondor connection brokering (ccb)`.
 
+:macro-def:`CCB_SERVER_STREAMING[Networking]`
+    A boolean value that controls whether a CCB server (broker) will proxy
+    private-to-private connections (CCB streaming mode). When ``True`` (the
+    default), if a daemon that is itself behind a CCB asks to reach another
+    CCB-routed daemon, the broker has the target reverse-connect to the broker
+    and then splices the two connections into a transparent TCP relay. The
+    end-to-end security handshake between the two daemons rides over the relay,
+    so the broker never decrypts the traffic. See
+    :ref:`admin-manual/networking:htcondor connection brokering (ccb)`.
+
+:macro-def:`CCB_SERVER_STREAMING_HANDSHAKE_TIMEOUT[Networking]`
+    The number of seconds a CCB server (broker) waits for the target of a
+    streaming request to connect back before canceling the connection reporting
+    a failure. The default is 300 (5 minutes). Set to 0 to disable handshake
+    reaping.
+
+:macro-def:`CCB_SERVER_MAX_STREAMING_SESSIONS[Networking]`
+    The maximum number of concurrent CCB streaming (proxy) sessions a broker will
+    maintain, counting both in-progress handshakes and established relays.
+    Requests beyond the limit are rejected with a clear failure. The default of
+    0 means unlimited.
+
+:macro-def:`CCB_SERVER_MAX_STREAMING_HANDSHAKES[Networking]`
+    The maximum number of CCB streaming (proxy) sessions a broker will keep in
+    the handshake state (waiting for the target to connect back) at once. This
+    bounds the more easily abused, never-completing requests separately from
+    established relays. The default of 0 means unlimited.
+
+:macro-def:`CCB_CLIENT_STREAMING[Networking]`
+    A boolean value that controls whether a daemon that is itself behind a CCB
+    will attempt to reach another CCB-routed (private) daemon by asking a
+    streaming-capable broker to proxy the connection, rather than giving up.
+    When ``True`` (the default), the attempt is only made when the broker
+    advertises support for streaming, so it is safe to leave enabled even in a
+    mixed-version pool.
+
 :macro-def:`CCB_HEARTBEAT_INTERVAL[Networking]`
     This is the maximum number of seconds of silence on a daemon's
     connection to the CCB server after which it will ping the server to

--- a/docs/admin-manual/networking.rst
+++ b/docs/admin-manual/networking.rst
@@ -649,6 +649,13 @@ requester only attempts a proxied connection after confirming (from the
 version exchanged during the security handshake) that the CCB server supports
 it, so streaming mode is safe to leave enabled in a mixed-version pool.
 
+The same proxying also helps a client that cannot accept a reverse connection
+at all, such as an unprivileged command-line tool behind a firewall or NAT.
+When ``TOOLS_ASSUME_FIREWALLS`` is set and such a client would otherwise be
+unable to open a reachable port to listen for the reverse connection, it
+requests a proxied connection through the CCB server instead of giving up,
+provided the server supports streaming.
+
 Any *condor_collector* may be used as a CCB server. There is no
 requirement that the *condor_collector* acting as the CCB server be the
 same *condor_collector* that a daemon advertises itself to (as with

--- a/docs/admin-manual/networking.rst
+++ b/docs/admin-manual/networking.rst
@@ -625,14 +625,29 @@ job is running and the execute node needs to connect back to the submit
 node (for example, to transfer output files), the execute node can
 connect by going through CCB to request a connection.
 
-If both A and B are in separate private networks, then CCB alone cannot
-provide connectivity. However, if an incoming port or port range can be
-opened in one of the private networks, then the situation becomes
-equivalent to one of the scenarios described above and CCB can provide
-bi-directional communication given only one-directional connectivity.
-See :ref:`admin-manual/networking:port usage in htcondor` for information on
+If both A and B are in separate private networks, then process A cannot
+accept the reverse connection from process B, so the basic scheme described
+above does not apply. Historically this was unsupported unless an incoming
+port or port range could be opened in one of the private networks (making the
+situation equivalent to one of the scenarios described above). See
+:ref:`admin-manual/networking:port usage in htcondor` for information on
 opening port ranges. Also note that CCB works nicely with
 *condor_shared_port*.
+
+Starting with HTCondor version 25.12.0, the both-private case is handled
+directly by **CCB streaming mode** without opening any ports. When the
+requesting process A is itself behind a CCB, it asks the CCB server to proxy
+the connection: the CCB server instructs process B to connect back to the CCB
+server (rather than to A), and the CCB server then splices the two
+connections together, acting as a transparent TCP relay between A and B. The
+normal end-to-end HTCondor security handshake is performed directly between A
+and B over this relay, so the CCB server authenticates and authorizes the two
+endpoints but never decrypts their traffic. Streaming mode is enabled by
+default and controlled by :macro:`CCB_SERVER_STREAMING` on the CCB server and
+:macro:`CCB_CLIENT_STREAMING` on the requesting daemon. A streaming-capable
+requester only attempts a proxied connection after confirming (from the
+version exchanged during the security handshake) that the CCB server supports
+it, so streaming mode is safe to leave enabled in a mixed-version pool.
 
 Any *condor_collector* may be used as a CCB server. There is no
 requirement that the *condor_collector* acting as the CCB server be the

--- a/docs/version-history/v25-version.hist
+++ b/docs/version-history/v25-version.hist
@@ -55,6 +55,16 @@
   addition to downloading individual files. Large files are uploaded in
   chunks via an upload session. Thanks to Zach McGrew for this contribution.
   :jira:`3792`
+- HTCondor Connection Brokering (CCB) now supports a streaming mode that
+  brokers connections between two daemons that are *both* behind a CCB,
+  without opening any incoming ports. When the requesting daemon is itself
+  CCB-routed, the CCB server has the target daemon connect back to the CCB
+  server and then relays bytes between the two connections; the end-to-end
+  security handshake is still performed directly between the two daemons, so
+  the CCB server never decrypts their traffic. Streaming mode is enabled by
+  default and controlled by the new configuration knobs
+  :macro:`CCB_SERVER_STREAMING` and :macro:`CCB_CLIENT_STREAMING`.
+  :jira:`3805`
 
 - Jobs that transfer input sandboxes now log a file transfer started 
   event even when there list of files to be transferred is empty.

--- a/src/ccb/ccb_client.cpp
+++ b/src/ccb/ccb_client.cpp
@@ -560,7 +560,36 @@ CCBClient::ReverseConnect_blocking( CondorError *error )
 				dprintf(D_ALWAYS,"CCBClient: %s\n",errmsg.c_str());
 				return false;
 			}
-		} else if( starts_with(reason, "cannot write") && toolsAssumeFirewalls ) {
+		} else if( toolsAssumeFirewalls ) {
+			// We are not using the shared port (reason: <reason> -- either it is
+			// disabled or its socket directory is not writable) and
+			// TOOLS_ASSUME_FIREWALLS says a random listen port would likely be
+			// firewalled.  So we must not open a plain listen socket and offer its
+			// (unreachable) address: we cannot accept a direct reverse connection.
+			// An unprivileged client behind a firewall or NAT generally cannot, so
+			// rather than hang waiting for a reverse connection that never arrives,
+			// fall back to streaming if it is enabled: ask the broker to proxy the
+			// connection on our existing request socket, so the target never has
+			// to reach us.  Our advertised address need not be reachable -- in
+			// proxy mode the broker splices the target onto the request socket and
+			// never dials it.  ProxyConnect_blocking version-gates each broker, so
+			// against an older broker that cannot stream we fall through and give
+			// up as before.
+			if( param_boolean("CCB_CLIENT_STREAMING", true) ) {
+				char const *my_addr =
+					daemonCore ? daemonCore->publicNetworkIpAddr() : NULL;
+				dprintf( D_NETWORK|D_FULLDEBUG,
+						 "CCBClient: cannot accept a direct reverse connection "
+						 "(assuming firewall); requesting a streaming (proxied) "
+						 "connection to %s instead.\n",
+						 m_target_peer_description.c_str() );
+				m_target_sock->enter_reverse_connecting_state();
+				if( ProxyConnect_blocking( error, my_addr ? my_addr : "" ) ) {
+					return true;
+				}
+				m_target_sock->exit_reverse_connecting_state(NULL);
+			}
+
 			std::string errmsg = reason;
 
 			if( error ) {

--- a/src/ccb/ccb_client.cpp
+++ b/src/ccb/ccb_client.cpp
@@ -33,8 +33,18 @@
 #include "condor_sinful.h"
 #include "shared_port_endpoint.h"
 #include "condor_config.h"
+#include "condor_version.h"
 
 static bool registered_reverse_connect_command = false;
+
+// Minimum broker version assumed to support CCB streaming/proxy mode, used as
+// the pre-send gate when a private client wants to reach another private peer.
+// This is the first HTCondor release whose CCB broker implements streaming;
+// against an older broker a private requester fails fast rather than sending a
+// request the broker would mishandle.
+static const int CCB_STREAMING_VERSION_MAJOR = 25;
+static const int CCB_STREAMING_VERSION_MINOR = 12;
+static const int CCB_STREAMING_VERSION_SUB   = 0;
 
 // hash of CCBClients waiting for a reverse connect command
 // indexed by connection id
@@ -48,7 +58,11 @@ CCBClient::CCBClient( char const *ccb_contact, ReliSock *target_sock ):
 	m_target_peer_description(m_target_sock->peer_description()),
 	m_ccb_sock(NULL),
 	m_ccb_cb(),
-	m_deadline_timer(-1)
+	m_deadline_timer(-1),
+	m_proxy_state(PROXY_NONE),
+	m_proxy_sock(NULL),
+	m_proxy_registered(false),
+	m_streaming_phase(true)
 {
 	// balance load across the CCB servers by randomizing order
 	std::random_device rd;
@@ -79,6 +93,7 @@ CCBClient::~CCBClient()
 	if( m_ccb_sock ) {
 		delete m_ccb_sock;
 	}
+	CleanupProxySock();
 	if( m_deadline_timer != -1 ) {
 		daemonCore->Cancel_Timer(m_deadline_timer);
 		m_deadline_timer = -1;
@@ -105,6 +120,7 @@ CCBClient::ReverseConnect( CondorError *error, bool non_blocking )
 		// DaemonCore::Register_Socket() and wait for a callback.
 
 		m_ccb_contacts_nb = m_ccb_contacts;
+		m_streaming_phase = true;  // try streaming first; fall back to direct later
 		return try_next_ccb();
 	}
 
@@ -125,9 +141,374 @@ CCBClient::myName()
 	return name;
 }
 
+std::string
+CCBClient::streamingReturnAddr()
+{
+	// Streaming/proxy mode only applies when this client is itself behind a
+	// CCB (our own command socket is CCB-routed) and streaming is enabled.
+	if( !param_boolean("CCB_CLIENT_STREAMING", true) ) {
+		return "";
+	}
+	if( !daemonCore || !daemonCore->publicNetworkIpAddr() ) {
+		return "";
+	}
+	Sinful s( daemonCore->publicNetworkIpAddr() );
+	if( s.getCCBContact() ) {
+		return daemonCore->publicNetworkIpAddr();
+	}
+	return "";
+}
+
+bool
+CCBClient::ProxyConnect_blocking( CondorError *error, char const *my_ccb_return )
+{
+	// Precondition: m_target_sock is in the reverse-connecting state so that on
+	// success we can adopt the proxied broker socket into it.
+	for( const auto& ccb_contact: m_ccb_contacts ) {
+		std::string ccb_address, ccbid;
+		if( !SplitCCBContact( ccb_contact.c_str(), ccb_address, ccbid, m_target_peer_description, error ) ) {
+			continue;
+		}
+
+		Daemon ccb(DT_COLLECTOR,ccb_address.c_str(),NULL);
+		Sock *sock = ccb.startCommand( CCB_REQUEST, Stream::reli_sock, DEFAULT_CEDAR_TIMEOUT, error );
+		if( !sock ) {
+			continue;
+		}
+
+		// Pre-send version gate: do not send a proxy request to a broker that
+		// cannot honor it (an old broker would forward our CCB-routed address
+		// to the target and the connection would silently fail).
+		CondorVersionInfo const *ver = sock->get_peer_version();
+		if( !ver || !ver->built_since_version(
+				CCB_STREAMING_VERSION_MAJOR,
+				CCB_STREAMING_VERSION_MINOR,
+				CCB_STREAMING_VERSION_SUB) )
+		{
+			dprintf(D_ALWAYS,
+					"CCBClient: broker %s does not support CCB streaming mode, "
+					"which is required to reach %s (private-to-private).\n",
+					ccb_address.c_str(), m_target_peer_description.c_str());
+			delete sock;
+			continue;
+		}
+
+		ClassAd msg;
+		msg.Assign(ATTR_CCBID,ccbid);
+		msg.Assign(ATTR_CLAIM_ID,m_connect_id);
+		msg.Assign(ATTR_NAME, myName());
+		// Send our own CCB-routed return address so the broker engages proxy
+		// mode, and flag the request explicitly.
+		msg.Assign(ATTR_MY_ADDRESS, my_ccb_return);
+		msg.Assign("CCBStreamingRequired", true);
+
+		dprintf(D_NETWORK|D_FULLDEBUG,
+				"CCBClient: requesting streaming (proxied) connection to %s "
+				"via CCB server %s#%s.\n",
+				m_target_peer_description.c_str(),
+				ccb_address.c_str(), ccbid.c_str());
+
+		sock->encode();
+		if( !putClassAd( sock, msg ) || !sock->end_of_message() ) {
+			delete sock;
+			continue;
+		}
+
+		// Read the broker's reply ({Result, ProxyMode}).
+		sock->decode();
+		ClassAd reply;
+		if( !getClassAd( sock, reply ) || !sock->end_of_message() ) {
+			delete sock;
+			continue;
+		}
+		bool result = false;
+		reply.LookupBool(ATTR_RESULT,result);
+		if( !result ) {
+			std::string remote_errmsg;
+			reply.LookupString(ATTR_ERROR_STRING,remote_errmsg);
+			dprintf(D_ALWAYS,
+					"CCBClient: broker %s refused streaming request to %s: %s\n",
+					ccb_address.c_str(), m_target_peer_description.c_str(),
+					remote_errmsg.c_str());
+			delete sock;
+			continue;
+		}
+
+		// The broker now splices the target's reverse-connect hello onto this
+		// socket. Read and validate it exactly as AcceptReversedConnection does.
+		int cmd = 0;
+		ClassAd hello;
+		if( !sock->get(cmd) || !getClassAd( sock, hello ) || !sock->end_of_message() ) {
+			delete sock;
+			continue;
+		}
+		std::string connect_id;
+		hello.LookupString(ATTR_CLAIM_ID,connect_id);
+		if( cmd != CCB_REVERSE_CONNECT || connect_id != m_connect_id ) {
+			dprintf(D_ALWAYS,
+					"CCBClient: invalid proxied hello from broker %s "
+					"(intended target is %s)\n",
+					ccb_address.c_str(), m_target_peer_description.c_str());
+			delete sock;
+			continue;
+		}
+
+		// Success: adopt the proxied socket as the connection to the target.
+		// From here on the socket is a transparent pipe to the target and the
+		// normal end-to-end CEDAR handshake proceeds over it.
+		//
+		// exit_reverse_connecting_state() clears the socket's m_ccb_client
+		// pointer, which in the blocking path is the only reference keeping this
+		// CCBClient alive -- without the reference below we would be deleted out
+		// from under ourselves and crash dereferencing m_target_sock.
+		classy_counted_ptr<CCBClient> self(this);
+		static_cast<ReliSock*>(sock)->resetHeaderMD();
+		m_target_sock->exit_reverse_connecting_state(static_cast<ReliSock*>(sock));
+		static_cast<ReliSock*>(m_target_sock)->resetHeaderMD();
+		delete sock; // exit_reverse_connecting_state has taken over the fd
+
+		dprintf(D_FULLDEBUG|D_NETWORK,
+				"CCBClient: established streaming (proxied) connection to %s "
+				"via CCB server %s.\n",
+				m_target_peer_description.c_str(), ccb_address.c_str());
+		return true;
+	}
+	return false;
+}
+
+// CleanupProxySock tears down the broker socket used by the non-blocking proxy
+// exchange, cancelling its DaemonCore registration if it was registered.
+void
+CCBClient::CleanupProxySock()
+{
+	if( m_proxy_sock ) {
+		if( m_proxy_registered ) {
+			daemonCore->Cancel_Socket( m_proxy_sock );
+			m_proxy_registered = false;
+		}
+		delete m_proxy_sock;
+		m_proxy_sock = NULL;
+	}
+	m_proxy_state = PROXY_NONE;
+}
+
+bool
+CCBClient::ProxyConnect_nonblocking( char const *ccbid, char const *my_ccb_return )
+{
+	// Precondition: m_target_sock is in the reverse-connecting state (set by
+	// ReverseConnect()), and m_cur_ccb_address is the broker to use.  The object
+	// is kept alive for the duration of the async exchange by
+	// waiting_for_reverse_connect (added in RegisterReverseConnectCallback at the
+	// top of try_next_ccb), so no extra reference is needed here.
+	Daemon ccb( DT_COLLECTOR, m_cur_ccb_address.c_str(), NULL );
+	Sock *sock = ccb.makeConnectedSocket( Stream::reli_sock, DEFAULT_CEDAR_TIMEOUT, 0, NULL, true /*nonblocking*/ );
+	if( !sock ) {
+		return false;
+	}
+
+	m_proxy_sock = sock;
+	m_proxy_registered = false;
+	m_proxy_state = PROXY_WAIT_REPLY;
+	m_proxy_ccbid = ccbid;
+	m_proxy_return = my_ccb_return;
+
+	dprintf( D_NETWORK|D_FULLDEBUG,
+			 "CCBClient: requesting streaming (proxied) connection to %s "
+			 "via CCB server %s#%s (non-blocking).\n",
+			 m_target_peer_description.c_str(), m_cur_ccb_address.c_str(), ccbid );
+
+	ccb.startCommand_nonblocking(
+		CCB_REQUEST, sock, DEFAULT_CEDAR_TIMEOUT, NULL,
+		[this]( bool success, Sock *s, CondorError *errstack,
+				const std::string & /*trust_domain*/, bool /*try_token*/ ) {
+			ProxyConnectCallback( success, s, errstack );
+		} );
+	return true;
+}
+
+void
+CCBClient::ProxyConnectCallback( bool success, Sock *sock, CondorError * /*errstack*/ )
+{
+	// If the reverse-connect was cancelled (e.g. deadline expired) while we were
+	// connecting, m_target_sock is gone; just clean up the broker socket.
+	if( !m_target_sock ) {
+		CleanupProxySock();
+		return;
+	}
+
+	if( !success ) {
+		ProxyConnectFailed();
+		return;
+	}
+
+	// Pre-send version gate: do not send a proxy request to a broker that cannot
+	// honor it.
+	CondorVersionInfo const *ver = sock->get_peer_version();
+	if( !ver || !ver->built_since_version(
+			CCB_STREAMING_VERSION_MAJOR,
+			CCB_STREAMING_VERSION_MINOR,
+			CCB_STREAMING_VERSION_SUB) )
+	{
+		dprintf( D_ALWAYS,
+				 "CCBClient: broker %s does not support CCB streaming mode, "
+				 "which is required to reach %s (private-to-private).\n",
+				 m_cur_ccb_address.c_str(), m_target_peer_description.c_str() );
+		ProxyConnectFailed();
+		return;
+	}
+
+	// Send the proxy request.
+	ClassAd msg;
+	msg.Assign( ATTR_CCBID, m_proxy_ccbid );
+	msg.Assign( ATTR_CLAIM_ID, m_connect_id );
+	msg.Assign( ATTR_NAME, myName() );
+	msg.Assign( ATTR_MY_ADDRESS, m_proxy_return );
+	msg.Assign( "CCBStreamingRequired", true );
+
+	sock->encode();
+	if( !putClassAd( sock, msg ) || !sock->end_of_message() ) {
+		ProxyConnectFailed();
+		return;
+	}
+
+	// Wait for the broker's reply, and then the proxied hello, asynchronously.
+	m_proxy_state = PROXY_WAIT_REPLY;
+	int rc = daemonCore->Register_Socket(
+		sock, sock->peer_description(),
+		[this]( Stream *s ) { return ProxyMsgHandler( s ); },
+		"CCBClient::ProxyMsgHandler" );
+	if( rc < 0 ) {
+		ProxyConnectFailed();
+		return;
+	}
+	m_proxy_registered = true;
+}
+
+int
+CCBClient::ProxyMsgHandler( Stream *stream )
+{
+	Sock *sock = (Sock *)stream;
+	sock->timeout( DEFAULT_CEDAR_TIMEOUT );
+
+	// If the reverse-connect was cancelled while we were waiting, clean up.
+	if( !m_target_sock ) {
+		CleanupProxySock();
+		return KEEP_STREAM;
+	}
+
+	if( m_proxy_state == PROXY_WAIT_REPLY ) {
+		ClassAd reply;
+		sock->decode();
+		if( !getClassAd( sock, reply ) || !sock->end_of_message() ) {
+			ProxyConnectFailed();
+			return KEEP_STREAM;
+		}
+		bool result = false;
+		reply.LookupBool( ATTR_RESULT, result );
+		if( !result ) {
+			std::string remote_errmsg;
+			reply.LookupString( ATTR_ERROR_STRING, remote_errmsg );
+			dprintf( D_ALWAYS,
+					 "CCBClient: broker %s refused streaming request to %s: %s\n",
+					 m_cur_ccb_address.c_str(), m_target_peer_description.c_str(),
+					 remote_errmsg.c_str() );
+			ProxyConnectFailed();
+			return KEEP_STREAM;
+		}
+		// Success so far; the broker will splice in the target's reverse-connect
+		// hello when the target connects.  Keep the socket registered and wait.
+		m_proxy_state = PROXY_WAIT_HELLO;
+		return KEEP_STREAM;
+	}
+
+	if( m_proxy_state == PROXY_WAIT_HELLO ) {
+		int cmd = 0;
+		ClassAd hello;
+		sock->decode();
+		if( !sock->get(cmd) || !getClassAd( sock, hello ) || !sock->end_of_message() ) {
+			ProxyConnectFailed();
+			return KEEP_STREAM;
+		}
+		std::string connect_id;
+		hello.LookupString( ATTR_CLAIM_ID, connect_id );
+		if( cmd != CCB_REVERSE_CONNECT || connect_id != m_connect_id ) {
+			dprintf( D_ALWAYS,
+					 "CCBClient: invalid proxied hello from broker %s "
+					 "(intended target is %s)\n",
+					 m_cur_ccb_address.c_str(), m_target_peer_description.c_str() );
+			ProxyConnectFailed();
+			return KEEP_STREAM;
+		}
+
+		// Success: adopt the proxied socket as the connection to the target and
+		// notify the waiting caller, mirroring ReverseConnectCallback().
+		daemonCore->Cancel_Socket( sock );
+		m_proxy_registered = false;
+		m_proxy_sock = NULL;
+		m_proxy_state = PROXY_NONE;
+
+		static_cast<ReliSock*>(sock)->resetHeaderMD();
+		m_target_sock->exit_reverse_connecting_state( static_cast<ReliSock*>(sock) );
+		static_cast<ReliSock*>(m_target_sock)->resetHeaderMD();
+		delete sock; // exit_reverse_connecting_state took over the fd
+
+		dprintf( D_FULLDEBUG|D_NETWORK,
+				 "CCBClient: established streaming (proxied) connection to %s "
+				 "via CCB server %s.\n",
+				 m_target_peer_description.c_str(), m_cur_ccb_address.c_str() );
+
+		if( m_ccb_cb ) {
+			m_ccb_cb->cancelCallback();
+			m_ccb_cb->cancelMessage( true );
+			m_ccb_cb = NULL;
+			decRefCount();
+		}
+		daemonCore->CallSocketHandler( m_target_sock, false );
+		m_target_sock = NULL;
+		UnregisterReverseConnectCallback();
+		return KEEP_STREAM; // socket already cancelled/deleted above
+	}
+
+	return KEEP_STREAM;
+}
+
+void
+CCBClient::ProxyConnectFailed()
+{
+	CleanupProxySock();
+	// Move on to the next broker (or give up if none remain).
+	try_next_ccb();
+}
+
 bool
 CCBClient::ReverseConnect_blocking( CondorError *error )
 {
+	// Hold a reference to ourselves for the duration of this call.  Below,
+	// exit_reverse_connecting_state() clears the socket's reference to this
+	// CCBClient, which would otherwise delete us mid-function -- fatal once we
+	// fall through to the plain reverse-connect loop and touch our members.
+	classy_counted_ptr<CCBClient> self(this);
+
+	// If we are ourselves behind a CCB, the target cannot reverse-connect to us
+	// directly; ask the broker to proxy instead (streaming mode).
+	std::string my_ccb_return = streamingReturnAddr();
+	if( !my_ccb_return.empty() ) {
+		m_target_sock->enter_reverse_connecting_state();
+		if( ProxyConnect_blocking( error, my_ccb_return.c_str() ) ) {
+			return true;
+		}
+		m_target_sock->exit_reverse_connecting_state(NULL);
+		// Streaming failed (e.g. the broker is too old or has streaming
+		// disabled).  As a last resort, fall through to the plain reverse
+		// connection below: we open a direct listen socket and offer it (our CCB
+		// contact stripped), which succeeds if the two endpoints turn out to be
+		// mutually reachable.  This mirrors the non-blocking try_next_ccb path.
+		dprintf(D_ALWAYS,
+				"CCBClient: streaming (proxy) connection to %s failed; falling "
+				"back to a direct reverse connection.\n",
+				m_target_peer_description.c_str());
+	}
+
 	std::shared_ptr<ReliSock> listen_sock;
 	std::shared_ptr<SharedPortEndpoint> shared_listener;
 	char const *listener_addr = NULL;
@@ -543,12 +924,28 @@ CCBClient::try_next_ccb()
 	RegisterReverseConnectCallback();
 
 	if(m_ccb_contacts_nb.empty()) {
-		dprintf(D_ALWAYS,
-				"CCBClient: no more CCB servers to try for requesting "
-				"reversed connection to %s; giving up.\n",
-				m_target_peer_description.c_str());
-		ReverseConnectCallback(NULL);
-		return false;
+		// If we exhausted every broker while attempting streaming (proxy) mode,
+		// fall back to a plain reverse connection as a last resort: retry the
+		// brokers with our CCB contact stripped.
+		char const *ra = daemonCore->publicNetworkIpAddr();
+		if( m_streaming_phase && ra && Sinful(ra).getCCBContact()
+			&& param_boolean("CCB_CLIENT_STREAMING", true) )
+		{
+			m_streaming_phase = false;
+			m_ccb_contacts_nb = m_ccb_contacts;
+			dprintf(D_ALWAYS,
+					"CCBClient: streaming (proxy) connection to %s failed on all "
+					"brokers; falling back to a direct reverse connection.\n",
+					m_target_peer_description.c_str());
+		}
+		if(m_ccb_contacts_nb.empty()) {
+			dprintf(D_ALWAYS,
+					"CCBClient: no more CCB servers to try for requesting "
+					"reversed connection to %s; giving up.\n",
+					m_target_peer_description.c_str());
+			ReverseConnectCallback(NULL);
+			return false;
+		}
 	}
 
 	std::string ccb_contact = m_ccb_contacts_nb.back();
@@ -567,15 +964,45 @@ CCBClient::try_next_ccb()
 
 	Sinful sinful_return(return_address);
 	if( sinful_return.getCCBContact() ) {
-		// uh oh!  Our return address is via CCB.
-		dprintf(D_ALWAYS,
-				"CCBClient: WARNING: trying to connect to %s via CCB, but "
-				"this appears to be a connection from one private network "
-				"to another, which is not supported by CCB.  Either that, "
-				"or you have not configured the private network name "
-				"to be the same in these two networks when it really should "
-				"be.  Assuming the latter.\n",
-				m_target_peer_description.c_str());
+		bool streaming_enabled = param_boolean("CCB_CLIENT_STREAMING", true);
+		if( m_streaming_phase && streaming_enabled ) {
+			// We are behind a CCB too (private-to-private): use streaming/proxy
+			// mode.  m_target_sock is already in the reverse-connecting state
+			// (set by ReverseConnect).  Drive the broker exchange asynchronously
+			// so we do not block the DaemonCore main loop; the rest of the work
+			// happens in ProxyConnectCallback / ProxyMsgHandler.
+			if( ProxyConnect_nonblocking( ccbid.c_str(), return_address ) ) {
+				return true;
+			}
+			// Failed to even initiate; try the next broker (or give up).
+			return try_next_ccb();
+		}
+
+		if( streaming_enabled ) {
+			// We have exhausted streaming on every broker and are now retrying
+			// with a plain reverse connection: strip our CCB contact and offer a
+			// direct return address, which succeeds if the endpoints are actually
+			// mutually reachable.
+			dprintf(D_NETWORK|D_FULLDEBUG,
+					"CCBClient: streaming exhausted; attempting a direct reverse "
+					"connection to %s with our CCB contact stripped.\n",
+					m_target_peer_description.c_str());
+		} else {
+			// Streaming is disabled.  Our return address is via CCB, so this
+			// looks like a private-to-private connection that plain CCB cannot
+			// make; assume instead that the private network names are mislabeled
+			// and try a direct reverse connection.
+			dprintf(D_ALWAYS,
+					"CCBClient: WARNING: trying to connect to %s via CCB, but "
+					"this appears to be a connection from one private network "
+					"to another, which is not supported without CCB streaming.  "
+					"Either that, or you have not configured the private network "
+					"name to be the same in these two networks when it really "
+					"should be.  Assuming the latter.  (CCB_CLIENT_STREAMING "
+					"enables private-to-private connections via a streaming-"
+					"capable broker.)\n",
+					m_target_peer_description.c_str());
+		}
 
 		// strip off CCB contact info in the return address
 		sinful_return.setCCBContact(NULL);
@@ -842,6 +1269,11 @@ CCBClient::ReverseConnectCallback(Sock *sock)
 	// and letting it continue on its way as though this were
 	// a normal non-blocking connection attempt that just
 	// finished.
+
+	// If a non-blocking proxy exchange is still in flight (e.g. this is the
+	// deadline/cancel path), tear down its broker socket first so its
+	// registered handler cannot fire after we are gone.
+	CleanupProxySock();
 
 	ASSERT( m_target_sock );
 

--- a/src/ccb/ccb_client.h
+++ b/src/ccb/ccb_client.h
@@ -56,8 +56,41 @@ class CCBClient: public Service, public ClassyCountedPtr {
 	std::shared_ptr<DCMsgCallback> m_ccb_cb; // callback object for async CCB request
 	int m_deadline_timer;
 
+	// Non-blocking streaming/proxy connect state (see ProxyConnect_nonblocking).
+	enum ProxyConnectState { PROXY_NONE, PROXY_WAIT_REPLY, PROXY_WAIT_HELLO };
+	ProxyConnectState m_proxy_state;
+	Sock *m_proxy_sock;        // broker socket during the proxy exchange
+	bool m_proxy_registered;   // m_proxy_sock is registered with DaemonCore
+	std::string m_proxy_ccbid; // target ccbid for the current broker
+	std::string m_proxy_return;// our CCB-routed return address
+	// True while try_next_ccb is still attempting streaming (proxy) mode; once
+	// every broker has been tried it flips to false and the brokers are retried
+	// with a plain reverse connection (CCB contact stripped) as a last resort.
+	bool m_streaming_phase;
+
 	bool ReverseConnect_blocking( CondorError *error );
 	static bool SplitCCBContact( char const *ccb_contact, std::string &ccb_address, std::string &ccbid, const std::string & peer, CondorError *error );
+
+	// Streaming/proxy mode (CCB_STREAMING): used when this client is itself
+	// behind a CCB (i.e. our own return address is CCB-routed), so the target
+	// cannot reverse-connect to us directly.  Instead we ask the broker to
+	// proxy: the target reverse-connects to the broker, the broker splices the
+	// two sockets, and we read the reverse-connect hello on the request socket
+	// itself.  Returns true and adopts the proxied socket into m_target_sock.
+	bool ProxyConnect_blocking( CondorError *error, char const *my_ccb_return );
+	// Non-blocking version of the streaming/proxy connect, used from the
+	// non-blocking try_next_ccb path.  Drives the broker exchange (connect+auth,
+	// request, reply, proxied hello) asynchronously via DaemonCore callbacks and
+	// then adopts the proxied socket into m_target_sock, without blocking the
+	// DaemonCore main loop.  Returns true if the async operation was initiated.
+	bool ProxyConnect_nonblocking( char const *ccbid, char const *my_ccb_return );
+	void ProxyConnectCallback( bool success, Sock *sock, CondorError *errstack );
+	int ProxyMsgHandler( Stream *stream );
+	void ProxyConnectFailed();
+	void CleanupProxySock();
+	// Returns our own CCB-routed return address if streaming is enabled and we
+	// are behind a CCB, else empty string.
+	std::string streamingReturnAddr();
 
 	bool AcceptReversedConnection(std::shared_ptr<ReliSock> listen_sock,std::shared_ptr<SharedPortEndpoint> shared_listener);
 	bool HandleReversedConnectionRequestReply(CondorError *error);

--- a/src/ccb/ccb_server.cpp
+++ b/src/ccb/ccb_server.cpp
@@ -979,6 +979,17 @@ public:
 	ReliSock *requester;  // endpoint "A"
 	ReliSock *target;     // endpoint "B"
 	bool relaying;
+	// Set once a relaying session is being torn down.  Both relay sockets share a
+	// handler that captures a shared_ptr to this session; the first to fail flips
+	// this flag and wakes the other, and every relay callback that sees it simply
+	// returns non-KEEP_STREAM so DaemonCore cancels+deletes its socket (see
+	// ProxyRelayData / BeginRelayTeardown).  The session itself is owned by the
+	// shared_ptrs captured in the two relay handlers (plus the m_proxy_sessions
+	// entry until teardown detaches it), so it is freed automatically once the
+	// last relay socket -- and thus its handler -- is gone.  This guarantees the
+	// session outlives every still-pending sibling callback without a manual
+	// reference count.
+	bool dying;
 	// When the session was created (request forwarded to the target).  The
 	// periodic maintenance sweep reaps a session that is still not relaying after
 	// the handshake timeout, so a target that never connects back cannot pin the
@@ -987,7 +998,7 @@ public:
 	Dir a_to_b;   // bytes read from the requester, to be written to the target
 	Dir b_to_a;   // bytes read from the target, to be written to the requester
 
-	CCBProxySession() : requester(nullptr), target(nullptr), relaying(false), created(0) {}
+	CCBProxySession() : requester(nullptr), target(nullptr), relaying(false), dying(false), created(0) {}
 };
 
 // Relay helpers (defined below; forward-declared for use in HandleReverseConnect).
@@ -1048,7 +1059,7 @@ CCBServer::StartProxyRequest( ReliSock *requester, CCBTarget *target, char const
 		return;
 	}
 
-	CCBProxySession *session = new CCBProxySession();
+	auto session = std::make_shared<CCBProxySession>();
 	session->connect_id = connect_id;
 	session->requester = requester;
 	session->created = time(nullptr);  // handshake deadline is relative to this
@@ -1059,8 +1070,7 @@ CCBServer::StartProxyRequest( ReliSock *requester, CCBTarget *target, char const
 	if( m_proxy_sessions.find(session->connect_id) != m_proxy_sessions.end() ) {
 		RequestReply( requester, false, "duplicate connect id", 0, target->getCCBID() );
 		ccb_stats.CCBRequestsFailed += 1;
-		delete session;
-		delete requester;
+		delete requester;  // session (shared_ptr) is freed on return; it never owns the socket
 		return;
 	}
 	m_proxy_sessions[session->connect_id] = session;
@@ -1085,7 +1095,7 @@ CCBServer::StartProxyRequest( ReliSock *requester, CCBTarget *target, char const
 				target->getCCBID());
 		RequestReply( requester, false, "failed to forward proxy request to target", 0, target->getCCBID() );
 		ccb_stats.CCBRequestsFailed += 1;
-		DestroyProxySession( session );
+		DestroyProxySession( session.get() );
 		return;
 	}
 
@@ -1121,7 +1131,7 @@ CCBServer::HandleReverseConnect( int cmd, Stream *stream )
 				sock->peer_description());
 		return FALSE;
 	}
-	CCBProxySession *session = it->second;
+	std::shared_ptr<CCBProxySession> session = it->second;
 	if( session->target ) {
 			// already satisfied; reject the duplicate
 		return FALSE;
@@ -1137,7 +1147,7 @@ CCBServer::HandleReverseConnect( int cmd, Stream *stream )
 		dprintf(D_ALWAYS,"CCB: failed to send proxy reply to requester %s\n",
 				session->requester->peer_description());
 		ccb_stats.CCBRequestsFailed += 1;
-		DestroyProxySession( session );
+		DestroyProxySession( session.get() );
 		return KEEP_STREAM; // we took ownership of sock via session->target
 	}
 
@@ -1151,7 +1161,7 @@ CCBServer::HandleReverseConnect( int cmd, Stream *stream )
 	{
 		dprintf(D_ALWAYS,"CCB: failed to replay reverse-connect hello to requester\n");
 		ccb_stats.CCBRequestsFailed += 1;
-		DestroyProxySession( session );
+		DestroyProxySession( session.get() );
 		return KEEP_STREAM;
 	}
 
@@ -1167,19 +1177,21 @@ CCBServer::HandleReverseConnect( int cmd, Stream *stream )
 	{
 		dprintf(D_ALWAYS,"CCB: failed to set proxy sockets non-blocking\n");
 		ccb_stats.CCBRequestsFailed += 1;
-		DestroyProxySession( session );
+		DestroyProxySession( session.get() );
 		return KEEP_STREAM;
 	}
 
-		// Begin the non-blocking byte relay.  Both sockets share one handler (a
-		// std::function that carries the session) which attempts non-blocking
-		// I/O in both directions and adjusts each socket's read/write interest
-		// to avoid triggering reads when we cannot write.
+		// Begin the non-blocking byte relay.  Both sockets share one handler that
+		// captures a shared_ptr to the session (so the session stays alive as long
+		// as either relay socket -- and thus its handler -- is registered).  The
+		// handler attempts non-blocking I/O in both directions and adjusts each
+		// socket's read/write interest to avoid triggering reads when we cannot
+		// write.
 	session->relaying = true;
 	m_pending_handshakes.erase( session->connect_id );  // handshake done -> relaying
 
 	StdSocketHandler relay_handler =
-		[this, session](Stream *) { return ProxyRelayData( session ); };
+		[this, session](Stream *) { return ProxyRelayData( session.get() ); };
 
 	int rc = daemonCore->Register_Socket(
 		session->requester,
@@ -1209,6 +1221,9 @@ CCBServer::HandleReverseConnect( int cmd, Stream *stream )
 
 #ifndef SHUT_WR
 #define SHUT_WR SD_SEND   // POSIX name for Winsock's "stop sending" shutdown
+#endif
+#ifndef SHUT_RDWR
+#define SHUT_RDWR SD_BOTH // POSIX name for Winsock's "stop both" shutdown
 #endif
 
 // ccbSetNonBlocking puts a socket fd into non-blocking mode.
@@ -1364,6 +1379,14 @@ CCBServer::ProxyRelayData( CCBProxySession *s )
 	if( !s ) {
 		return KEEP_STREAM;
 	}
+	if( s->dying ) {
+		// The session is already being torn down: the other socket's callback (or
+		// this socket's own teardown) flipped it dying and woke us only so that we
+		// retire this socket.  Do not touch the splice; returning non-KEEP_STREAM
+		// makes DaemonCore cancel+delete this socket, which drops this handler's
+		// shared_ptr and frees the session once the other socket is gone too.
+		return FALSE;
+	}
 
 	// Non-blocking I/O makes it safe to attempt both directions on every
 	// callback regardless of which socket woke us; an unready socket simply
@@ -1377,14 +1400,14 @@ CCBServer::ProxyRelayData( CCBProxySession *s )
 		ccb_stats.CCBStreamingFailed += 1;
 		dprintf(D_NETWORK,"CCB RELAY: tearing down session (request id %s) on pump error\n",
 				s->request_id.c_str());
-		DestroyProxySession( s );
-		return KEEP_STREAM;
+		BeginRelayTeardown( s );
+		return FALSE;
 	}
 
 	// Both directions fully closed: tear down.
 	if( s->a_to_b.dst_shutdown && s->b_to_a.dst_shutdown ) {
-		DestroyProxySession( s );
-		return KEEP_STREAM;
+		BeginRelayTeardown( s );
+		return FALSE;
 	}
 
 	// Re-evaluate each socket's read/write interest.  A socket is the source of
@@ -1421,7 +1444,7 @@ CCBServer::SweepProxySessions()
 			// DestroyProxySession erases the current element, so advance first.
 		auto next_it = it;
 		++next_it;
-		CCBProxySession *session = it->second;
+		CCBProxySession *session = it->second.get();
 		if( !session->relaying && now - session->created >= handshake_timeout ) {
 			dprintf(D_ALWAYS,
 					"CCB: streaming (proxy) handshake for request id %s timed out "
@@ -1444,30 +1467,64 @@ CCBServer::DestroyProxySession( CCBProxySession *session )
 	if( !session ) {
 		return;
 	}
+		// This path is only for a session that has not begun relaying (it is still
+		// in the handshake).  No relay sockets are registered with DaemonCore yet,
+		// so there is no sibling callback to race and everything can be freed
+		// synchronously.  A relaying session is torn down via BeginRelayTeardown,
+		// which lets each socket retire itself from its own callback.
+	ASSERT( !session->relaying );
+
+		// We still own these sockets (DaemonCore only takes ownership once they are
+		// registered for relaying), so delete them here.  delete on nullptr is fine.
+	delete session->requester;
+	delete session->target;
+	session->requester = nullptr;
+	session->target = nullptr;
+
+		// Dropping the m_proxy_sessions entry releases the only shared_ptr to a
+		// pre-relaying session (no relay handler holds one yet), so this frees it.
+	m_pending_handshakes.erase( session->connect_id );
 	auto it = m_proxy_sessions.find( session->connect_id );
-	if( it != m_proxy_sessions.end() && it->second == session ) {
+	if( it != m_proxy_sessions.end() && it->second.get() == session ) {
 		m_proxy_sessions.erase( it );
 	}
-		// Idempotent: a no-op if the session already started relaying.
-	m_pending_handshakes.erase( session->connect_id );
-	if( session->relaying ) {
-		ccb_stats.CCBStreamingActive -= 1;
+}
+
+void
+CCBServer::BeginRelayTeardown( CCBProxySession *session )
+{
+	if( !session || session->dying ) {
+		return;  // idempotent: the other socket may have started this already
 	}
+	session->dying = true;
+	ccb_stats.CCBStreamingActive -= 1;
+
+		// Wake both relay sockets so that each retires itself from its own callback
+		// -- the only context in which DaemonCore can safely cancel and delete a
+		// socket that may currently be in service.  shutdown() forces an EOF/error
+		// wakeup even on a socket with no pending I/O, and selecting it for read
+		// guarantees it lands in the next select() set.  Each woken callback returns
+		// non-KEEP_STREAM, so DaemonCore cancels+deletes its socket and destroys its
+		// copy of the relay handler; the session is freed once the last such handler
+		// (its shared_ptr) is gone.
 	if( session->requester ) {
-		if( session->relaying ) {
-			daemonCore->Cancel_Socket( session->requester );
-		}
-		delete session->requester;
-		session->requester = nullptr;
+		daemonCore->Set_Socket_Handler_Type( session->requester, HANDLE_READ );
+		shutdown( session->requester->get_file_desc(), SHUT_RDWR );
 	}
 	if( session->target ) {
-		if( session->relaying ) {
-			daemonCore->Cancel_Socket( session->target );
-		}
-		delete session->target;
-		session->target = nullptr;
+		daemonCore->Set_Socket_Handler_Type( session->target, HANDLE_READ );
+		shutdown( session->target->get_file_desc(), SHUT_RDWR );
 	}
-	delete session;
+
+		// Detach from the lookup tables so no new request can match this session and
+		// so the shared_ptr the map held is released (the relay handlers keep the
+		// session alive until their sockets are gone).  Do this last: the shutdown
+		// calls above still need session->requester / session->target.
+	m_pending_handshakes.erase( session->connect_id );  // a no-op once relaying
+	auto it = m_proxy_sessions.find( session->connect_id );
+	if( it != m_proxy_sessions.end() && it->second.get() == session ) {
+		m_proxy_sessions.erase( it );
+	}
 }
 
 CCBServerRequest *

--- a/src/ccb/ccb_server.cpp
+++ b/src/ccb/ccb_server.cpp
@@ -38,6 +38,15 @@ struct CCBStats {
 	stats_entry_recent<int> CCBRequestsNotFound;
 	stats_entry_recent<int> CCBRequestsSucceeded;
 	stats_entry_recent<int> CCBRequestsFailed;
+	// Streaming/proxy mode: proxy requests received; sessions the broker
+	// successfully spliced; relays that failed *after* the splice was established
+	// (a clean shutdown / EOF is not counted as a failure); how many are relaying
+	// right now; and the total bytes relayed (summed over both directions).
+	stats_entry_recent<int> CCBStreamingRequests;
+	stats_entry_recent<int> CCBStreamingSessions;
+	stats_entry_recent<int> CCBStreamingFailed;
+	stats_entry_abs<int> CCBStreamingActive;
+	stats_entry_recent<int64_t> CCBStreamingBytes;
 
 	void AddStatsToPool(StatisticsPool& pool, int publevel)
 	{
@@ -48,6 +57,11 @@ struct CCBStats {
 		STATS_POOL_ADD(pool, "", CCBRequestsNotFound, publevel);
 		STATS_POOL_ADD(pool, "", CCBRequestsSucceeded, publevel);
 		STATS_POOL_ADD(pool, "", CCBRequestsFailed, publevel);
+		STATS_POOL_ADD(pool, "", CCBStreamingRequests, publevel);
+		STATS_POOL_ADD(pool, "", CCBStreamingSessions, publevel);
+		STATS_POOL_ADD(pool, "", CCBStreamingFailed, publevel);
+		STATS_POOL_ADD(pool, "", CCBStreamingActive, publevel);
+		STATS_POOL_ADD(pool, "", CCBStreamingBytes, publevel);
 	}
 };
 
@@ -934,9 +948,7 @@ CCBServer::RequestFinished( CCBServerRequest *request, bool success, char const 
 // When the requester is itself behind a CCB it cannot accept a direct reverse
 // connection.  Instead the broker keeps the requester's CCB_REQUEST socket,
 // tells the target to reverse-connect to the broker, and then splices the two
-// sockets together as a transparent TCP relay.  The end-to-end CEDAR handshake
-// between the two real peers rides opaquely over the relay, so security is
-// preserved end-to-end and the broker never needs to decrypt the data.
+// sockets together as a transparent TCP relay.
 // ---------------------------------------------------------------------------
 
 class CCBProxySession {
@@ -1003,6 +1015,8 @@ CCBServer::RequestNeedsProxy( ClassAd &msg, char const *return_addr )
 void
 CCBServer::StartProxyRequest( ReliSock *requester, CCBTarget *target, char const *connect_id, char const *name )
 {
+	ccb_stats.CCBStreamingRequests += 1;
+
 		// Enforce the configured limits before committing any resources: an
 		// overall cap on concurrent proxy sessions, and a tighter cap on sessions
 		// still in the handshake (the more easily abused, never-completing kind).
@@ -1044,6 +1058,7 @@ CCBServer::StartProxyRequest( ReliSock *requester, CCBTarget *target, char const
 		// id is a fresh random token, so this should not normally happen).
 	if( m_proxy_sessions.find(session->connect_id) != m_proxy_sessions.end() ) {
 		RequestReply( requester, false, "duplicate connect id", 0, target->getCCBID() );
+		ccb_stats.CCBRequestsFailed += 1;
 		delete session;
 		delete requester;
 		return;
@@ -1069,6 +1084,7 @@ CCBServer::StartProxyRequest( ReliSock *requester, CCBTarget *target, char const
 				"CCB: failed to forward proxy request to target ccbid %lu\n",
 				target->getCCBID());
 		RequestReply( requester, false, "failed to forward proxy request to target", 0, target->getCCBID() );
+		ccb_stats.CCBRequestsFailed += 1;
 		DestroyProxySession( session );
 		return;
 	}
@@ -1120,6 +1136,7 @@ CCBServer::HandleReverseConnect( int cmd, Stream *stream )
 	if( !putClassAd( session->requester, reply ) || !session->requester->end_of_message() ) {
 		dprintf(D_ALWAYS,"CCB: failed to send proxy reply to requester %s\n",
 				session->requester->peer_description());
+		ccb_stats.CCBRequestsFailed += 1;
 		DestroyProxySession( session );
 		return KEEP_STREAM; // we took ownership of sock via session->target
 	}
@@ -1133,6 +1150,7 @@ CCBServer::HandleReverseConnect( int cmd, Stream *stream )
 		!session->requester->end_of_message() )
 	{
 		dprintf(D_ALWAYS,"CCB: failed to replay reverse-connect hello to requester\n");
+		ccb_stats.CCBRequestsFailed += 1;
 		DestroyProxySession( session );
 		return KEEP_STREAM;
 	}
@@ -1148,6 +1166,7 @@ CCBServer::HandleReverseConnect( int cmd, Stream *stream )
 		!ccbSetNonBlocking(session->target->get_file_desc()) )
 	{
 		dprintf(D_ALWAYS,"CCB: failed to set proxy sockets non-blocking\n");
+		ccb_stats.CCBRequestsFailed += 1;
 		DestroyProxySession( session );
 		return KEEP_STREAM;
 	}
@@ -1175,6 +1194,12 @@ CCBServer::HandleReverseConnect( int cmd, Stream *stream )
 		relay_handler,
 		"CCBServer::ProxyRelayData" );
 	ASSERT( rc >= 0 );
+
+		// The broker's job -- connecting the two peers -- is done; the splice is
+		// live.  Count it as a succeeded request and as an active relay.
+	ccb_stats.CCBStreamingSessions += 1;
+	ccb_stats.CCBStreamingActive += 1;
+	ccb_stats.CCBRequestsSucceeded += 1;
 
 	dprintf(D_FULLDEBUG|D_NETWORK,
 			"CCB: established streaming (proxy) relay for request id %s\n",
@@ -1292,6 +1317,7 @@ static bool ccbPumpDirection( CCBProxySession::Dir &d, ReliSock *src, ReliSock *
 		int cap = (int)d.buf.size();
 		ssize_t n = recv( srcfd, d.buf.data(), cap, 0 );
 		if( n > 0 ) {
+			ccb_stats.CCBStreamingBytes += (int64_t)n;
 			d.len = (int)n;
 			d.off = 0;
 			if( !ccbFlush( d, dstfd ) ) {
@@ -1345,6 +1371,10 @@ CCBServer::ProxyRelayData( CCBProxySession *s )
 	if( !ccbPumpDirection( s->a_to_b, s->requester, s->target, "req->tgt" ) ||
 		!ccbPumpDirection( s->b_to_a, s->target, s->requester, "tgt->req" ) )
 	{
+		// A hard send/recv error after the splice was established (a clean
+		// shutdown / EOF does not get here -- it sets src_eof and is handled
+		// below as an orderly close).
+		ccb_stats.CCBStreamingFailed += 1;
 		dprintf(D_NETWORK,"CCB RELAY: tearing down session (request id %s) on pump error\n",
 				s->request_id.c_str());
 		DestroyProxySession( s );
@@ -1420,6 +1450,9 @@ CCBServer::DestroyProxySession( CCBProxySession *session )
 	}
 		// Idempotent: a no-op if the session already started relaying.
 	m_pending_handshakes.erase( session->connect_id );
+	if( session->relaying ) {
+		ccb_stats.CCBStreamingActive -= 1;
+	}
 	if( session->requester ) {
 		if( session->relaying ) {
 			daemonCore->Cancel_Socket( session->requester );

--- a/src/ccb/ccb_server.cpp
+++ b/src/ccb/ccb_server.cpp
@@ -168,6 +168,20 @@ CCBServer::RegisterHandlers()
 		READ);
 	ASSERT( rc >= 0 );
 
+	if( param_boolean("CCB_SERVER_STREAMING",true) ) {
+			// In streaming/proxy mode, targets reverse-connect to *us* and we
+			// splice them to the requester.  This inbound connection is the
+			// raw CCB_REVERSE_CONNECT command (no security handshake), so it is
+			// registered with ALLOW, exactly as CCBClient does on its end.
+		rc = daemonCore->Register_CommandWithPayload(
+			CCB_REVERSE_CONNECT,
+			"CCB_REVERSE_CONNECT",
+			(CommandHandlercpp)&CCBServer::HandleReverseConnect,
+			"CCBServer::HandleReverseConnect",
+			this,
+			ALLOW);
+		ASSERT( rc >= 0 );
+	}
 }
 
 void
@@ -443,6 +457,7 @@ CCBServer::PollSockets(int /* timerID */)
 
 	// periodically call the following
 	SweepReconnectInfo();
+	SweepProxySessions();
 }
 
 int
@@ -610,6 +625,42 @@ CCBServer::HandleRequest(int cmd,Stream *stream)
 		return FALSE;
 	}
 
+		// Streaming/proxy mode: if the requester is itself behind a CCB (its
+		// return address is CCB-routed, or it explicitly asked for streaming),
+		// it cannot accept a direct reverse connection.  Instead we keep its
+		// socket, have the target reverse-connect to us, and splice the two.
+		//
+		// Do NOT shrink this socket's OS buffers (below): unlike a normal CCB
+		// request -- a one-shot exchange of small ClassAds -- a streaming
+		// request socket becomes a data relay carrying a peer's entire
+		// connection, so it should keep the (autotuned / inherited) socket
+		// buffers rather than the tiny control-plane size.
+	if( RequestNeedsProxy( msg, return_addr.c_str() ) ) {
+		StartProxyRequest( sock, target, connect_id.c_str(), sock->peer_description() );
+		return KEEP_STREAM;
+	}
+
+		// The requester insisted on streaming (it cannot accept a direct reverse
+		// connection) but we are not going to proxy -- streaming is disabled here
+		// (CCB_SERVER_STREAMING is false).  Reject cleanly with an explanatory
+		// message rather than forwarding a request the target cannot satisfy,
+		// which would otherwise fail slowly and confusingly.
+	bool streaming_required = false;
+	if( msg.LookupBool("CCBStreamingRequired", streaming_required) && streaming_required ) {
+		dprintf(D_ALWAYS,
+				"CCB: rejecting request from %s for ccbid %s: it requires CCB "
+				"streaming mode, which is disabled on this broker "
+				"(CCB_SERVER_STREAMING is false).\n",
+				sock->peer_description(), target_ccbid_str.c_str());
+		RequestReply( sock, false,
+					  "CCB streaming mode is required to reach this daemon but is "
+					  "disabled on the CCB server (CCB_SERVER_STREAMING is false)",
+					  0, target_ccbid );
+		return FALSE;
+	}
+
+		// Normal CCB request: only small ClassAds flow on this socket, and the
+		// broker may hold many of them, so shrink its buffers.
 	SetSmallBuffers(sock);
 
 	CCBServerRequest *request =
@@ -875,6 +926,515 @@ CCBServer::RequestFinished( CCBServerRequest *request, bool success, char const 
 	} else {
 		ccb_stats.CCBRequestsFailed += 1;
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Streaming/proxy mode (CCB_STREAMING)
+//
+// When the requester is itself behind a CCB it cannot accept a direct reverse
+// connection.  Instead the broker keeps the requester's CCB_REQUEST socket,
+// tells the target to reverse-connect to the broker, and then splices the two
+// sockets together as a transparent TCP relay.  The end-to-end CEDAR handshake
+// between the two real peers rides opaquely over the relay, so security is
+// preserved end-to-end and the broker never needs to decrypt the data.
+// ---------------------------------------------------------------------------
+
+class CCBProxySession {
+public:
+	// One direction of the relay.  The userspace buffer starts small and grows
+	// on demand up to RELAY_BUF_MAX, so a broker carrying many mostly-idle proxy
+	// sessions does not pay the full per-direction footprint for each.  It only
+	// holds bytes read from the source that the destination could not yet accept;
+	// the in-flight headroom that decouples a fast sender from a slow receiver
+	// lives in the kernel socket buffers.  We stop reading the source while this
+	// buffer is non-empty; the source's data then backs up in the kernel TCP
+	// buffer, which provides backpressure for the TCP sender.
+	static const int RELAY_BUF_START = 4 * 1024;          // initial shuttle size
+	static const int RELAY_BUF_MAX   = 32 * 1024;         // cap it grows to
+	struct Dir {
+		std::vector<char> buf;  // grows from RELAY_BUF_START up to RELAY_BUF_MAX
+		int  len;           // bytes currently buffered
+		int  off;           // bytes already written to the destination
+		bool src_eof;       // source closed its sending side
+		bool dst_shutdown;  // we have shut down the destination's write side
+		Dir() : len(0), off(0), src_eof(false), dst_shutdown(false) {}
+		bool hasData() const { return off < len; }
+		void clear() { len = 0; off = 0; }
+	};
+
+	std::string connect_id;
+	std::string request_id;
+	ReliSock *requester;  // endpoint "A"
+	ReliSock *target;     // endpoint "B"
+	bool relaying;
+	// When the session was created (request forwarded to the target).  The
+	// periodic maintenance sweep reaps a session that is still not relaying after
+	// the handshake timeout, so a target that never connects back cannot pin the
+	// requester's socket forever.
+	time_t created;
+	Dir a_to_b;   // bytes read from the requester, to be written to the target
+	Dir b_to_a;   // bytes read from the target, to be written to the requester
+
+	CCBProxySession() : requester(nullptr), target(nullptr), relaying(false), created(0) {}
+};
+
+// Relay helpers (defined below; forward-declared for use in HandleReverseConnect).
+static bool ccbSetNonBlocking( int fd );
+
+bool
+CCBServer::RequestNeedsProxy( ClassAd &msg, char const *return_addr )
+{
+	if( !param_boolean("CCB_SERVER_STREAMING",true) ) {
+		return false;
+	}
+	bool required = false;
+	if( msg.LookupBool("CCBStreamingRequired",required) && required ) {
+		return true;
+	}
+	if( return_addr ) {
+		Sinful s(return_addr);
+		if( s.getCCBContact() ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+void
+CCBServer::StartProxyRequest( ReliSock *requester, CCBTarget *target, char const *connect_id, char const *name )
+{
+		// Enforce the configured limits before committing any resources: an
+		// overall cap on concurrent proxy sessions, and a tighter cap on sessions
+		// still in the handshake (the more easily abused, never-completing kind).
+		// 0 means unlimited.  Reject over-limit requests with a clear failure.
+	int max_sessions = param_integer("CCB_SERVER_MAX_STREAMING_SESSIONS", 0, 0);
+	if( max_sessions > 0 && (int)m_proxy_sessions.size() >= max_sessions ) {
+		dprintf(D_ALWAYS,
+				"CCB: refusing streaming request from %s: at the streaming "
+				"session limit (CCB_SERVER_MAX_STREAMING_SESSIONS=%d).\n",
+				requester->peer_description(), max_sessions);
+		RequestReply( requester, false,
+				"CCB streaming session limit reached on the broker", 0,
+				target->getCCBID() );
+		ccb_stats.CCBRequestsFailed += 1;
+		delete requester;
+		return;
+	}
+	int max_handshakes = param_integer("CCB_SERVER_MAX_STREAMING_HANDSHAKES", 0, 0);
+	if( max_handshakes > 0 && (int)m_pending_handshakes.size() >= max_handshakes ) {
+		dprintf(D_ALWAYS,
+				"CCB: refusing streaming request from %s: at the streaming "
+				"handshake limit (CCB_SERVER_MAX_STREAMING_HANDSHAKES=%d).\n",
+				requester->peer_description(), max_handshakes);
+		RequestReply( requester, false,
+				"CCB streaming handshake limit reached on the broker", 0,
+				target->getCCBID() );
+		ccb_stats.CCBRequestsFailed += 1;
+		delete requester;
+		return;
+	}
+
+	CCBProxySession *session = new CCBProxySession();
+	session->connect_id = connect_id;
+	session->requester = requester;
+	session->created = time(nullptr);  // handshake deadline is relative to this
+	CCBIDToString( m_next_request_id++, session->request_id );
+
+		// If a session with this connect id already exists, reject (the connect
+		// id is a fresh random token, so this should not normally happen).
+	if( m_proxy_sessions.find(session->connect_id) != m_proxy_sessions.end() ) {
+		RequestReply( requester, false, "duplicate connect id", 0, target->getCCBID() );
+		delete session;
+		delete requester;
+		return;
+	}
+	m_proxy_sessions[session->connect_id] = session;
+	m_pending_handshakes.insert( session->connect_id );  // pending until relaying
+
+		// Ask the target to reverse-connect to *this broker*.
+	ClassAd msg;
+	msg.Assign( ATTR_COMMAND, CCB_REQUEST );
+	std::string myaddr = "<" + m_address + ">";
+	msg.Assign( ATTR_MY_ADDRESS, myaddr );
+	msg.Assign( ATTR_CLAIM_ID, connect_id );
+	msg.Assign( ATTR_REQUEST_ID, session->request_id );
+	if( name ) {
+		msg.Assign( ATTR_NAME, name );
+	}
+
+	Sock *tsock = target->getSock();
+	tsock->encode();
+	if( !putClassAd( tsock, msg ) || !tsock->end_of_message() ) {
+		dprintf(D_ALWAYS,
+				"CCB: failed to forward proxy request to target ccbid %lu\n",
+				target->getCCBID());
+		RequestReply( requester, false, "failed to forward proxy request to target", 0, target->getCCBID() );
+		DestroyProxySession( session );
+		return;
+	}
+
+	dprintf(D_FULLDEBUG,
+			"CCB: started streaming (proxy) session for target ccbid %lu, "
+			"request id %s\n",
+			target->getCCBID(), session->request_id.c_str());
+}
+
+int
+CCBServer::HandleReverseConnect( int cmd, Stream *stream )
+{
+	ReliSock *sock = (ReliSock *)stream;
+	ASSERT( cmd == CCB_REVERSE_CONNECT );
+	sock->timeout(1);
+
+	ClassAd hello;
+	sock->decode();
+	if( !getClassAd( sock, hello ) || !sock->end_of_message() ) {
+		dprintf(D_ALWAYS,
+				"CCB: failed to read reverse-connect hello from %s\n",
+				sock->peer_description());
+		return FALSE;
+	}
+
+	std::string connect_id;
+	hello.LookupString( ATTR_CLAIM_ID, connect_id );
+
+	auto it = m_proxy_sessions.find( connect_id );
+	if( it == m_proxy_sessions.end() ) {
+		dprintf(D_ALWAYS,
+				"CCB: no pending proxy session for reverse connect from %s\n",
+				sock->peer_description());
+		return FALSE;
+	}
+	CCBProxySession *session = it->second;
+	if( session->target ) {
+			// already satisfied; reject the duplicate
+		return FALSE;
+	}
+	session->target = sock;
+
+		// Tell the requester its connection will be proxied on this socket.
+	ClassAd reply;
+	reply.Assign( ATTR_RESULT, true );
+	reply.Assign( "ProxyMode", true );
+	session->requester->encode();
+	if( !putClassAd( session->requester, reply ) || !session->requester->end_of_message() ) {
+		dprintf(D_ALWAYS,"CCB: failed to send proxy reply to requester %s\n",
+				session->requester->peer_description());
+		DestroyProxySession( session );
+		return KEEP_STREAM; // we took ownership of sock via session->target
+	}
+
+		// Replay the target's reverse-connect hello to the requester so its
+		// accept logic (cmd==CCB_REVERSE_CONNECT && ClaimId==connect_id) passes.
+	session->requester->encode();
+	int rcmd = CCB_REVERSE_CONNECT;
+	if( !session->requester->put(rcmd) ||
+		!putClassAd( session->requester, hello ) ||
+		!session->requester->end_of_message() )
+	{
+		dprintf(D_ALWAYS,"CCB: failed to replay reverse-connect hello to requester\n");
+		DestroyProxySession( session );
+		return KEEP_STREAM;
+	}
+
+		// From here on, both sockets carry opaque end-to-end bytes.  Disable
+		// any broker-session crypto on the requester socket so the relay reads
+		// the raw bytes the requester sends after it adopts the connection.
+	session->requester->set_crypto_key( false, NULL );
+	session->target->set_crypto_key( false, NULL );
+
+		// Put both sockets in non-blocking mode for the relay.
+	if( !ccbSetNonBlocking(session->requester->get_file_desc()) ||
+		!ccbSetNonBlocking(session->target->get_file_desc()) )
+	{
+		dprintf(D_ALWAYS,"CCB: failed to set proxy sockets non-blocking\n");
+		DestroyProxySession( session );
+		return KEEP_STREAM;
+	}
+
+		// Begin the non-blocking byte relay.  Both sockets share one handler (a
+		// std::function that carries the session) which attempts non-blocking
+		// I/O in both directions and adjusts each socket's read/write interest
+		// to avoid triggering reads when we cannot write.
+	session->relaying = true;
+	m_pending_handshakes.erase( session->connect_id );  // handshake done -> relaying
+
+	StdSocketHandler relay_handler =
+		[this, session](Stream *) { return ProxyRelayData( session ); };
+
+	int rc = daemonCore->Register_Socket(
+		session->requester,
+		"ccb proxy (requester)",
+		relay_handler,
+		"CCBServer::ProxyRelayData" );
+	ASSERT( rc >= 0 );
+
+	rc = daemonCore->Register_Socket(
+		session->target,
+		"ccb proxy (target)",
+		relay_handler,
+		"CCBServer::ProxyRelayData" );
+	ASSERT( rc >= 0 );
+
+	dprintf(D_FULLDEBUG|D_NETWORK,
+			"CCB: established streaming (proxy) relay for request id %s\n",
+			session->request_id.c_str());
+	return KEEP_STREAM;
+}
+
+#ifndef SHUT_WR
+#define SHUT_WR SD_SEND   // POSIX name for Winsock's "stop sending" shutdown
+#endif
+
+// ccbSetNonBlocking puts a socket fd into non-blocking mode.
+static bool ccbSetNonBlocking( int fd )
+{
+#ifdef WIN32
+	unsigned long mode = 1;
+	return ioctlsocket( (SOCKET)fd, FIONBIO, &mode ) == 0;
+#else
+	int flags = fcntl( fd, F_GETFL, 0 );
+	if( flags < 0 ) {
+		return false;
+	}
+	return fcntl( fd, F_SETFL, flags | O_NONBLOCK ) == 0;
+#endif
+}
+
+// ccbHandlerType maps desired read/write interest to a daemonCore HandlerType.
+static HandlerType ccbHandlerType( bool want_read, bool want_write )
+{
+	if( want_read && want_write ) return HANDLE_READ_WRITE;
+	if( want_read )               return HANDLE_READ;
+	if( want_write )              return HANDLE_WRITE;
+	return HANDLE_NONE;
+}
+
+// The relay does raw non-blocking recv()/send(), so it must classify socket
+// errors portably: on Windows they live in WSAGetLastError() (not errno) and use
+// WSAE* names.  Capture the error immediately after the failing call.
+static int ccbSockErrno()
+{
+#ifdef WIN32
+	return WSAGetLastError();
+#else
+	return errno;
+#endif
+}
+static bool ccbWouldBlock( int e )
+{
+#ifdef WIN32
+	return e == WSAEWOULDBLOCK;
+#else
+	return e == EAGAIN || e == EWOULDBLOCK;
+#endif
+}
+static bool ccbInterrupted( int e )
+{
+#ifdef WIN32
+	return e == WSAEINTR;
+#else
+	return e == EINTR;
+#endif
+}
+
+// ccbFlush writes as much of a direction's buffer to the destination fd as it
+// can without blocking.  Returns false on a hard (non-retryable) error.
+static bool ccbFlush( CCBProxySession::Dir &d, int dstfd )
+{
+	while( d.hasData() ) {
+		ssize_t w = send( dstfd, d.buf.data() + d.off, d.len - d.off, 0 );
+		if( w > 0 ) {
+			d.off += (int)w;
+		}
+		else {
+			int e = ccbSockErrno();
+			if( w < 0 && ccbWouldBlock(e) ) {
+				break; // destination not ready; keep the remainder buffered
+			}
+			else if( w < 0 && ccbInterrupted(e) ) {
+				continue;
+			}
+			else {
+				return false; // hard error (e.g. EPIPE)
+			}
+		}
+	}
+	if( !d.hasData() ) {
+		d.clear();
+	}
+	return true;
+}
+
+// ccbPumpDirection runs one direction of the relay: flush any buffered bytes to
+// the destination, then -- while our small userspace buffer is empty -- read
+// from the source and push it toward the destination, looping so that one
+// wakeup drains everything the kernel currently has rather than a single chunk.
+// We stop reading the source while the buffer holds unflushed bytes: the
+// source's data then backs up in the kernel socket buffer and, beyond that,
+// throttles the real sender via TCP.  The two directions are independent, and
+// the relay only adds buffering to the path, so it cannot deadlock a stream that
+// a direct connection would not.  Once the source has closed and the buffer is
+// drained, the destination's write side is shut down to propagate EOF.  Returns
+// false on a hard error.
+static bool ccbPumpDirection( CCBProxySession::Dir &d, ReliSock *src, ReliSock *dst, const char *label )
+{
+	int srcfd = src->get_file_desc();
+	int dstfd = dst->get_file_desc();
+
+	if( !ccbFlush( d, dstfd ) ) {
+		dprintf(D_NETWORK,"CCB RELAY[%s]: flush hard error (errno=%d)\n",label,ccbSockErrno());
+		return false;
+	}
+
+	while( !d.src_eof && !d.hasData() ) {
+		if( d.buf.empty() ) { d.buf.resize( CCBProxySession::RELAY_BUF_START ); }
+		int cap = (int)d.buf.size();
+		ssize_t n = recv( srcfd, d.buf.data(), cap, 0 );
+		if( n > 0 ) {
+			d.len = (int)n;
+			d.off = 0;
+			if( !ccbFlush( d, dstfd ) ) {
+				dprintf(D_NETWORK,"CCB RELAY[%s]: post-recv flush hard error (errno=%d)\n",label,ccbSockErrno());
+				return false;
+			}
+			// We filled the buffer and drained it, so the source likely has more
+			// queued; grow (up to the cap) so the next read drains more per
+			// syscall.  Idle/light sessions never fill it and stay small.
+			if( n == cap && !d.hasData() && cap < CCBProxySession::RELAY_BUF_MAX ) {
+				int next = cap * 2;
+				d.buf.resize( next < CCBProxySession::RELAY_BUF_MAX ? next : CCBProxySession::RELAY_BUF_MAX );
+			}
+		}
+		else if( n == 0 ) {
+			d.src_eof = true;
+			break;
+		}
+		else {
+			int e = ccbSockErrno();
+			if( ccbWouldBlock(e) ) {
+				break; // source drained for now
+			}
+			else if( ccbInterrupted(e) ) {
+				continue;
+			}
+			else {
+				return false; // hard error
+			}
+		}
+	}
+
+	if( d.src_eof && !d.hasData() && !d.dst_shutdown ) {
+		shutdown( dstfd, SHUT_WR );
+		d.dst_shutdown = true;
+		dprintf(D_NETWORK,"CCB RELAY[%s]: source EOF, shut down dst fd=%d write side\n",label,dstfd);
+	}
+	return true;
+}
+
+int
+CCBServer::ProxyRelayData( CCBProxySession *s )
+{
+	if( !s ) {
+		return KEEP_STREAM;
+	}
+
+	// Non-blocking I/O makes it safe to attempt both directions on every
+	// callback regardless of which socket woke us; an unready socket simply
+	// returns EAGAIN.
+	if( !ccbPumpDirection( s->a_to_b, s->requester, s->target, "req->tgt" ) ||
+		!ccbPumpDirection( s->b_to_a, s->target, s->requester, "tgt->req" ) )
+	{
+		dprintf(D_NETWORK,"CCB RELAY: tearing down session (request id %s) on pump error\n",
+				s->request_id.c_str());
+		DestroyProxySession( s );
+		return KEEP_STREAM;
+	}
+
+	// Both directions fully closed: tear down.
+	if( s->a_to_b.dst_shutdown && s->b_to_a.dst_shutdown ) {
+		DestroyProxySession( s );
+		return KEEP_STREAM;
+	}
+
+	// Re-evaluate each socket's read/write interest.  A socket is the source of
+	// one direction and the destination of the other:
+	//   - read it while its outbound buffer is empty (once it holds unflushed
+	//     bytes we stop reading and let the source back up in the kernel)
+	//   - write it while the other direction has buffered bytes for it
+	HandlerType ht_req = ccbHandlerType(
+		!s->a_to_b.hasData() && !s->a_to_b.src_eof,
+		s->b_to_a.hasData() );
+	HandlerType ht_tgt = ccbHandlerType(
+		!s->b_to_a.hasData() && !s->b_to_a.src_eof,
+		s->a_to_b.hasData() );
+	daemonCore->Set_Socket_Handler_Type( s->requester, ht_req );
+	daemonCore->Set_Socket_Handler_Type( s->target, ht_tgt );
+
+	return KEEP_STREAM;
+}
+
+void
+CCBServer::SweepProxySessions()
+{
+		// Reap streaming (proxy) sessions whose handshake never completed: the
+		// target was asked to connect back to be spliced but never did, so the
+		// requester's socket would otherwise be pinned indefinitely.
+	int handshake_timeout =
+		param_integer("CCB_SERVER_STREAMING_HANDSHAKE_TIMEOUT", 300, 0);
+	if( handshake_timeout <= 0 ) {
+		return;
+	}
+	time_t now = time(nullptr);
+	auto it = m_proxy_sessions.begin();
+	while( it != m_proxy_sessions.end() ) {
+			// DestroyProxySession erases the current element, so advance first.
+		auto next_it = it;
+		++next_it;
+		CCBProxySession *session = it->second;
+		if( !session->relaying && now - session->created >= handshake_timeout ) {
+			dprintf(D_ALWAYS,
+					"CCB: streaming (proxy) handshake for request id %s timed out "
+					"after %d seconds; the target never connected back to be "
+					"relayed.\n",
+					session->request_id.c_str(), handshake_timeout);
+			RequestReply( session->requester, false,
+					"CCB streaming handshake timed out: the target did not "
+					"connect back to the broker", 0, 0 );
+			ccb_stats.CCBRequestsFailed += 1;
+			DestroyProxySession( session );
+		}
+		it = next_it;
+	}
+}
+
+void
+CCBServer::DestroyProxySession( CCBProxySession *session )
+{
+	if( !session ) {
+		return;
+	}
+	auto it = m_proxy_sessions.find( session->connect_id );
+	if( it != m_proxy_sessions.end() && it->second == session ) {
+		m_proxy_sessions.erase( it );
+	}
+		// Idempotent: a no-op if the session already started relaying.
+	m_pending_handshakes.erase( session->connect_id );
+	if( session->requester ) {
+		if( session->relaying ) {
+			daemonCore->Cancel_Socket( session->requester );
+		}
+		delete session->requester;
+		session->requester = nullptr;
+	}
+	if( session->target ) {
+		if( session->relaying ) {
+			daemonCore->Cancel_Socket( session->target );
+		}
+		delete session->target;
+		session->target = nullptr;
+	}
+	delete session;
 }
 
 CCBServerRequest *

--- a/src/ccb/ccb_server.h
+++ b/src/ccb/ccb_server.h
@@ -79,8 +79,11 @@ class CCBServer: Service {
 		// to them if things go wrong
 	std::map<CCBID,CCBServerRequest *> m_requests;// request_id --> req
 
-		// streaming/proxy sessions (private-to-private), keyed by connect id
-	std::map<std::string,CCBProxySession *> m_proxy_sessions;
+		// streaming/proxy sessions (private-to-private), keyed by connect id.
+		// Held by shared_ptr: once relaying, each of the two relay sockets' handlers
+		// also captures a shared_ptr, so the session lives until both the map entry
+		// is detached (BeginRelayTeardown) and both relay sockets are gone.
+	std::map<std::string,std::shared_ptr<CCBProxySession>> m_proxy_sessions;
 		// connect ids of the sessions in m_proxy_sessions that are still in the
 		// handshake (not yet relaying), so CCB_SERVER_MAX_STREAMING_HANDSHAKES can
 		// be enforced in O(1) on the connection path.  A session is erased here
@@ -119,8 +122,15 @@ class CCBServer: Service {
 	int HandleReverseConnect( int cmd, Stream *stream );
 		// daemonCore socket handler that relays bytes for an active proxy.
 	int ProxyRelayData( CCBProxySession *session );
-		// Tear down and free a proxy session, closing both sockets.
+		// Tear down a proxy session that is not yet relaying (handshake phase):
+		// no relay sockets are registered, so this frees it synchronously.
 	void DestroyProxySession( CCBProxySession *session );
+		// Begin tearing down a *relaying* session: detach it from m_proxy_sessions
+		// (dropping that shared_ptr) and shut down both relay sockets so each wakes,
+		// returns non-KEEP_STREAM, and is cancelled+deleted by DaemonCore.  The
+		// session is freed once the last relay handler (holding a shared_ptr) is
+		// destroyed.  Idempotent.
+	void BeginRelayTeardown( CCBProxySession *session );
 		// Periodic maintenance: reap proxy sessions whose handshake never
 		// completed (called from PollSockets, the existing CCB poll timer).
 	void SweepProxySessions();

--- a/src/ccb/ccb_server.h
+++ b/src/ccb/ccb_server.h
@@ -30,16 +30,21 @@
 
 #include "dc_service.h"
 #include <map>
+#include <string>
+#include <unordered_set>
 
 class StatisticsPool;
 void AddCCBStatsToPool(StatisticsPool& pool, int publevel);
 
 class Sock;
+class ReliSock;
 class Stream;
+namespace classad { class ClassAd; }
 
 class CCBTarget;
 class CCBServerRequest;
 class CCBReconnectInfo;
+class CCBProxySession;
 
 typedef unsigned long CCBID;
 
@@ -74,6 +79,16 @@ class CCBServer: Service {
 		// to them if things go wrong
 	std::map<CCBID,CCBServerRequest *> m_requests;// request_id --> req
 
+		// streaming/proxy sessions (private-to-private), keyed by connect id
+	std::map<std::string,CCBProxySession *> m_proxy_sessions;
+		// connect ids of the sessions in m_proxy_sessions that are still in the
+		// handshake (not yet relaying), so CCB_SERVER_MAX_STREAMING_HANDSHAKES can
+		// be enforced in O(1) on the connection path.  A session is erased here
+		// when it starts relaying and (idempotently) when it is destroyed; because
+		// erase-of-absent is a no-op, a missed transition self-heals at teardown
+		// rather than wedging the count forever the way a bare counter would.
+	std::unordered_set<std::string> m_pending_handshakes;
+
 	int m_polling_timer;
 		// The epoll file descriptor.  Only used on platforms where
 		// epoll is available.
@@ -92,6 +107,23 @@ class CCBServer: Service {
 
 	void ForwardRequestToTarget( CCBServerRequest *request, CCBTarget *target );
 	void RequestReply( Sock *sock, bool success, char const *error_msg, CCBID request_cid, CCBID target_cid );
+
+		// --- streaming/proxy mode (CCB_STREAMING) ---
+		// True if the requester is itself behind a CCB (its return address is
+		// CCB-routed), so it cannot accept a direct reverse connection.
+	bool RequestNeedsProxy( classad::ClassAd &msg, char const *return_addr );
+		// Begin a proxy session: register a rendezvous keyed by connect_id and
+		// ask the target to reverse-connect to this broker.
+	void StartProxyRequest( ReliSock *requester, CCBTarget *target, char const *connect_id, char const *name );
+		// Raw command handler for the target's inbound reverse connection.
+	int HandleReverseConnect( int cmd, Stream *stream );
+		// daemonCore socket handler that relays bytes for an active proxy.
+	int ProxyRelayData( CCBProxySession *session );
+		// Tear down and free a proxy session, closing both sockets.
+	void DestroyProxySession( CCBProxySession *session );
+		// Periodic maintenance: reap proxy sessions whose handshake never
+		// completed (called from PollSockets, the existing CCB poll timer).
+	void SweepProxySessions();
 
 	void RequestFinished( CCBServerRequest *request, bool success, char const *error_msg );
 

--- a/src/condor_daemon_core.V6/condor_daemon_core.h
+++ b/src/condor_daemon_core.V6/condor_daemon_core.h
@@ -167,7 +167,8 @@ typedef int	(*DataThreadWorkerFunc)(int data_n1, int data_n2, void * data_vp);
 typedef int	(*DataThreadReaperFunc)(int data_n1, int data_n2, void * data_vp, int exit_status);
 //@}
 
-typedef enum { 
+typedef enum {
+	HANDLE_NONE=0,	// registered but not polled for read or write
 	HANDLE_READ=1,
 	HANDLE_WRITE,
 	HANDLE_READ_WRITE
@@ -1057,6 +1058,18 @@ class DaemonCore : public Service
         @return Not_Yet_Documented
     */
     int Lookup_Socket ( Stream * iosock );
+
+    /** Change the I/O interest of an already-registered socket without
+        re-registering it. This lets a byte relay (e.g. CCB streaming) implement
+        backpressure: pause reads on the source while the destination is
+        congested (HANDLE_WRITE or HANDLE_NONE), and watch the destination for
+        writability while bytes are buffered. The socket keeps its existing
+        handler and registration.
+        @param iosock        the registered socket to adjust
+        @param handler_type  the new interest (HANDLE_NONE/READ/WRITE/READ_WRITE)
+        @return true if the socket was found and updated, false otherwise
+    */
+    bool Set_Socket_Handler_Type( Stream *iosock, HandlerType handler_type );
 	//@}
 
 	/** @name Pipe events.

--- a/src/condor_daemon_core.V6/daemon_core.cpp
+++ b/src/condor_daemon_core.V6/daemon_core.cpp
@@ -1829,9 +1829,16 @@ int DaemonCore::Register_Socket(Stream *iosock, const char* iosock_descrip,
 	}
 	sockTable[i].handler = handler;
 	sockTable[i].handlercpp = handlercpp;
-	if (handler_f) {
-		sockTable[i].std_handler = *handler_f;
-	}
+		// Always (re)assign std_handler -- including clearing it when this
+		// registration does not supply one.  Cancel_Socket does not clear a slot's
+		// std_handler, so a slot freed by a std::function-handler socket keeps that
+		// std::function until the slot is reused.  If the slot is then reused by a
+		// registration with only a C/C++ handler (or none, e.g. a command socket via
+		// Register_Command_Socket), the stale std_handler would otherwise linger and,
+		// because CallSocketHandler_worker dispatches std_handler when handler and
+		// handlercpp are both null, be invoked on the wrong socket -- a use-after-free
+		// of whatever the stale std::function captured.
+	sockTable[i].std_handler = handler_f ? *handler_f : StdSocketHandler();
 	sockTable[i].is_cpp = (bool)is_cpp;
 	sockTable[i].handler_type = handler_type;
 	sockTable[i].service = s;

--- a/src/condor_daemon_core.V6/daemon_core.cpp
+++ b/src/condor_daemon_core.V6/daemon_core.cpp
@@ -2710,6 +2710,19 @@ int DaemonCore::Lookup_Socket( Stream *insock )
 	return -1;
 }
 
+bool DaemonCore::Set_Socket_Handler_Type( Stream *iosock, HandlerType handler_type )
+{
+	int i = Lookup_Socket( iosock );
+	if ( i < 0 ) {
+		return false;
+	}
+	sockTable[i].handler_type = handler_type;
+	// Wake up the main select loop so the new interest takes effect promptly
+	// rather than waiting for the current timeout to expire.
+	Wake_up_select();
+	return true;
+}
+
 int DaemonCore::Cancel_Reaper( int rid )
 {
 	if ( daemonCore == NULL ) {
@@ -3603,6 +3616,10 @@ void DaemonCore::Driver()
 				} else {
 					int sockfd = sockEnt.iosock->get_file_desc();
 					switch( sockEnt.handler_type ) {
+					case HANDLE_NONE:
+						// registered but not currently polled (e.g. a relay
+						// pausing reads to apply backpressure)
+						break;
 					case HANDLE_READ:
 						selector.add_fd( sockfd, Selector::IO_READ );
 						break;
@@ -3642,6 +3659,8 @@ void DaemonCore::Driver()
 			if ( pipeTable[i].index != -1 ) {	// if a valid entry....
 				int pipefd = pipeHandleTable[pipeTable[i].index];
 				switch( pipeTable[i].handler_type ) {
+				case HANDLE_NONE:
+					break;
 				case HANDLE_READ:
 					selector.add_fd( pipefd, Selector::IO_READ );
 					break;
@@ -3857,17 +3876,25 @@ void DaemonCore::Driver()
 								sockEnt.call_handler = true;
 							}
 						}
-					} else if (sockEnt.handler_type == HANDLE_READ || sockEnt.handler_type == HANDLE_READ_WRITE) {
-						if ( (selector.fd_ready( sockEnt.iosock->get_file_desc(), Selector::IO_READ ) ) ||
-							 sock_timed_out )
-						{
-							sockEnt.call_handler = true;
+					} else {
+						// NOTE: read and write interest are checked with
+						// independent ifs (not else-if) so that a
+						// HANDLE_READ_WRITE socket fires its handler on EITHER
+						// read or write readiness.  (As an else-if chain the
+						// write check would be unreachable for READ_WRITE.)
+						if (sockEnt.handler_type == HANDLE_READ || sockEnt.handler_type == HANDLE_READ_WRITE) {
+							if ( (selector.fd_ready( sockEnt.iosock->get_file_desc(), Selector::IO_READ ) ) ||
+								 sock_timed_out )
+							{
+								sockEnt.call_handler = true;
+							}
 						}
-					} else if (sockEnt.handler_type == HANDLE_WRITE || sockEnt.handler_type == HANDLE_READ_WRITE) {
-						if ( (selector.fd_ready(sockEnt.iosock->get_file_desc(), Selector::IO_WRITE ) ) ||
-							 sock_timed_out )
-						{
-							sockEnt.call_handler = true;
+						if (sockEnt.handler_type == HANDLE_WRITE || sockEnt.handler_type == HANDLE_READ_WRITE) {
+							if ( (selector.fd_ready(sockEnt.iosock->get_file_desc(), Selector::IO_WRITE ) ) ||
+								 sock_timed_out )
+							{
+								sockEnt.call_handler = true;
+							}
 						}
 					}
 				}	// end of if valid sock entry

--- a/src/condor_tests/CMakeLists.txt
+++ b/src/condor_tests/CMakeLists.txt
@@ -266,6 +266,9 @@ if (BUILD_TESTING)
 		# ClassAds test suite
 		condor_pl_test (test_classad_version_comparison "Test ClassAd version comparison functions" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 
+		# CCB streaming/proxy (private-to-private) connections
+		condor_pl_test (test_ccb_streaming "Test CCB streaming/proxy mode for private-to-private connections" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
+
 		if (LINUX OR APPLE)
 			condor_pl_test(test_admin_capability "Use admin capability from collector" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 			# Fail.  We can't build this on Windows because of bad target names.

--- a/src/condor_tests/CMakeLists.txt
+++ b/src/condor_tests/CMakeLists.txt
@@ -276,6 +276,10 @@ if (BUILD_TESTING)
 		# CCB streaming/proxy (private-to-private) connections
 		condor_pl_test (test_ccb_streaming "Test CCB streaming/proxy mode for private-to-private connections" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 
+		# CCB streaming/proxy coverage of additional network paths (shared port,
+		# chirp, reconnect, ssh_to_job)
+		condor_pl_test (test_ccb_streaming_paths "Test CCB streaming/proxy mode across additional network paths" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
+
 		# CCB streaming/proxy relay throughput benchmark
 		condor_pl_test (test_ccb_proxy_bench "Benchmark CCB streaming/proxy relay throughput" "ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 

--- a/src/condor_tests/CMakeLists.txt
+++ b/src/condor_tests/CMakeLists.txt
@@ -99,6 +99,13 @@ if (BUILD_TESTING)
         OFF
     )
 
+    condor_exe( ccb_proxy_bench
+        "ccb_proxy_bench.cpp"
+        "${C_LIBEXEC}"
+        "${CONDOR_LIBS}"
+        OFF
+    )
+
     condor_exe( test_awaitable_deadline_socketd
         "test_awaitable_deadline_socketd.cpp"
         "${C_LIBEXEC}"
@@ -268,6 +275,9 @@ if (BUILD_TESTING)
 
 		# CCB streaming/proxy (private-to-private) connections
 		condor_pl_test (test_ccb_streaming "Test CCB streaming/proxy mode for private-to-private connections" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
+
+		# CCB streaming/proxy relay throughput benchmark
+		condor_pl_test (test_ccb_proxy_bench "Benchmark CCB streaming/proxy relay throughput" "ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 
 		if (LINUX OR APPLE)
 			condor_pl_test(test_admin_capability "Use admin capability from collector" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")

--- a/src/condor_tests/ccb_proxy_bench.cpp
+++ b/src/condor_tests/ccb_proxy_bench.cpp
@@ -1,0 +1,443 @@
+/***************************************************************************
+ *
+ * Benchmark for CCB streaming (proxy) mode.
+ *
+ * Establishes a single streamed connection through a running CCB broker
+ * (a condor_collector with CCB enabled), exactly as a private-to-private
+ * pair would: a "target" registers with the broker, a "requester" sends a
+ * CCB_REQUEST with CCBStreamingRequired set, the target reverse-connects to
+ * the broker, and the broker splices the two sockets.  Once the splice is up,
+ * both ends send raw bytes in both directions for a fixed interval and the
+ * program prints the average transfer rate each way -- i.e. the throughput of
+ * the broker's relay itself.
+ *
+ * Usage: ccb_proxy_bench <broker-sinful> [seconds]
+ *
+ ***************************************************************************/
+
+#include "condor_common.h"
+#include "condor_config.h"
+#include "condor_debug.h"
+#include "condor_attributes.h"
+#include "condor_commands.h"
+#include "condor_crypt.h"
+#include "daemon.h"
+#include "reli_sock.h"
+#include "classad_oldnew.h"
+#include "condor_classad.h"
+
+#ifdef WIN32
+
+// This benchmark drives the relay with fork()/poll(), which have no Windows
+// equivalent here; build a stub so the test exe still links.
+int main( int, char ** )
+{
+	fprintf(stderr, "ccb_proxy_bench is not supported on this platform.\n");
+	return 1;
+}
+
+#else
+
+#include <poll.h>
+#include <sys/wait.h>
+#include <chrono>
+#include <memory>
+#include <vector>
+
+static const int BLAST_BUF = 256 * 1024;
+
+// Run a bidirectional blast on fd for `seconds`: keep the outbound direction
+// full and drain the inbound direction, returning the inbound throughput in
+// bytes/sec (i.e. the rate at which the peer's data arrives).
+static double blast( int fd, int seconds )
+{
+	int flags = fcntl(fd, F_GETFL, 0);
+	if( flags >= 0 ) { fcntl(fd, F_SETFL, flags | O_NONBLOCK); }
+
+	std::vector<char> out(BLAST_BUF, 'x');
+	std::vector<char> in(BLAST_BUF);
+	uint64_t received = 0;
+
+	auto start = std::chrono::steady_clock::now();
+	auto deadline = start + std::chrono::seconds(seconds);
+
+	while( std::chrono::steady_clock::now() < deadline ) {
+		struct pollfd pfd;
+		pfd.fd = fd;
+		pfd.events = POLLIN | POLLOUT;
+		pfd.revents = 0;
+		int rc = poll(&pfd, 1, 100);
+		if( rc < 0 ) { if( errno == EINTR ) { continue; } break; }
+		if( pfd.revents & (POLLERR|POLLNVAL) ) { break; }
+		if( pfd.revents & POLLOUT ) {
+			ssize_t n = send(fd, out.data(), out.size(), 0);
+			if( n < 0 && errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR ) { break; }
+		}
+		if( pfd.revents & POLLIN ) {
+			ssize_t n = recv(fd, in.data(), in.size(), 0);
+			if( n > 0 ) { received += (uint64_t)n; }
+			else if( n == 0 ) { break; }
+			else if( errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR ) { break; }
+		}
+	}
+	double secs = std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+	return secs > 0 ? (double)received / secs : 0.0;
+}
+
+// targetRole: register with the broker, wait for the forwarded request, reverse-
+// connect to the broker, and blast.  Reports its ccbid and, after the blast, the
+// requester->target rate (the inbound rate it measured) to the parent over the
+// pipe.  Exits non-zero on failure (which the parent sees as EOF on the pipe).
+static int targetRole( const char *broker, int seconds, FILE *to_parent )
+{
+	Daemon ccb(DT_COLLECTOR, broker, NULL);
+	Sock *reg = ccb.startCommand(CCB_REGISTER, Stream::reli_sock, 20, NULL);
+	if( !reg ) { fprintf(stderr, "target: startCommand(CCB_REGISTER) failed\n"); return 1; }
+
+	ClassAd ad;
+	ad.Assign(ATTR_COMMAND, CCB_REGISTER);
+	ad.Assign(ATTR_NAME, "ccb_proxy_bench-target");
+	reg->encode();
+	if( !putClassAd(reg, ad) || !reg->end_of_message() ) {
+		fprintf(stderr, "target: failed to send registration\n"); return 1;
+	}
+	ClassAd reply;
+	reg->decode();
+	if( !getClassAd(reg, reply) || !reg->end_of_message() ) {
+		fprintf(stderr, "target: failed to read registration reply\n"); return 1;
+	}
+	std::string contact;
+	reply.LookupString(ATTR_CCBID, contact);
+	std::string ccbid = contact;            // contact is "<broker-sinful>#<id>"
+	size_t hash = contact.rfind('#');
+	if( hash != std::string::npos ) { ccbid = contact.substr(hash+1); }
+
+	// Tell the requester (parent) the ccbid so it can request us.
+	fprintf(to_parent, "%s\n", ccbid.c_str());
+	fflush(to_parent);
+
+	// Wait for the broker to forward the request, then reverse-connect.
+	ClassAd fwd;
+	reg->decode();
+	if( !getClassAd(reg, fwd) || !reg->end_of_message() ) {
+		fprintf(stderr, "target: failed to read forwarded request\n"); return 1;
+	}
+	std::string proxy_addr, cid, rid;
+	fwd.LookupString(ATTR_MY_ADDRESS, proxy_addr);
+	fwd.LookupString(ATTR_CLAIM_ID, cid);
+	fwd.LookupString(ATTR_REQUEST_ID, rid);
+
+	ReliSock rc;
+	if( !rc.connect(proxy_addr.c_str(), 0) ) {
+		fprintf(stderr, "target: reverse-connect to %s failed\n", proxy_addr.c_str()); return 1;
+	}
+	ClassAd hello;
+	hello.Assign(ATTR_CLAIM_ID, cid);
+	hello.Assign(ATTR_REQUEST_ID, rid);
+	hello.Assign(ATTR_MY_ADDRESS, proxy_addr);
+	rc.encode();
+	int cmd = CCB_REVERSE_CONNECT;
+	if( !rc.put(cmd) || !putClassAd(&rc, hello) || !rc.end_of_message() ) {
+		fprintf(stderr, "target: failed to send reverse-connect hello\n"); return 1;
+	}
+
+	double rate = blast(rc.get_file_desc(), seconds);   // requester -> target
+	fprintf(to_parent, "%.6f\n", rate);
+	fflush(to_parent);
+	return 0;
+}
+
+// requesterRole: stream-connect to the target (via the broker), blast, and print
+// the throughput each direction.
+static int requesterRole( const char *broker, int seconds, FILE *from_target )
+{
+	// First line from the target: its ccbid.
+	char line[256];
+	if( !fgets(line, sizeof(line), from_target) ) {
+		fprintf(stderr, "requester: target failed before registering\n"); return 1;
+	}
+	std::string ccbid(line);
+	while( !ccbid.empty() && (ccbid.back()=='\n' || ccbid.back()=='\r') ) { ccbid.pop_back(); }
+
+	Daemon ccb(DT_COLLECTOR, broker, NULL);
+	Sock *req = ccb.startCommand(CCB_REQUEST, Stream::reli_sock, 20, NULL);
+	if( !req ) { fprintf(stderr, "requester: startCommand(CCB_REQUEST) failed\n"); return 1; }
+
+	char *connect_id = Condor_Crypt_Base::randomHexKey(20);
+	ClassAd reqad;
+	reqad.Assign(ATTR_CCBID, ccbid);
+	reqad.Assign(ATTR_CLAIM_ID, connect_id);
+	reqad.Assign(ATTR_NAME, "ccb_proxy_bench-requester");
+	reqad.Assign(ATTR_MY_ADDRESS, "<0.0.0.0:0>"); // unreachable; proxy ignores it
+	reqad.Assign("CCBStreamingRequired", true);
+	free(connect_id);
+	req->encode();
+	if( !putClassAd(req, reqad) || !req->end_of_message() ) {
+		fprintf(stderr, "requester: failed to send request\n"); return 1;
+	}
+	ClassAd reply;
+	req->decode();
+	if( !getClassAd(req, reply) || !req->end_of_message() ) {
+		fprintf(stderr, "requester: failed to read reply\n"); return 1;
+	}
+	bool result = false;
+	reply.LookupBool(ATTR_RESULT, result);
+	if( !result ) {
+		std::string err; reply.LookupString(ATTR_ERROR_STRING, err);
+		fprintf(stderr, "requester: broker refused: %s\n", err.c_str()); return 1;
+	}
+	// Read the proxied reverse-connect hello.
+	int cmd = 0;
+	ClassAd hello;
+	req->decode();
+	if( !req->get(cmd) || !getClassAd(req, hello) || !req->end_of_message() ) {
+		fprintf(stderr, "requester: failed to read proxied hello\n"); return 1;
+	}
+
+	double tgt_to_req = blast(req->get_file_desc(), seconds);
+
+	// Second line from the target: the requester->target rate it measured.
+	double req_to_tgt = 0.0;
+	if( fgets(line, sizeof(line), from_target) ) { req_to_tgt = atof(line); }
+
+	auto gbits = [](double bps){ return bps * 8.0 / 1e9; };
+	auto mib   = [](double bps){ return bps / (1024.0*1024.0); };
+	printf("CCB proxy relay throughput over %ds:\n", seconds);
+	printf("  requester -> target : %8.1f MiB/s  (%.2f Gbps)\n", mib(req_to_tgt), gbits(req_to_tgt));
+	printf("  target -> requester : %8.1f MiB/s  (%.2f Gbps)\n", mib(tgt_to_req), gbits(tgt_to_req));
+	printf("  aggregate           : %8.1f MiB/s  (%.2f Gbps)\n",
+		   mib(req_to_tgt+tgt_to_req), gbits(req_to_tgt+tgt_to_req));
+	return 0;
+}
+
+// targetRole_deadbeat: register like targetRole and report our ccbid, but then
+// deliberately never reverse-connect.  We stay registered (socket open) so the
+// broker forwards the request and opens a proxy session, then block until the
+// parent terminates us -- which it does once it has seen the broker reap the
+// never-completed handshake.  Used by the handshake-timeout test.
+static int targetRole_deadbeat( const char *broker, FILE *to_parent )
+{
+	Daemon ccb(DT_COLLECTOR, broker, NULL);
+	Sock *reg = ccb.startCommand(CCB_REGISTER, Stream::reli_sock, 20, NULL);
+	if( !reg ) { fprintf(stderr, "target: startCommand(CCB_REGISTER) failed\n"); return 1; }
+
+	ClassAd ad;
+	ad.Assign(ATTR_COMMAND, CCB_REGISTER);
+	ad.Assign(ATTR_NAME, "ccb_proxy_bench-deadbeat-target");
+	reg->encode();
+	if( !putClassAd(reg, ad) || !reg->end_of_message() ) {
+		fprintf(stderr, "target: failed to send registration\n"); return 1;
+	}
+	ClassAd reply;
+	reg->decode();
+	if( !getClassAd(reg, reply) || !reg->end_of_message() ) {
+		fprintf(stderr, "target: failed to read registration reply\n"); return 1;
+	}
+	std::string contact;
+	reply.LookupString(ATTR_CCBID, contact);
+	std::string ccbid = contact;
+	size_t hash = contact.rfind('#');
+	if( hash != std::string::npos ) { ccbid = contact.substr(hash+1); }
+
+	fprintf(to_parent, "%s\n", ccbid.c_str());
+	fflush(to_parent);
+
+	// Never reverse-connect; stay alive and registered until the parent kills us.
+	pause();
+	return 0;
+}
+
+// requesterRole_expectReap: ask the broker (streaming mode) to reach the deadbeat
+// target.  Since the target never connects back, the broker should reap the
+// half-open session after CCB_SERVER_STREAMING_HANDSHAKE_TIMEOUT and send a
+// failure reply.  Returns 0 only if that failure reply arrives.
+static int requesterRole_expectReap( const char *broker, FILE *from_target )
+{
+	char line[256];
+	if( !fgets(line, sizeof(line), from_target) ) {
+		fprintf(stderr, "requester: target failed before registering\n"); return 1;
+	}
+	std::string ccbid(line);
+	while( !ccbid.empty() && (ccbid.back()=='\n' || ccbid.back()=='\r') ) { ccbid.pop_back(); }
+
+	Daemon ccb(DT_COLLECTOR, broker, NULL);
+	Sock *req = ccb.startCommand(CCB_REQUEST, Stream::reli_sock, 20, NULL);
+	if( !req ) { fprintf(stderr, "requester: startCommand(CCB_REQUEST) failed\n"); return 1; }
+
+	char *connect_id = Condor_Crypt_Base::randomHexKey(20);
+	ClassAd reqad;
+	reqad.Assign(ATTR_CCBID, ccbid);
+	reqad.Assign(ATTR_CLAIM_ID, connect_id);
+	reqad.Assign(ATTR_NAME, "ccb_proxy_bench-requester");
+	reqad.Assign(ATTR_MY_ADDRESS, "<0.0.0.0:0>"); // unreachable; proxy ignores it
+	reqad.Assign("CCBStreamingRequired", true);
+	free(connect_id);
+	req->encode();
+	if( !putClassAd(req, reqad) || !req->end_of_message() ) {
+		fprintf(stderr, "requester: failed to send request\n"); return 1;
+	}
+
+	// Wait for the broker's reply: the target never connects back, so the broker
+	// must reap the handshake (after its timeout plus a poll cycle) and reply with
+	// failure.  Allow generous time for that.
+	req->timeout(120);
+	ClassAd reply;
+	req->decode();
+	if( !getClassAd(req, reply) || !req->end_of_message() ) {
+		fprintf(stderr, "requester: no reply from broker (expected a reap failure)\n");
+		return 1;
+	}
+	bool result = true;
+	reply.LookupBool(ATTR_RESULT, result);
+	std::string err; reply.LookupString(ATTR_ERROR_STRING, err);
+	if( result ) {
+		fprintf(stderr, "requester: broker reported success, but the handshake "
+						"should have been reaped\n");
+		return 1;
+	}
+	printf("CCB streaming handshake reaped as expected: %s\n", err.c_str());
+	return 0;
+}
+
+// Send one streaming CCB_REQUEST for `ccbid` on a fresh connection and leave it
+// open (so the pending session it creates is not torn down).  Returns the socket,
+// or null on failure.  `holder` keeps the Daemon alive for the socket's lifetime.
+static Sock *sendStreamingRequest( const char *broker, const std::string &ccbid,
+								   std::shared_ptr<Daemon> &holder )
+{
+	holder = std::make_shared<Daemon>(DT_COLLECTOR, broker, (char *)NULL);
+	Sock *req = holder->startCommand(CCB_REQUEST, Stream::reli_sock, 20, NULL);
+	if( !req ) { fprintf(stderr, "cap-test: startCommand(CCB_REQUEST) failed\n"); return nullptr; }
+	char *cid = Condor_Crypt_Base::randomHexKey(20);
+	ClassAd reqad;
+	reqad.Assign(ATTR_CCBID, ccbid);
+	reqad.Assign(ATTR_CLAIM_ID, cid);
+	reqad.Assign(ATTR_NAME, "ccb_proxy_bench-cap-requester");
+	reqad.Assign(ATTR_MY_ADDRESS, "<0.0.0.0:0>");
+	reqad.Assign("CCBStreamingRequired", true);
+	free(cid);
+	req->encode();
+	if( !putClassAd(req, reqad) || !req->end_of_message() ) {
+		fprintf(stderr, "cap-test: failed to send request\n"); return nullptr;
+	}
+	return req;
+}
+
+// capTest: register a deadbeat target, open one streaming session (left pending),
+// then send a second streaming request that should be rejected because the broker
+// is at its configured streaming limit.  Returns 0 only if the second request is
+// refused.  Run with CCB_SERVER_MAX_STREAMING_SESSIONS or _HANDSHAKES set to 1.
+static int capTest( const char *broker )
+{
+	Daemon ccb(DT_COLLECTOR, broker, NULL);
+	Sock *reg = ccb.startCommand(CCB_REGISTER, Stream::reli_sock, 20, NULL);
+	if( !reg ) { fprintf(stderr, "cap-test: startCommand(CCB_REGISTER) failed\n"); return 1; }
+	ClassAd ad;
+	ad.Assign(ATTR_COMMAND, CCB_REGISTER);
+	ad.Assign(ATTR_NAME, "ccb_proxy_bench-cap-target");
+	reg->encode();
+	if( !putClassAd(reg, ad) || !reg->end_of_message() ) { fprintf(stderr, "cap-test: register send failed\n"); return 1; }
+	ClassAd rreply;
+	reg->decode();
+	if( !getClassAd(reg, rreply) || !reg->end_of_message() ) { fprintf(stderr, "cap-test: register reply failed\n"); return 1; }
+	std::string contact;
+	rreply.LookupString(ATTR_CCBID, contact);
+	std::string ccbid = contact;
+	size_t hash = contact.rfind('#');
+	if( hash != std::string::npos ) { ccbid = contact.substr(hash+1); }
+
+	// First request fills the one allowed slot (its session stays pending; we
+	// never read its reply).
+	std::shared_ptr<Daemon> hold1;
+	Sock *req1 = sendStreamingRequest(broker, ccbid, hold1);
+	if( !req1 ) { return 1; }
+
+	// Let the broker register the pending session before we probe the limit.
+	sleep(2);
+
+	// Second request must be rejected: the broker is at its streaming limit.
+	std::shared_ptr<Daemon> hold2;
+	Sock *req2 = sendStreamingRequest(broker, ccbid, hold2);
+	if( !req2 ) { return 1; }
+	req2->timeout(30);
+	ClassAd reply;
+	req2->decode();
+	if( !getClassAd(req2, reply) || !req2->end_of_message() ) {
+		fprintf(stderr, "cap-test: no reply to the over-limit request\n"); return 1;
+	}
+	bool result = true;
+	reply.LookupBool(ATTR_RESULT, result);
+	std::string err; reply.LookupString(ATTR_ERROR_STRING, err);
+	if( result ) {
+		fprintf(stderr, "cap-test: over-limit request was accepted; expected rejection\n"); return 1;
+	}
+	printf("CCB streaming limit enforced: %s\n", err.c_str());
+	return 0;
+}
+
+int main( int argc, char **argv )
+{
+	if( argc < 2 ) {
+		fprintf(stderr, "usage: %s <broker-sinful> [seconds | --no-reverse-connect | --cap-test]\n", argv[0]);
+		return 2;
+	}
+	const char *broker = argv[1];
+	bool reaper_mode = false;
+	bool cap_mode = false;
+	int seconds = 5;
+	for( int i = 2; i < argc; i++ ) {
+		if( std::string(argv[i]) == "--no-reverse-connect" ) { reaper_mode = true; }
+		else if( std::string(argv[i]) == "--cap-test" ) { cap_mode = true; }
+		else { seconds = atoi(argv[i]); }
+	}
+
+	if( cap_mode ) {
+		set_priv_initialize();
+		config();
+		signal(SIGPIPE, SIG_IGN);
+		return capTest(broker);
+	}
+
+	set_priv_initialize();
+	config();
+	signal(SIGPIPE, SIG_IGN);
+
+	int fds[2];
+	if( pipe(fds) != 0 ) { fprintf(stderr, "pipe() failed\n"); return 1; }
+
+	pid_t pid = fork();
+	if( pid < 0 ) { fprintf(stderr, "fork() failed\n"); return 1; }
+
+	if( pid == 0 ) {
+		// Child: the target.
+		close(fds[0]);
+		FILE *to_parent = fdopen(fds[1], "w");
+		int rc = reaper_mode
+			? (to_parent ? targetRole_deadbeat(broker, to_parent) : 1)
+			: (to_parent ? targetRole(broker, seconds, to_parent) : 1);
+		if( to_parent ) { fclose(to_parent); }
+		_exit(rc);
+	}
+
+	// Parent: the requester.
+	close(fds[1]);
+	FILE *from_target = fdopen(fds[0], "r");
+
+	if( reaper_mode ) {
+		int rc = from_target ? requesterRole_expectReap(broker, from_target) : 1;
+		if( from_target ) { fclose(from_target); }
+		kill(pid, SIGTERM);   // release the deadbeat target
+		waitpid(pid, NULL, 0);
+		return rc;
+	}
+
+	int rc = from_target ? requesterRole(broker, seconds, from_target) : 1;
+	if( from_target ) { fclose(from_target); }
+
+	int status = 0;
+	waitpid(pid, &status, 0);
+	if( rc == 0 && !(WIFEXITED(status) && WEXITSTATUS(status) == 0) ) { rc = 1; }
+	return rc;
+}
+
+#endif // WIN32

--- a/src/condor_tests/test_ccb_proxy_bench.py
+++ b/src/condor_tests/test_ccb_proxy_bench.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env pytest
+
+# Benchmark for CCB streaming (proxy) mode: stand up a collector-as-CCB and run
+# ccb_proxy_bench, which establishes one streamed (proxied) connection through
+# the broker and blasts raw bytes in both directions, reporting the relay's
+# average throughput each way.  This is a performance probe rather than a strict
+# pass/fail test: it asserts the proxied connection was established and prints
+# the measured rates.
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from ornithology import action, Condor
+
+logger = logging.getLogger(__name__)
+
+BENCH_SECONDS = 5
+
+
+def broker_sinful(condor):
+    addr_file = condor.run_command(
+        ["condor_config_val", "COLLECTOR_ADDRESS_FILE"]
+    ).stdout.strip()
+    return Path(addr_file).read_text().splitlines()[0].strip()
+
+
+def ccb_proxy_bench_path(condor):
+    libexec = condor.run_command(["condor_config_val", "LIBEXEC"]).stdout.strip()
+    return str(Path(libexec) / "ccb_proxy_bench")
+
+
+@action
+def bench_condor(test_dir):
+    with Condor(
+        local_dir=test_dir / "condor",
+        config={
+            # IPv4 only, for a deterministic single-host network setup.
+            "ENABLE_IPV6": "FALSE",
+            # With shared port, the reverse-connect socket is established via
+            # fd-passing whose buffering makes the bidirectional measurement
+            # lopsided; a plain TCP reverse connect keeps the two directions even.
+            "USE_SHARED_PORT": "FALSE",
+            "DAEMON_LIST": "MASTER COLLECTOR",
+            # So the test can confirm the bytes really traversed the relay.
+            "COLLECTOR_DEBUG": "D_FULLDEBUG",
+        },
+    ) as condor:
+        yield condor
+
+
+class TestCCBProxyBench:
+    def test_proxy_throughput(self, bench_condor):
+        condor = bench_condor
+
+        libexec = condor.run_command(
+            ["condor_config_val", "LIBEXEC"]
+        ).stdout.strip()
+        bench = str(Path(libexec) / "ccb_proxy_bench")
+
+        addr_file = condor.run_command(
+            ["condor_config_val", "COLLECTOR_ADDRESS_FILE"]
+        ).stdout.strip()
+        broker = Path(addr_file).read_text().splitlines()[0].strip()
+
+        result = condor.run_command(
+            [bench, broker, str(BENCH_SECONDS)],
+            timeout=BENCH_SECONDS + 30,
+        )
+        logger.info("ccb_proxy_bench output:\n%s", result.stdout)
+        # Make the numbers visible in the test output.
+        print("\n" + result.stdout)
+
+        assert result.returncode == 0
+        assert "throughput" in result.stdout
+
+        # Confirm the broker actually proxied the connection, so the measured
+        # rates are the relay's and not some direct path.
+        collector_log = condor.collector_log.open()
+        assert collector_log.wait(
+            condition=lambda line: "streaming (proxy)" in line,
+            timeout=30,
+        )
+
+
+@action
+def reaper_condor(test_dir):
+    with Condor(
+        local_dir=test_dir / "reaper",
+        config={
+            "ENABLE_IPV6": "FALSE",
+            "USE_SHARED_PORT": "FALSE",
+            "DAEMON_LIST": "MASTER COLLECTOR",
+            "COLLECTOR_DEBUG": "D_FULLDEBUG",
+            # Reap a never-completed streaming handshake quickly: short timeout
+            # and a tight poll interval so the maintenance sweep runs often.
+            "CCB_SERVER_STREAMING_HANDSHAKE_TIMEOUT": "3",
+            "CCB_POLLING_INTERVAL": "1",
+        },
+    ) as condor:
+        yield condor
+
+
+class TestCCBProxyHandshakeTimeout:
+    def test_broker_reaps_incomplete_handshake(self, reaper_condor):
+        # A streaming request whose target registers but never connects back must
+        # not pin the requester's socket forever: the broker reaps the half-open
+        # session after the handshake timeout and replies with a failure, which
+        # ccb_proxy_bench --no-reverse-connect verifies.
+        condor = reaper_condor
+
+        libexec = condor.run_command(
+            ["condor_config_val", "LIBEXEC"]
+        ).stdout.strip()
+        bench = str(Path(libexec) / "ccb_proxy_bench")
+
+        addr_file = condor.run_command(
+            ["condor_config_val", "COLLECTOR_ADDRESS_FILE"]
+        ).stdout.strip()
+        broker = Path(addr_file).read_text().splitlines()[0].strip()
+
+        result = condor.run_command(
+            [bench, broker, "--no-reverse-connect"],
+            timeout=90,
+        )
+        logger.info("ccb_proxy_bench --no-reverse-connect output:\n%s", result.stdout)
+
+        # The requester received the broker's failure reply (the reap).
+        assert result.returncode == 0, (
+            "reaper test failed (rc=%s): %s" % (result.returncode, result.stderr)
+        )
+        assert "handshake reaped as expected" in result.stdout
+
+        # And the broker logged that it timed the handshake out.
+        collector_log = condor.collector_log.open()
+        assert collector_log.wait(
+            condition=lambda line: "handshake" in line and "timed out" in line,
+            timeout=30,
+        )
+
+
+class TestCCBProxyConnectionLimits:
+    # Each cap, set to 1, must make the broker refuse a second concurrent
+    # streaming request.  A long handshake timeout keeps the first (pending)
+    # session alive while ccb_proxy_bench --cap-test probes the limit.
+    @pytest.mark.parametrize(
+        "cap_knob",
+        ["CCB_SERVER_MAX_STREAMING_SESSIONS", "CCB_SERVER_MAX_STREAMING_HANDSHAKES"],
+    )
+    def test_broker_enforces_streaming_limit(self, test_dir, cap_knob):
+        with Condor(
+            local_dir=test_dir / ("cap_" + cap_knob),
+            config={
+                "ENABLE_IPV6": "FALSE",
+                "USE_SHARED_PORT": "FALSE",
+                "DAEMON_LIST": "MASTER COLLECTOR",
+                "COLLECTOR_DEBUG": "D_FULLDEBUG",
+                cap_knob: "1",
+                # Keep the first (pending) session from being reaped mid-test.
+                "CCB_SERVER_STREAMING_HANDSHAKE_TIMEOUT": "60",
+            },
+        ) as condor:
+            result = condor.run_command(
+                [ccb_proxy_bench_path(condor), broker_sinful(condor), "--cap-test"],
+                timeout=60,
+            )
+            logger.info(
+                "ccb_proxy_bench --cap-test (%s) output:\n%s", cap_knob, result.stdout
+            )
+            assert result.returncode == 0, (
+                "cap test failed (rc=%s): %s" % (result.returncode, result.stderr)
+            )
+            assert "limit enforced" in result.stdout

--- a/src/condor_tests/test_ccb_streaming.py
+++ b/src/condor_tests/test_ccb_streaming.py
@@ -16,13 +16,12 @@
 #     schedd by asking the broker to proxy on its own request socket.
 #
 # CCB is forced between processes on a single host with the same mechanism as
-# the existing lib_ccb_* tests: a mismatch in PRIVATE_NETWORK_NAME keeps the CCB
-# contact (daemon.cpp New_addr), and special_connect() then reverse-connects via
-# the broker -- it does not depend on address reachability.
+# the existing lib_ccb_* tests: a mismatch in PRIVATE_NETWORK_NAME.
 
 import logging
 import os
 import tempfile
+import time
 
 import pytest
 
@@ -35,6 +34,14 @@ from ornithology import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def proxy_session_count(condor):
+    # The broker logs one "started streaming (proxy) session" per connection it
+    # relays; counting them is an immediate, reliable streaming-usage signal.
+    return condor.collector_log.path.read_text().count(
+        "started streaming (proxy) session"
+    )
 
 # A unique payload the job must receive via HTCondor file transfer and echo back.
 TRANSFER_SENTINEL = "ccb-streaming-file-transfer-payload-2f9c1a7b"
@@ -118,9 +125,6 @@ def completed_job(condor, test_dir, transfer_job_executable, transfer_input_file
         },
         count=1,
     )
-    # The job can only run if the shadow (NET_SUBMIT) successfully reaches the
-    # startd/starter (NET_EXEC) through the streaming proxy -- the two sit on
-    # different CCB-routed private networks.
     assert handle.wait(
         condition=ClusterState.all_complete,
         timeout=240,
@@ -171,43 +175,162 @@ def ccb_tool_condor(test_dir):
 
 
 class TestCCBStreamingTool:
+    # A firewalled client can be unable to accept a reverse connection in two
+    # distinct ways, exercising different client code paths -- both must fall
+    # back to asking the broker to stream the connection:
+    #
+    #   * shared_port=True : the client tries to receive the reverse connection on
+    #     a shared-port endpoint, but creating it fails (its DAEMON_SOCKET_DIR is
+    #     not writable -- the access(W_OK) check root bypasses).
+    #   * shared_port=False: the client would open a plain listen socket, but
+    #     TOOLS_ASSUME_FIREWALLS says it cannot accept inbound connections at all.
+    @pytest.mark.parametrize("tool_uses_shared_port", [True, False])
     def test_firewalled_tool_reaches_schedd_via_streaming(
-        self, ccb_tool_condor, monkeypatch
+        self, ccb_tool_condor, monkeypatch, tool_uses_shared_port
     ):
-        # The trick below makes the tool's shared-port writability check fail via
-        # access(W_OK), which root bypasses.  This scenario is specifically about
-        # an unprivileged client, so skip when running as root.
+        # The shared-port variant relies on access(W_OK) failing, which root
+        # bypasses, so this unprivileged-client scenario must skip as root.
         if getattr(os, "geteuid", lambda: 1)() == 0:
             pytest.skip("simulating a tool that cannot use shared port requires non-root")
 
         condor = ccb_tool_condor
 
-        # Point the tool's DAEMON_SOCKET_DIR at an existing read-only directory so
-        # its shared-port writability check fails with "cannot write".  Combined
-        # with TOOLS_ASSUME_FIREWALLS, that leaves the tool unable to accept a
-        # direct reverse connection, so to reach the CCB-routed schedd it must ask
-        # the broker to proxy (stream) the connection on its request socket.  The
-        # directory must be short: the daemon socket path it stands in for has to
-        # fit in a unix-domain sockaddr (~108 chars), and the per-test directory
-        # is already long, so use a brief /tmp path.
-        ro_dir = tempfile.mkdtemp(prefix="ccbro", dir="/tmp")
-        os.chmod(ro_dir, 0o555)
-        try:
-            monkeypatch.setenv("_CONDOR_TOOLS_ASSUME_FIREWALLS", "TRUE")
+        monkeypatch.setenv("_CONDOR_TOOLS_ASSUME_FIREWALLS", "TRUE")
+        ro_dir = None
+        if tool_uses_shared_port:
+            # Point the tool's DAEMON_SOCKET_DIR at an existing read-only directory
+            # so its shared-port writability check fails with "cannot write".  The
+            # directory must be short: the daemon socket path it stands in for has
+            # to fit in a unix-domain sockaddr (~108 chars), and the per-test
+            # directory is already long, so use a brief /tmp path.
+            ro_dir = tempfile.mkdtemp(prefix="ccbro", dir="/tmp")
+            os.chmod(ro_dir, 0o555)
             monkeypatch.setenv("_CONDOR_USE_SHARED_PORT", "TRUE")
             monkeypatch.setenv("_CONDOR_DAEMON_SOCKET_DIR", ro_dir)
+        else:
+            monkeypatch.setenv("_CONDOR_USE_SHARED_PORT", "FALSE")
+
+        try:
+            before = proxy_session_count(condor)
 
             # condor_q connects to the (CCB-routed) schedd to read its queue.
             p = condor.run_command(["condor_q"], timeout=60)
-            assert p.returncode == 0
+            assert p.returncode == 0, "condor_q failed: %s" % p.stderr
 
-            # The broker must have logged that it proxied the tool's connection;
-            # had the tool instead reached the schedd directly, no relay appears.
-            collector_log = condor.collector_log.open()
-            assert collector_log.wait(
-                condition=lambda line: "streaming (proxy)" in line,
-                timeout=60,
+            # A new relay appeared for this run: had the tool instead reached the
+            # schedd directly, the broker would log no streaming session.
+            deadline = time.time() + 60
+            while time.time() < deadline and proxy_session_count(condor) <= before:
+                time.sleep(1)
+            assert proxy_session_count(condor) > before, (
+                "firewalled condor_q (tool_uses_shared_port=%s) was not streamed"
+                % tool_uses_shared_port
             )
+
+            # The broker's streaming statistics (published in its collector ad)
+            # should account for the session and the bytes it relayed.
+            sessions = condor.run_command(
+                ["condor_status", "-collector", "-af", "CCBStreamingSessions"]
+            )
+            assert sessions.returncode == 0
+            assert sessions.stdout.strip() not in ("", "undefined"), (
+                "CCBStreamingSessions not published: %r" % sessions.stdout
+            )
+            assert int(sessions.stdout.strip()) >= 1
+
+            num_bytes = condor.run_command(
+                ["condor_status", "-collector", "-af", "CCBStreamingBytes"]
+            )
+            assert int(num_bytes.stdout.strip()) > 0
+
+            # The request that produced the session is counted, and an orderly
+            # close (EOF) is not counted as a relay failure.
+            requests = condor.run_command(
+                ["condor_status", "-collector", "-af", "CCBStreamingRequests"]
+            )
+            assert int(requests.stdout.strip()) >= 1
+            failed = condor.run_command(
+                ["condor_status", "-collector", "-af", "CCBStreamingFailed"]
+            )
+            assert int(failed.stdout.strip()) == 0
         finally:
-            os.chmod(ro_dir, 0o755)
-            os.rmdir(ro_dir)
+            if ro_dir is not None:
+                os.chmod(ro_dir, 0o755)
+                os.rmdir(ro_dir)
+
+
+@action
+def no_streaming_condor(test_dir):
+    # The same private-to-private topology as TestCCBStreaming, but with
+    # streaming disabled on the broker.  A CCB-routed requester is refused
+    # streaming and then falls back to a plain reverse connection (preserving the
+    # pre-streaming behavior); on a single host the endpoints are actually
+    # mutually reachable, so the fallback recovers the connection.
+    with Condor(
+        local_dir=test_dir / "condor",
+        config={
+            "ENABLE_IPV6": "FALSE",
+            # The case under test.
+            "CCB_SERVER_STREAMING": "FALSE",
+            "PRIVATE_NETWORK_NAME": "NET_DEFAULT",
+            "SCHEDD.PRIVATE_NETWORK_NAME": "NET_SUBMIT",
+            "SHADOW.PRIVATE_NETWORK_NAME": "NET_SUBMIT",
+            "STARTD.PRIVATE_NETWORK_NAME": "NET_EXEC",
+            "SCHEDD.CCB_ADDRESS": "$(COLLECTOR_HOST)",
+            "SHADOW.CCB_ADDRESS": "$(COLLECTOR_HOST)",
+            "STARTD.CCB_ADDRESS": "$(COLLECTOR_HOST)",
+            "USE_SHARED_PORT": "FALSE",
+            "DAEMON_LIST": "MASTER COLLECTOR NEGOTIATOR STARTD SCHEDD",
+            "COLLECTOR_DEBUG": "D_FULLDEBUG",
+        },
+    ) as condor:
+        yield condor
+
+
+class TestCCBStreamingDisabled:
+    # Backward compatibility / graceful degradation: a requester that is itself
+    # CCB-routed asks a broker that will not proxy because CCB_SERVER_STREAMING is
+    # false.  The broker must refuse the streaming request with a clear message
+    # and not crash; the requester then falls back to a plain reverse connection,
+    # which succeeds here because the single-host endpoints are mutually
+    # reachable.  (A genuinely old broker that predates streaming is caught
+    # earlier by the requester's pre-send version gate, and falls back the same
+    # way.)
+    def test_streaming_refused_then_direct_fallback(
+        self, no_streaming_condor, path_to_sleep
+    ):
+        condor = no_streaming_condor
+        handle = condor.submit(
+            description={
+                "executable": path_to_sleep,
+                "arguments": "1",
+                "request_memory": "16MB",
+                "request_disk": "16MB",
+                "log": "test_ccb_streaming_disabled.log",
+            },
+            count=1,
+        )
+
+        # The requester is refused streaming and falls back to a direct reverse
+        # connection, which recovers the connection here (reachable endpoints),
+        # so the job still runs to completion.
+        assert handle.wait(
+            condition=ClusterState.all_complete,
+            timeout=240,
+            verbose=True,
+        )
+
+        # The broker refused the streaming attempt along the way with a clear
+        # message (rather than forwarding a doomed request or faulting).  Read the
+        # full log rather than tailing it: the refusal happens early, during the
+        # claim, and may be written before we would start watching.
+        assert "requires CCB streaming mode" in condor.collector_log.path.read_text()
+
+        # No daemon crashed handling the refused streaming request.
+        for daemon_log in (
+            condor.collector_log,
+            condor.schedd_log,
+            condor.startd_log,
+            condor.negotiator_log,
+        ):
+            assert "Stack dump" not in daemon_log.path.read_text()

--- a/src/condor_tests/test_ccb_streaming.py
+++ b/src/condor_tests/test_ccb_streaming.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env pytest
+
+# Test CCB streaming/proxy mode, in which a connection between two daemons that
+# are both behind a Condor Connection Broker is relayed (spliced) through the
+# broker rather than made directly.
+#
+# Every daemon registers with the collector-acting-as-CCB, but only the shadow
+# is placed on a separate private network (NET_B). The long-running daemons stay
+# on the PUBLIC network so the pool stands up normally (local tools such as
+# condor_who can reach them directly). When the shadow connects to the startd /
+# starter to run the job, it cannot use their addresses (different private
+# network) and, being itself CCB-routed, the broker proxies the connection in
+# streaming mode. A job that runs to completion therefore proves the
+# private-to-private path worked, and we additionally confirm the broker logged
+# that it established a streaming relay.
+
+import logging
+
+from ornithology import (
+    action,
+    Condor,
+    ClusterState,
+    write_file,
+    format_script,
+)
+
+logger = logging.getLogger(__name__)
+
+# A unique payload the job must receive via HTCondor file transfer and echo back.
+TRANSFER_SENTINEL = "ccb-streaming-file-transfer-payload-2f9c1a7b"
+
+
+@action
+def condor(test_dir):
+    with Condor(
+        local_dir=test_dir / "condor",
+        config={
+            # IPv4 only, for a deterministic single-host network setup.
+            "ENABLE_IPV6": "FALSE",
+            # Force CCB between daemons on a single host using the same mechanism
+            # as lib_ccb_schedd.run: the collector/negotiator stay on the default
+            # network (no CCB) so local tools and pushed updates reach them
+            # directly; the submit side (schedd/shadow) is on NET_SUBMIT and
+            # CCB-routed, and the execute side (startd) is on NET_EXEC and
+            # CCB-routed, so the shadow->startd job connection is private-to-
+            # private and must be relayed by the broker.
+            "PRIVATE_NETWORK_NAME": "NET_DEFAULT",
+            "SCHEDD.PRIVATE_NETWORK_NAME": "NET_SUBMIT",
+            "SHADOW.PRIVATE_NETWORK_NAME": "NET_SUBMIT",
+            "STARTD.PRIVATE_NETWORK_NAME": "NET_EXEC",
+            "SCHEDD.CCB_ADDRESS": "$(COLLECTOR_HOST)",
+            "SHADOW.CCB_ADDRESS": "$(COLLECTOR_HOST)",
+            "STARTD.CCB_ADDRESS": "$(COLLECTOR_HOST)",
+            # CCB's reverse-connect listener relies on the shared port being
+            # off (matching the existing lib_ccb_* tests).
+            "USE_SHARED_PORT": "FALSE",
+            "DAEMON_LIST": "MASTER COLLECTOR NEGOTIATOR STARTD SCHEDD",
+            # Make the broker's streaming-relay message visible in the collector
+            # log (the second test asserts on it).
+            "COLLECTOR_DEBUG": "D_FULLDEBUG",
+        },
+    ) as condor:
+        yield condor
+
+
+@action
+def transfer_input_file(test_dir):
+    # A real input file the job must receive via HTCondor file transfer.
+    return write_file(test_dir / "ccb_input.dat", TRANSFER_SENTINEL + "\n")
+
+
+@action
+def transfer_job_executable(test_dir):
+    # The job reads its transferred input file and writes it to stdout (which
+    # file transfer brings back to the submit node).  If the input did not
+    # arrive, cat fails and the job exits non-zero -- so a clean, content-
+    # matching run proves the sandbox transfer completed end to end.
+    return write_file(
+        test_dir / "ccb_xfer_job.sh",
+        format_script(
+            """
+            #!/bin/sh
+            cat ccb_input.dat
+            """
+        ),
+    )
+
+
+@action
+def completed_job(condor, test_dir, transfer_job_executable, transfer_input_file):
+    handle = condor.submit(
+        description={
+            "executable": transfer_job_executable.as_posix(),
+            "output": (test_dir / "ccb_xfer_job.out").as_posix(),
+            "error": (test_dir / "ccb_xfer_job.err").as_posix(),
+            "log": "test_ccb_streaming.log",
+            "transfer_input_files": transfer_input_file.as_posix(),
+            # Force file transfer even though the daemons share a host (and thus
+            # a FileSystemDomain): with should_transfer_files=YES the shadow and
+            # starter do a real sandbox transfer over a *separate* connection
+            # from the job's syscall socket.  Because the shadow (NET_SUBMIT) and
+            # starter (NET_EXEC) are both CCB-routed, that transfer connection is
+            # private-to-private and must be relayed by the broker too.
+            "should_transfer_files": "YES",
+            "when_to_transfer_output": "ON_EXIT",
+            "request_memory": "16MB",
+            "request_disk": "16MB",
+        },
+        count=1,
+    )
+    # The job can only run if the shadow (NET_SUBMIT) successfully reaches the
+    # startd/starter (NET_EXEC) through the streaming proxy -- the two sit on
+    # different CCB-routed private networks.
+    assert handle.wait(
+        condition=ClusterState.all_complete,
+        timeout=240,
+        verbose=True,
+    )
+    return handle
+
+
+class TestCCBStreaming:
+    def test_job_ran_via_streaming_ccb(self, completed_job):
+        # Reaching this point means the private-to-private connection worked.
+        assert completed_job.state.all_complete()
+
+    def test_broker_established_streaming_relay(self, condor, completed_job):
+        # The collector-as-CCB should have logged a streaming/proxy relay.
+        collector_log = condor.collector_log.open()
+        assert collector_log.wait(
+            condition=lambda line: "streaming (proxy)" in line,
+            timeout=60,
+        )
+
+    def test_file_transfer_delivered_via_streaming(self, completed_job, test_dir):
+        # The job catted its transferred input file to stdout, which file
+        # transfer carried back.  Seeing the sentinel confirms the sandbox
+        # transfer -- a distinct shadow<->starter connection from the job's
+        # syscall socket -- completed over the private-to-private relay.
+        out = (test_dir / "ccb_xfer_job.out").read_text()
+        assert TRANSFER_SENTINEL in out

--- a/src/condor_tests/test_ccb_streaming.py
+++ b/src/condor_tests/test_ccb_streaming.py
@@ -1,20 +1,30 @@
 #!/usr/bin/env pytest
 
-# Test CCB streaming/proxy mode, in which a connection between two daemons that
-# are both behind a Condor Connection Broker is relayed (spliced) through the
-# broker rather than made directly.
+# Test CCB streaming/proxy mode, in which a connection that the standard CCB
+# connection-reversal scheme cannot make is instead relayed (spliced) through
+# the broker.  Two scenarios are covered:
 #
-# Every daemon registers with the collector-acting-as-CCB, but only the shadow
-# is placed on a separate private network (NET_B). The long-running daemons stay
-# on the PUBLIC network so the pool stands up normally (local tools such as
-# condor_who can reach them directly). When the shadow connects to the startd /
-# starter to run the job, it cannot use their addresses (different private
-# network) and, being itself CCB-routed, the broker proxies the connection in
-# streaming mode. A job that runs to completion therefore proves the
-# private-to-private path worked, and we additionally confirm the broker logged
-# that it established a streaming relay.
+#   * Daemon-to-daemon (TestCCBStreaming): the submit side (schedd/shadow) and
+#     the execute side (startd) are placed on different CCB-routed private
+#     networks, so the shadow->startd connection that carries the job is
+#     private-to-private and the broker must proxy it.  A job that runs to
+#     completion proves the path worked, and the broker logs the relay.
+#
+#   * Firewalled tool (TestCCBStreamingTool): a command-line tool that cannot
+#     accept a reverse connection -- TOOLS_ASSUME_FIREWALLS is set and it has no
+#     writable daemon socket directory for shared port -- reaches a CCB-routed
+#     schedd by asking the broker to proxy on its own request socket.
+#
+# CCB is forced between processes on a single host with the same mechanism as
+# the existing lib_ccb_* tests: a mismatch in PRIVATE_NETWORK_NAME keeps the CCB
+# contact (daemon.cpp New_addr), and special_connect() then reverse-connects via
+# the broker -- it does not depend on address reachability.
 
 import logging
+import os
+import tempfile
+
+import pytest
 
 from ornithology import (
     action,
@@ -139,3 +149,65 @@ class TestCCBStreaming:
         # syscall socket -- completed over the private-to-private relay.
         out = (test_dir / "ccb_xfer_job.out").read_text()
         assert TRANSFER_SENTINEL in out
+
+
+@action
+def ccb_tool_condor(test_dir):
+    # A minimal pool whose schedd is CCB-routed on a private network, so a client
+    # on the default network must reach it through the collector-acting-as-CCB.
+    with Condor(
+        local_dir=test_dir / "tool_condor",
+        config={
+            "ENABLE_IPV6": "FALSE",
+            "PRIVATE_NETWORK_NAME": "NET_DEFAULT",
+            "SCHEDD.PRIVATE_NETWORK_NAME": "NET_SUBMIT",
+            "SCHEDD.CCB_ADDRESS": "$(COLLECTOR_HOST)",
+            "USE_SHARED_PORT": "FALSE",
+            "DAEMON_LIST": "MASTER COLLECTOR SCHEDD",
+            "COLLECTOR_DEBUG": "D_FULLDEBUG",
+        },
+    ) as condor:
+        yield condor
+
+
+class TestCCBStreamingTool:
+    def test_firewalled_tool_reaches_schedd_via_streaming(
+        self, ccb_tool_condor, monkeypatch
+    ):
+        # The trick below makes the tool's shared-port writability check fail via
+        # access(W_OK), which root bypasses.  This scenario is specifically about
+        # an unprivileged client, so skip when running as root.
+        if getattr(os, "geteuid", lambda: 1)() == 0:
+            pytest.skip("simulating a tool that cannot use shared port requires non-root")
+
+        condor = ccb_tool_condor
+
+        # Point the tool's DAEMON_SOCKET_DIR at an existing read-only directory so
+        # its shared-port writability check fails with "cannot write".  Combined
+        # with TOOLS_ASSUME_FIREWALLS, that leaves the tool unable to accept a
+        # direct reverse connection, so to reach the CCB-routed schedd it must ask
+        # the broker to proxy (stream) the connection on its request socket.  The
+        # directory must be short: the daemon socket path it stands in for has to
+        # fit in a unix-domain sockaddr (~108 chars), and the per-test directory
+        # is already long, so use a brief /tmp path.
+        ro_dir = tempfile.mkdtemp(prefix="ccbro", dir="/tmp")
+        os.chmod(ro_dir, 0o555)
+        try:
+            monkeypatch.setenv("_CONDOR_TOOLS_ASSUME_FIREWALLS", "TRUE")
+            monkeypatch.setenv("_CONDOR_USE_SHARED_PORT", "TRUE")
+            monkeypatch.setenv("_CONDOR_DAEMON_SOCKET_DIR", ro_dir)
+
+            # condor_q connects to the (CCB-routed) schedd to read its queue.
+            p = condor.run_command(["condor_q"], timeout=60)
+            assert p.returncode == 0
+
+            # The broker must have logged that it proxied the tool's connection;
+            # had the tool instead reached the schedd directly, no relay appears.
+            collector_log = condor.collector_log.open()
+            assert collector_log.wait(
+                condition=lambda line: "streaming (proxy)" in line,
+                timeout=60,
+            )
+        finally:
+            os.chmod(ro_dir, 0o755)
+            os.rmdir(ro_dir)

--- a/src/condor_tests/test_ccb_streaming_paths.py
+++ b/src/condor_tests/test_ccb_streaming_paths.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env pytest
+
+# Additional CCB streaming/proxy coverage for network paths that the core
+# test_ccb_streaming.py does not exercise:
+#
+#   * condor_chirp          -- the running job's chirp/remote-syscall traffic to
+#     the shadow, which rides the (streamed) shadow<->starter connection.
+#   * job reconnect         -- a fresh shadow reconnecting to a still-running
+#     starter, a brand-new private-to-private connection.
+#   * condor_ssh_to_job     -- the interactive session reaching the execute side.
+#
+# (USE_SHARED_PORT coverage lives with the firewalled-tool test in
+# test_ccb_streaming.py: under shared port a daemon delegates its CCB listener to
+# the condor_shared_port server, so a single pool has no daemon-to-daemon mismatch
+# to stream; the shared-port code path that does stream is a firewalled client
+# whose shared-port reverse-connect listener cannot be created.)
+#
+# All three use the same private-to-private topology as test_ccb_streaming.py
+# (collector/negotiator public so local tools reach them directly; schedd/shadow
+# on NET_SUBMIT and startd/starter on NET_EXEC, each CCB-routed).  Every test
+# asserts the broker actually relayed in streaming mode -- the collector-as-CCB
+# logs one "started streaming (proxy) session" per relayed connection -- so a
+# pass means the path genuinely went through the proxy, not a direct connection.
+
+import logging
+import os
+import re
+import signal
+import time
+from pathlib import Path
+
+from ornithology import (
+    standup,
+    action,
+    Condor,
+    ClusterState,
+    write_file,
+    format_script,
+)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+# The private-to-private topology, shared by every pool below.  USE_SHARED_PORT
+# is set per-pool because it is itself one of the variables under test.
+STREAMING_CONFIG = {
+    # IPv4 only, for a deterministic single-host network setup.
+    "ENABLE_IPV6": "FALSE",
+    "PRIVATE_NETWORK_NAME": "NET_DEFAULT",
+    "SCHEDD.PRIVATE_NETWORK_NAME": "NET_SUBMIT",
+    "SHADOW.PRIVATE_NETWORK_NAME": "NET_SUBMIT",
+    "STARTD.PRIVATE_NETWORK_NAME": "NET_EXEC",
+    "SCHEDD.CCB_ADDRESS": "$(COLLECTOR_HOST)",
+    "SHADOW.CCB_ADDRESS": "$(COLLECTOR_HOST)",
+    "STARTD.CCB_ADDRESS": "$(COLLECTOR_HOST)",
+    "DAEMON_LIST": "MASTER COLLECTOR NEGOTIATOR STARTD SCHEDD",
+    # The broker logs each relay it establishes in its collector log.
+    "COLLECTOR_DEBUG": "D_FULLDEBUG",
+}
+
+# The broker logs exactly one of these per private-to-private connection it
+# relays, so counting them is an immediate, reliable streaming-usage signal
+# (no metric-publication delay).
+_SESSION_MARK = "started streaming (proxy) session"
+
+
+def streaming_session_count(condor):
+    return condor.collector_log.path.read_text().count(_SESSION_MARK)
+
+
+def wait_for_new_streaming_session(condor, baseline, timeout=120):
+    # Poll the broker log until it relays a session beyond `baseline`, i.e. the
+    # action under test opened a new private-to-private connection.
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if streaming_session_count(condor) > baseline:
+            return True
+        time.sleep(2)
+    return False
+
+
+def newest_pid_in_logs(log_dir, glob):
+    # DaemonCore logs "** PID = <pid>" at startup; return the most recent one
+    # across all matching log files (e.g. the current shadow or starter).
+    newest_pid, newest_mtime = None, -1.0
+    for path in Path(log_dir).glob(glob):
+        pids = re.findall(r"\*\* PID = (\d+)", path.read_text())
+        if pids and path.stat().st_mtime > newest_mtime:
+            newest_pid, newest_mtime = int(pids[-1]), path.stat().st_mtime
+    return newest_pid
+
+
+def log_dir_of(condor):
+    return Path(condor.run_command(["condor_config_val", "LOG"]).stdout.strip())
+
+
+# ---------------------------------------------------------------------------
+# condor_chirp (rides the streamed shadow<->starter connection)
+# ---------------------------------------------------------------------------
+
+
+@standup
+def noshared_condor(test_dir):
+    # CCB's reverse-connect listener relies on shared port being off (matching
+    # the existing lib_ccb_* tests), so the non-shared-port scenarios share one
+    # pool with shared port disabled.
+    with Condor(
+        local_dir=test_dir / "noshared",
+        config={**STREAMING_CONFIG, "USE_SHARED_PORT": "FALSE"},
+    ) as condor:
+        yield condor
+
+
+@action
+def chirp_job(noshared_condor, test_dir):
+    # A job that round-trips a value through condor_chirp: set_job_attr writes it
+    # to the job ad via the shadow, get_job_attr reads it back -- both over the
+    # remote-syscall connection, which here is the streamed shadow<->starter
+    # relay.  The value is echoed to stdout (transferred back) for verification.
+    # condor_chirp is not on the job's PATH, so invoke it by full path (the
+    # execute side shares this host's install).
+    libexec = noshared_condor.run_command(
+        ["condor_config_val", "LIBEXEC"]
+    ).stdout.strip()
+    chirp = os.path.join(libexec, "condor_chirp")
+    exe = write_file(
+        test_dir / "chirp_job.sh",
+        format_script(
+            """
+            #!/bin/sh
+            "{chirp}" set_job_attr CCBChirpProof 4242
+            echo "chirp_roundtrip=$("{chirp}" get_job_attr CCBChirpProof)"
+            """.format(chirp=chirp)
+        ),
+    )
+    handle = noshared_condor.submit(
+        description={
+            "executable": exe.as_posix(),
+            "output": (test_dir / "chirp_job.out").as_posix(),
+            "error": (test_dir / "chirp_job.err").as_posix(),
+            "log": (test_dir / "chirp_job.log").as_posix(),
+            "should_transfer_files": "YES",
+            "when_to_transfer_output": "ON_EXIT",
+            "want_io_proxy": "true",
+            "request_memory": "16MB",
+            "request_disk": "16MB",
+        },
+        count=1,
+    )
+    assert handle.wait(
+        condition=ClusterState.all_complete, timeout=240, verbose=True
+    )
+    return handle
+
+
+class TestCCBStreamingChirp:
+    def test_chirp_round_trip(self, chirp_job, test_dir):
+        # Seeing the value come back proves both the set_job_attr and the
+        # get_job_attr chirp calls reached the shadow and returned -- the chirp
+        # traffic crossed the broker relay (the only shadow<->starter path).
+        out = (test_dir / "chirp_job.out").read_text()
+        assert "chirp_roundtrip=4242" in out
+
+    def test_broker_streamed_for_chirp_job(self, noshared_condor, chirp_job):
+        assert streaming_session_count(noshared_condor) >= 1
+
+
+# ---------------------------------------------------------------------------
+# job reconnect (a fresh shadow reconnects to a live starter)
+# ---------------------------------------------------------------------------
+
+
+@action
+def reconnect_job(noshared_condor, path_to_sleep, test_dir):
+    condor = noshared_condor
+    handle = condor.submit(
+        description={
+            "executable": path_to_sleep,
+            "arguments": "120",
+            "should_transfer_files": "YES",
+            "when_to_transfer_output": "ON_EXIT",
+            "log": (test_dir / "reconnect.log").as_posix(),
+            # Let the starter wait for a reconnect rather than killing the job
+            # when its shadow dies.
+            "+JobLeaseDuration": "40",
+        },
+        count=1,
+    )
+    assert handle.wait(condition=ClusterState.all_running, timeout=120, verbose=True)
+    time.sleep(3)  # let the shadow finish establishing/lease-renewing
+
+    before = streaming_session_count(condor)
+    shadow_pid = newest_pid_in_logs(log_dir_of(condor), "ShadowLog*")
+    assert shadow_pid is not None, "could not find a shadow PID"
+
+    # Kill the shadow (NOT the starter): the schedd spawns a fresh shadow that
+    # reconnects to the still-running starter, which is a brand-new private-to-
+    # private connection the broker must stream.
+    os.kill(shadow_pid, signal.SIGKILL)
+
+    streamed_after_reconnect = wait_for_new_streaming_session(condor, before)
+    completed = handle.wait(
+        condition=ClusterState.all_complete,
+        fail_condition=ClusterState.any_held,
+        timeout=300,
+        verbose=True,
+    )
+    return {
+        "handle": handle,
+        "streamed_after_reconnect": streamed_after_reconnect,
+        "completed": completed,
+    }
+
+
+class TestCCBStreamingReconnect:
+    def test_reconnect_used_streaming(self, reconnect_job):
+        # A new streaming session appeared after we killed the shadow, i.e. the
+        # replacement shadow reconnected to the starter through the broker.
+        assert reconnect_job["streamed_after_reconnect"]
+
+    def test_job_survived_reconnect(self, reconnect_job):
+        assert reconnect_job["completed"]
+
+
+# ---------------------------------------------------------------------------
+# condor_ssh_to_job
+# ---------------------------------------------------------------------------
+
+
+@action
+def ssh_target_job(noshared_condor, path_to_sleep, test_dir):
+    handle = noshared_condor.submit(
+        description={
+            "executable": path_to_sleep,
+            "arguments": "600",
+            "should_transfer_files": "YES",
+            "when_to_transfer_output": "ON_EXIT",
+            "log": (test_dir / "ssh.log").as_posix(),
+        },
+        count=1,
+    )
+    assert handle.wait(condition=ClusterState.all_running, timeout=120, verbose=True)
+    return handle
+
+
+class TestCCBStreamingSSH:
+    def test_ssh_to_job_uses_streaming(self, noshared_condor, ssh_target_job):
+        condor = noshared_condor
+        job_id = "{}.0".format(ssh_target_job.clusterid)
+
+        before = streaming_session_count(condor)
+        # We assert on the connection being streamed, not on the remote command:
+        # condor_ssh_to_job has to reach the (CCB-routed) execute side to run the
+        # command at all, and that reach is the private-to-private connection the
+        # broker must relay.  (The trivial remote command's own exit can vary by
+        # platform and is not what is under test here.)
+        cp = condor.run_command(
+            ["condor_ssh_to_job", "-auto-retry", job_id, "/usr/bin/true"],
+            timeout=120,
+        )
+        logger.info("condor_ssh_to_job rc=%s stderr=%s", cp.returncode, cp.stderr)
+
+        assert wait_for_new_streaming_session(condor, before), (
+            "condor_ssh_to_job did not establish a streamed connection "
+            "(rc=%s, stderr=%s)" % (cp.returncode, cp.stderr)
+        )

--- a/src/condor_utils/param_info.in
+++ b/src/condor_utils/param_info.in
@@ -4352,6 +4352,41 @@ type=int
 description=Interval between CCB protocol heartbeats
 tags=ccb
 
+[CCB_SERVER_STREAMING]
+default=true
+version=25.12.0
+type=bool
+description=When true, a CCB server (broker) will proxy private-to-private connections: if a requester that is itself behind a CCB asks to reach another CCB-routed daemon, the broker has the target reverse-connect to the broker and splices the two sockets into a transparent relay.
+tags=ccb
+
+[CCB_SERVER_STREAMING_HANDSHAKE_TIMEOUT]
+default=300
+version=25.12.0
+type=int
+description=How long (in seconds) a CCB server (broker) waits for the target of a streaming (proxy) request to connect back and be spliced before abandoning the half-open session, freeing the requester's socket, and reporting a failure. This bounds only the handshake; once the relay is established it has no idle timeout. Set to 0 to disable handshake reaping.
+tags=ccb
+
+[CCB_SERVER_MAX_STREAMING_SESSIONS]
+default=0
+version=25.12.0
+type=int
+description=The maximum number of concurrent CCB streaming (proxy) sessions a broker will maintain, counting both in-progress handshakes and established relays. Requests beyond the limit are rejected with a clear failure. The default of 0 means unlimited.
+tags=ccb
+
+[CCB_SERVER_MAX_STREAMING_HANDSHAKES]
+default=0
+version=25.12.0
+type=int
+description=The maximum number of CCB streaming (proxy) sessions a broker will keep in the handshake state (waiting for the target to connect back) at once. This bounds the more easily abused, never-completing requests separately from established relays; requests beyond the limit are rejected. The default of 0 means unlimited.
+tags=ccb
+
+[CCB_CLIENT_STREAMING]
+default=true
+version=25.12.0
+type=bool
+description=When true, a daemon that is itself behind a CCB will attempt to reach another CCB-routed (private) peer by asking a streaming-capable broker to proxy the connection, instead of giving up. The attempt is only made when the broker advertises support, so this is safe to leave enabled.
+tags=ccb
+
 [ROOSTER_INTERVAL]
 default=300
 version=7.4.0


### PR DESCRIPTION
Adds a streaming (proxy) mode to the CCB so two peers that are each behind a CCB can connect — for example a submit-side daemon on one private network reaching an execute-side daemon on another. In streaming mode the broker keeps the requester's request socket, tells the target to reverse-connect to the broker instead, and splices the two sockets into a transparent TCP relay.