### PR TITLE
HTCONDOR-3821: Prefer AES for non-negotiated and family security sessions

### DIFF
--- a/docs/version-history/v25-version.hist
+++ b/docs/version-history/v25-version.hist
@@ -1,5 +1,11 @@
 *** 25.13.0 features
 
+- Non-negotiated and family security sessions now always prefer ``AES``
+  (AES-GCM) when both peers support it, rather than falling back to the
+  antiquated ``BLOWFISH`` cipher. ``BLOWFISH`` and ``3DES`` remain available
+  for FIPS mode and for interoperating with peers that predate AES support.
+  :jira:`3821`
+
 *** 25.13.0 bugs
 
 *** 25.0.13 bugs

--- a/src/condor_daemon_core.V6/daemon_command.cpp
+++ b/src/condor_daemon_core.V6/daemon_command.cpp
@@ -832,8 +832,9 @@ DaemonCommandProtocol::CommandProtocolResult DaemonCommandProtocol::ReadCommand(
 				// figure out which one to use.
 				// If the client's resume session ad gives a crypto method
 				// list, use the first entry in it.
-				// Otherwise, the client is 8.9, so if we have a list, use
-				// the first entry that's BLOWFISH or 3DES.
+				// Otherwise, the client predates the crypto-method list
+				// (pre-9.9.0), so pick from the session's list, always
+				// preferring AES-GCM when it is available.
 				// Whichever one we use, set it as the preferred method
 				// for the session, in case we need to connect to our
 				// peer in the future.
@@ -846,7 +847,7 @@ DaemonCommandProtocol::CommandProtocolResult DaemonCommandProtocol::ReadCommand(
 						active_crypto = SecMan::getCryptProtocolNameToEnum(client_crypto_methods.c_str());
 					} else {
 						std::string pick_crypto;
-						pick_crypto = SecMan::getPreferredOldCryptProtocol(session_crypto_methods);
+						pick_crypto = SecMan::getPreferredCryptProtocol(session_crypto_methods);
 						active_crypto = SecMan::getCryptProtocolNameToEnum(pick_crypto.c_str());
 					}
 					session->setPreferredProtocol(active_crypto);

--- a/src/condor_includes/condor_secman.h
+++ b/src/condor_includes/condor_secman.h
@@ -328,7 +328,9 @@ public:
 	static Protocol getCryptProtocolNameToEnum(char const *name);
 	static const char *getCryptProtocolEnumToName(Protocol proto);
 
-	static std::string getPreferredOldCryptProtocol(const std::string &name);
+	// Pick the crypto method a non-negotiated/family session should use from a
+	// comma-separated list, always preferring AES-GCM when it is offered.
+	static std::string getPreferredCryptProtocol(const std::string &name);
 
  private:
 	static  std::string		filterAuthenticationMethods(DCpermission perm, const std::string &input_methods);

--- a/src/condor_io/condor_secman.cpp
+++ b/src/condor_io/condor_secman.cpp
@@ -3735,28 +3735,32 @@ SecMan::getCryptProtocolEnumToName(Protocol proto)
 }
 
 std::string
-SecMan::getPreferredOldCryptProtocol(const std::string &name)
+SecMan::getPreferredCryptProtocol(const std::string &name)
 {
-	std::string answer;
+	// Choose which single crypto method a non-negotiated or family session
+	// should use, always preferring AES-GCM when the peer offers it. Blowfish
+	// and 3DES remain available as fallbacks (in FIPS mode or for a peer that
+	// predates AES), but we no longer prefer those antiquated ciphers over AES.
+	std::string fallback;
 	for (auto& tmp : StringTokenIterator(name)) {
 		dprintf(D_NETWORK|D_VERBOSE, "Considering crypto protocol %s.\n", tmp.c_str());
-		if (!strcasecmp(tmp.c_str(), "BLOWFISH")) {
-			dprintf(D_NETWORK|D_VERBOSE, "Decided on crypto protocol %s.\n", tmp.c_str());
-			return "BLOWFISH";
-		} else if (!strcasecmp(tmp.c_str(), "3DES") || !strcasecmp(tmp.c_str(), "TRIPLEDES")) {
-			dprintf(D_NETWORK|D_VERBOSE, "Decided on crypto protocol %s.\n", tmp.c_str());
-			return "3DES";
-		} else if (!strcasecmp(tmp.c_str(), "AES")) {
-			dprintf(D_NETWORK|D_VERBOSE, "Decided on crypto protocol %s.\n", tmp.c_str());
-			answer = tmp;
+		if (!strcasecmp(tmp.c_str(), "AES")) {
+			dprintf(D_NETWORK|D_VERBOSE, "Decided on crypto protocol AES.\n");
+			return "AES";
+		} else if (fallback.empty()) {
+			if (!strcasecmp(tmp.c_str(), "3DES") || !strcasecmp(tmp.c_str(), "TRIPLEDES")) {
+				fallback = "3DES";
+			} else if (!strcasecmp(tmp.c_str(), "BLOWFISH")) {
+				fallback = "BLOWFISH";
+			}
 		}
 	}
-	if (answer.empty()) {
+	if (fallback.empty()) {
 		dprintf(D_NETWORK, "Could not decide on crypto protocol from list %s, return CONDOR_NO_PROTOCOL.\n", name.c_str());
 	} else {
-		dprintf(D_NETWORK|D_VERBOSE, "Decided on crypto protocol %s.\n", answer.c_str());
+		dprintf(D_NETWORK|D_VERBOSE, "No AES offered; falling back to crypto protocol %s.\n", fallback.c_str());
 	}
-	return answer;
+	return fallback;
 }
 
 bool
@@ -4075,16 +4079,21 @@ SecMan::ExportSecSessionInfo(char const *session_id,std::string &session_info) {
 	policy->LookupString(ATTR_SEC_CRYPTO_METHODS, crypto_methods);
 	size_t pos = crypto_methods.find(',');
 	if( pos != std::string::npos ) {
-		std::string preferred = getPreferredOldCryptProtocol(crypto_methods);
-		if (preferred.empty()) {
-			preferred = crypto_methods.substr(0, pos);
-		}
-		exp_policy.Assign(ATTR_SEC_CRYPTO_METHODS, preferred);
+		// Always prefer AES for the exported (non-negotiated / family) session.
+		// Move AES to the front of the method list so that the peer importing
+		// this session derives its preferred key as AES-GCM -- KeyCacheEntry
+		// takes the first method as the session's preferred protocol -- and
+		// advertise AES as the single (legacy) CryptoMethods value read by
+		// peers that don't understand CryptoMethodsList. The full ordered list
+		// still travels so a peer may fall back to Blowfish or 3DES.
+		std::vector<std::string> methods = split(crypto_methods);
+		std::stable_partition(methods.begin(), methods.end(),
+			[](const std::string &m) { return !strcasecmp(m.c_str(), "AES"); });
+		exp_policy.Assign(ATTR_SEC_CRYPTO_METHODS, methods.front());
 
-		// ',' is not a permissible character in claim IDs.
-		// Convert it to a different delimiter...
-		std::replace(crypto_methods.begin(), crypto_methods.end(), ',', '.');
-		exp_policy.Assign(ATTR_SEC_CRYPTO_METHODS_LIST, crypto_methods);
+		// ',' is not a permissible character in claim IDs, so join the list
+		// with a different delimiter...
+		exp_policy.Assign(ATTR_SEC_CRYPTO_METHODS_LIST, join(methods, "."));
 	} else if (!crypto_methods.empty()) {
 		exp_policy.Assign(ATTR_SEC_CRYPTO_METHODS, crypto_methods);
 	}


### PR DESCRIPTION
HTCondor exports a session's crypto method for non-negotiated and family (daemon-to-daemon inherited) sessions via ExportSecSessionInfo, and on session resumption the server picks a method for pre-9.9.0 clients that do not advertise one. Both paths used getPreferredOldCryptProtocol, which preferred BLOWFISH > 3DES > AES for backward compatibility with pre-8.9.x peers (added in HTCONDOR-233). As a result, two fully AES-capable modern daemons would still secure their family session with the antiquated BLOWFISH+MD5 cipher.

Replace getPreferredOldCryptProtocol with getPreferredCryptProtocol, which always prefers AES-GCM when the peer offers it, falling back to 3DES or BLOWFISH only when AES is unavailable (e.g. FIPS mode or a pre-8.9 peer). In ExportSecSessionInfo, also move AES to the front of the exported CryptoMethodsList so the importing peer derives AES-GCM as its preferred key (KeyCacheEntry takes the first method as the session's preferred protocol). The BLOWFISH and 3DES cipher implementations are unchanged and remain available; only the default preference changes.

For non-negotiated session communication with pre-8.9.x peers, one will need to manually set a list of compatible sessions on both sides.