### PR TITLE
HTCONDOR-3822: Add multi-chapter RFC describing the CEDAR protocol

### DIFF
--- a/cedar-rfc/01-message-framing.md
+++ b/cedar-rfc/01-message-framing.md
@@ -1,0 +1,293 @@
+# Chapter 1. Message Framing and Primitive Encodings
+
+This chapter specifies the lowest layer of CEDAR: how a byte stream is
+divided into frames and messages, how primitive values are encoded inside
+a message, and how frames are protected with AES-256-GCM once a channel
+key has been established.
+
+## 1.1 The Stream / Message / Frame Model
+
+A CEDAR **stream** is a bidirectional, reliable, ordered byte channel —
+in practice a TCP connection. Application data is exchanged as
+**messages**. A message is an ordered sequence of encoded values
+(integers, strings, ClassAds, raw bytes) terminated by an explicit
+end-of-message marker. The receiver cannot begin decoding a value until
+it knows the message boundary semantics; both implementations buffer an
+entire frame before yielding data to the decoder.
+
+Each message is carried as one or more **frames**. Senders flush a frame
+when their buffer reaches an implementation-chosen threshold (the C++
+implementation defaults to a 4 KiB buffer; the Go implementation targets
+16 KiB frames, `golang-cedar/message/message.go`), and mark the final
+frame of the message with the end-of-message flag.
+
+There is no connection preamble: the first bytes on a fresh CEDAR TCP
+connection are the header of the first frame.
+
+## 1.2 Frame Header
+
+Every frame begins with a 5-byte header
+(`src/condor_io/reli_sock.cpp:45`, `golang-cedar/stream/stream.go:82-96`):
+
+```
+ Offset  Size  Field
+ ------  ----  -----------------------------------------------------
+      0     1  end-of-message flag:
+               0 = additional frames of this message follow
+               1 = this frame completes the message
+    1-4     4  payload length in bytes, unsigned, big-endian
+    5-…     N  payload (N = payload length)
+```
+
+Constraints (`src/condor_io/reli_sock.cpp:901-931`):
+
+- The payload length MUST be greater than 0 and MUST NOT exceed
+  **1,048,576 bytes (1 MiB)**. A receiver MUST reject frames outside
+  this range and abort the connection.
+- The C++ receiver accepts end-of-message flag values 0 through 10 and
+  treats any nonzero value as end-of-message; values 2–10 are reserved.
+  Senders MUST send only 0 or 1.
+
+Messages larger than 1 MiB are simply carried in multiple frames; there
+is no limit on total message size at the framing layer (higher layers
+impose their own limits).
+
+> **Legacy note.** When the legacy per-frame MAC ("MD") mode is active
+> the header is extended by a 16- or 32-byte MAC following the 5 fixed
+> bytes. This mode is tied to the legacy ciphers and is out of scope for
+> this document; the AES-GCM mechanism of §1.4 provides integrity via
+> the GCM authentication tag instead and uses the unmodified 5-byte
+> header.
+
+## 1.3 Primitive Encodings
+
+The following encodings apply to the byte sequence inside message
+payloads (after decryption, when encryption is active). They are
+implemented in `src/condor_io/stream.cpp` and
+`golang-cedar/message/message.go`.
+
+### 1.3.1 Integers
+
+**All** integer types — `char`-sized values excepted — are widened to 64
+bits and transmitted as **8 bytes, big-endian, two's complement**
+(`stream.cpp:559-612`, `message.go:502-529`). This applies uniformly to
+`short`, `int`, `long`, `long long`, and their unsigned variants; the Go
+`PutInt32`/`PutInt64`/`PutUint32` helpers all delegate to the same 8-byte
+encoding. Booleans are transmitted as integers 0 or 1.
+
+### 1.3.2 Single Bytes and Raw Byte Arrays
+
+A `char`/byte value is transmitted as a single octet. Raw byte arrays
+(`put_bytes`) are transmitted verbatim with no length prefix or
+terminator; the surrounding protocol must convey the length (typically
+via a preceding integer field).
+
+### 1.3.3 Floating-Point Values
+
+Floating-point values are **not** sent as IEEE-754 bit patterns.
+A `float` is first widened to `double`; the double is then decomposed
+with `frexp()` into a normalized fraction and a binary exponent, and both
+parts are sent as CEDAR integers (§1.3.1) — 16 bytes total
+(`stream.cpp:623-629, 852-862`, `message.go:291-305, 531-550`):
+
+```
+frac, exp = frexp(d)                    // 0.5 <= |frac| < 1.0
+fracInt   = trunc(frac * 2147483647)    // scaled by 2^31 - 1
+wire      = int64(fracInt) || int64(exp)
+```
+
+The receiver reconstructs `ldexp(fracInt / 2147483647.0, exp)`. This
+encoding is portable but lossy in the low-order bits of the mantissa
+(the fraction is scaled into 31 bits).
+
+### 1.3.4 Strings
+
+Strings are sequences of non-NUL octets. Two encodings exist, selected
+by whether channel encryption is currently active
+(`stream.cpp:633-660, 875-898, 973-1021`, `message.go:309-364, 554-609`):
+
+**Plaintext channel:**
+
+```
+string  := octets* 0x00        ; NUL-terminated
+null    := 0xFF                ; a "no string" marker (BIN_NULL_CHAR)
+```
+
+An *empty* string is the single byte `0x00`; an *absent* (NULL) string is
+the single byte `0xFF`.
+
+**Encrypted channel:** because the decoder cannot scan ciphertext for a
+terminator, strings are length-prefixed:
+
+```
+string  := int64(len) octets[len]
+```
+
+where `len` counts the octets **including** the trailing NUL, which is
+still present, and the length is encoded as a CEDAR integer (8 bytes,
+big-endian). The C++ receiver rejects encrypted string lengths above
+10,000,000 bytes; the Go implementation offers `GetStringWithMaxSize`
+for the same denial-of-service protection.
+
+Senders MUST NOT embed a NUL inside a string (the Go implementation
+truncates at the first NUL).
+
+## 1.4 Frame Protection with AES-256-GCM
+
+Once the command-protocol handshake (Chapter 4) has produced a 32-byte
+symmetric key and selected the `AES` crypto method, every subsequent
+frame payload is protected with AES-256-GCM
+(`src/condor_io/reli_sock.cpp:984-1063, 1213-1293`,
+`golang-cedar/stream/stream.go:578-805`). The 5-byte frame header
+remains in cleartext; the length field gives the length of the
+*ciphertext* payload.
+
+### 1.4.1 Ciphertext Layout
+
+```
+first encrypted frame:
+    header(5) || IV(16) || ciphertext || tag(16)
+subsequent frames:
+    header(5) || ciphertext || tag(16)
+```
+
+- The **IV** is 16 random bytes chosen by each sender and transmitted
+  in the clear ahead of the first ciphertext it produces.
+- The GCM **authentication tag** is 16 bytes and trails the ciphertext.
+- Per-frame IVs after the first are derived deterministically: each
+  direction maintains a frame counter, and the leading 32-bit word of
+  the IV is the base value plus the counter (big-endian); the remaining
+  12 bytes are unchanged. Senders and receivers keep independent
+  counters per direction, so IVs never repeat under a given key.
+
+### 1.4.2 Additional Authenticated Data and Transcript Binding
+
+The GCM AAD for every frame includes the 5-byte cleartext frame header,
+so a tampered length or end-of-message flag causes tag verification to
+fail.
+
+The **first** encrypted frame in each direction additionally binds the
+plaintext pre-handshake transcript into the channel: both sides maintain
+SHA-256 digests over all bytes sent and all bytes received *before*
+encryption was enabled (capped at the first 1 MiB in each direction).
+These digests are finalized when encryption starts and prepended to the
+AAD of the first encrypted frame (`reli_sock.cpp:1231-1277`):
+
+```
+AAD(first frame, sender)   = sent_digest(32) || received_digest(32) || header(5)     ; 69 bytes
+AAD(first frame, receiver) = received_digest(32) || sent_digest(32) || header(5)
+AAD(later frames)          = header(5)
+```
+
+Because the security negotiation of Chapter 4 happens in cleartext, this
+binding detects a man-in-the-middle who altered the negotiation (for
+example, downgrading the offered methods): the two sides' transcript
+digests will disagree, and the first encrypted frame will fail
+authentication.
+
+### 1.4.3 Secrets on Plaintext Channels
+
+Even when full-channel encryption was not negotiated, individual values
+may be sent encrypted ("secrets", used e.g. for `ZKM` ClassAd attributes,
+§2.4) if a key is available: the sender enables the cipher for just those
+bytes. The string encoding then follows the encrypted form of §1.3.4.
+
+## 1.5 Worked Examples
+
+### 1.5.1 A Single-Frame Message
+
+A message containing three values — the integer `42`, the string
+`"pool"`, and the real `0.25` — fits in one frame. The payload is
+8 + 5 + 16 = 29 bytes:
+
+```
+01                        frame header: end-of-message = 1
+00 00 00 1D               frame header: payload length = 29
+00 00 00 00 00 00 00 2A   int 42            (8-byte big-endian)
+70 6F 6F 6C 00            "pool"            (NUL-terminated)
+00 00 00 00 3F FF FF FF   0.25, fraction:   trunc(0.5 × (2^31−1)) = 1073741823
+FF FF FF FF FF FF FF FF   0.25, exponent:   −1
+```
+
+(`frexp(0.25)` yields fraction 0.5, exponent −1.) Note the encoding is
+lossy: the receiver computes `ldexp(1073741823 / 2147483647.0, -1)` =
+0.2499999998835…, not exactly 0.25 (§1.3.3).
+
+### 1.5.2 A Message Spanning Multiple Frames
+
+Frame boundaries are chosen by the sender's buffering, not by value
+boundaries; a receiver MUST treat the concatenated payloads as one
+contiguous byte sequence. Consider a message consisting of a single
+string of 6,000 `'A'` characters (6,001 payload bytes including the
+NUL), sent by the C++ implementation with its default 4 KiB buffer:
+
+```
+frame 1:
+00                        end-of-message = 0 (more frames follow)
+00 00 10 00               payload length = 4096
+41 41 41 … 41             first 4096 bytes of the string
+
+frame 2:
+01                        end-of-message = 1 (message complete)
+00 00 07 71               payload length = 1905
+41 41 … 41 00             remaining 1904 'A's and the terminating NUL
+```
+
+The string value is split mid-value across the two frames; equally, a
+single frame routinely carries many small values. The Go implementation
+would send the same message split at its 16 KiB target instead — i.e.
+as one frame — and both forms are valid: framing carries **no**
+semantic information beyond the message boundary.
+
+### 1.5.3 An Encrypted Frame
+
+The message of §1.5.1 sent as the *first* frame after AES-256-GCM was
+enabled (§1.4). The 29 plaintext bytes yield 29 ciphertext bytes; the
+payload gains the 16-byte IV (first frame only) and the 16-byte tag,
+so the header advertises 61 bytes:
+
+```
+01                        end-of-message = 1            (cleartext)
+00 00 00 3D               payload length = 61           (cleartext)
+xx × 16                   IV, randomly chosen by sender (cleartext)
+xx × 29                   AES-256-GCM ciphertext of the 29 payload bytes
+xx × 16                   GCM authentication tag
+```
+
+with
+
+```
+AAD = SHA-256(bytes sent before encryption)     (32 bytes)
+   || SHA-256(bytes received before encryption) (32 bytes)
+   || 01 00 00 00 3D                            (this frame's header)
+```
+
+A subsequent frame carrying the same message would omit the IV
+(payload length 45) and use only the 5 header bytes as AAD; its IV is
+the transmitted IV with the leading 32-bit word incremented by the
+per-direction frame counter.
+
+## 1.6 UDP Framing (C++ Only)
+
+The C++ implementation also carries CEDAR messages over UDP
+(*SafeSock*, `src/condor_io/SafeMsg.cpp`, `src/condor_includes/SafeMsg.h`).
+A message is split into datagrams of at most 60,000 bytes, each carrying
+a 25-byte header beginning with the magic string `"MaGic6.0"`, a
+last-fragment flag, a 16-bit sequence number, and a message identifier
+(sender IP, PID, timestamp, message number) used for reassembly. An
+optional 10-byte extension header tagged `"CRAP"` carries per-datagram
+crypto/MAC parameters keyed by security-session identifiers.
+
+The Go implementation does not implement UDP transport, and modern
+HTCondor deployments increasingly disable it (`noUDP`, §3.1). UDP
+framing is therefore not specified further in this document.
+
+## 1.7 Implementation Differences
+
+| Aspect | C++ | Go |
+|---|---|---|
+| UDP (SafeSock) | yes | no |
+| Legacy MAC header ("MD" mode) | yes | not implemented (`stream.go:83` TODO) |
+| Frame flush threshold | 4 KiB buffer | 16 KiB target frame |
+| Max frame payload | 1 MiB | 1 MiB |
+| Bounded-size string reads | encrypted strings capped at 10 MB | explicit `GetStringWithMaxSize` |

--- a/cedar-rfc/02-serialization.md
+++ b/cedar-rfc/02-serialization.md
@@ -1,0 +1,207 @@
+# Chapter 2. Serialization of Complex Objects
+
+The composite data structure of the HTCondor ecosystem is the
+**ClassAd**: an unordered set of `name = expression` pairs, where
+expressions belong to the ClassAd language (literals, attribute
+references, operators, function calls, lists, and nested record
+expressions). CEDAR does not define a binary encoding for the ClassAd
+expression tree; instead, each attribute is shipped as *text* in the
+"old ClassAds" syntax, wrapped in the primitive encodings of Chapter 1.
+
+Implementations: `src/condor_utils/classad_oldnew.cpp` (C++),
+`golang-cedar/message/classad.go` with the expression language in
+`golang-classads/` (Go).
+
+## 2.1 Wire Format of a ClassAd
+
+A ClassAd is serialized as (`classad_oldnew.cpp:590-901`,
+`classad.go:94-186`):
+
+```
+classad :=
+    int64   numExprs                 ; number of attribute strings that follow
+    attr*   numExprs attributes
+    string  MyType                   ; usually ""
+    string  TargetType               ; usually ""
+
+attr :=
+    string  "Name = <expression text>"          ; ordinary attribute
+  | string  "ZKM" , secret "Name = <expr text>" ; secret attribute (§2.4)
+```
+
+- `numExprs` is a CEDAR integer (8 bytes, big-endian). Receivers MUST
+  bound it; the C++ receiver rejects counts outside 0…1,000,000.
+- Each attribute is a single CEDAR string of the exact form
+  `Name` + `" = "` (space, equals, space) + the unparsed expression.
+- The two trailing type strings are always present unless the peer
+  agreed to the `NO_TYPES` option (§2.5); in modern usage both are
+  empty strings.
+
+Example — the byte sequence for `[ JobId = 1; Priority = 0 ]` on a
+plaintext channel:
+
+```
+00 00 00 00 00 00 00 02                          numExprs = 2
+4A 6F 62 49 64 20 3D 20 31 00                    "JobId = 1\0"
+50 72 69 6F 72 69 74 79 20 3D 20 30 00           "Priority = 0\0"
+00                                               MyType = ""
+00                                               TargetType = ""
+```
+
+If the sending ClassAd is *chained* to a parent ad (C++ feature), the
+parent's attributes are serialized first and the child's attributes
+follow, overriding duplicates by name at the receiver.
+
+## 2.2 Expression Text
+
+The expression portion is produced by the ClassAd unparser and parsed by
+the ClassAd parser on receipt. The forms relevant to interoperability:
+
+- **Booleans:** `true` / `false` (case-insensitive on input).
+- **Integers:** optional sign followed by decimal digits, e.g. `-30`.
+- **Reals:** decimal or scientific notation, e.g. `1.5`, `1.23e10`.
+  (Note: as expression *text*; the binary float encoding of §1.3.3 is
+  not used inside ClassAds.)
+- **Strings:** double-quoted with backslash escapes
+  (`\"`, `\\`, `\n`, `\r`, `\t`, …).
+- **Lists:** `{ expr, expr, ... }`.
+- **Nested ClassAds:** `[ name = expr; name = expr; ... ]` — carried as
+  text inside the parent attribute's string; nesting does not introduce
+  additional wire structure.
+- **Arbitrary expressions:** transmitted verbatim, e.g.
+  `Requirements = (Memory >= 1024) && (Cpus > 0)`.
+
+Both implementations include a "fast path" that recognizes simple
+literals (booleans, integers, reals, short quoted strings without
+escapes) without invoking the full parser
+(`classad_oldnew.cpp:378-408`, `classad.go:320-363`); this is an
+optimization and MUST NOT change the accepted language.
+
+## 2.3 Special Attributes
+
+- **`ServerTime`** — when the sender requests the `SERVER_TIME` option,
+  an attribute `ServerTime = <unix-seconds>` is counted in `numExprs`
+  and sent first (`classad_oldnew.cpp:749-752`, `classad.go:136-140`).
+  It lets the receiver estimate clock skew relative to the sender.
+
+## 2.4 Secret (Private) Attributes
+
+Some attributes carry capabilities that must not appear in cleartext
+even when the channel as a whole is unencrypted (e.g. a startd claim
+identifier). Two generations of policy identify them
+(`classad_oldnew.cpp:698-816`, `classad.go:62-89`):
+
+- **V1:** a fixed name list — `Capability`, `ClaimId`, `ClaimIds`,
+  `ClaimIdList`, `ChildClaimIds`, `TransferKey`.
+- **V2:** any attribute whose name begins with `_condor_priv`
+  (case-insensitive), plus any names the caller explicitly designates.
+
+When the stream has a usable key and the attribute is private, the
+sender emits the marker string `"ZKM"` (a normal CEDAR string,
+`5A 4B 4D 00`) in place of the attribute, immediately followed by the
+`"Name = value"` string sent as a **secret** — i.e. encrypted with the
+channel key even if bulk encryption is off, and therefore
+length-prefixed per §1.3.4. A receiver that sees `ZKM` MUST decrypt the
+next string and parse it as the real attribute. The `ZKM` marker string
+itself counts as the attribute's slot in `numExprs`.
+
+If no key is available, the sender either transmits the attribute in
+cleartext or omits private attributes entirely (the `NO_PRIVATE`
+option). Senders SHOULD omit V2 private attributes when talking to
+peers older than HTCondor 9.9.0, which do not understand them.
+
+The Go implementation currently *detects* private attributes and
+supports attribute whitelisting, but does not yet emit the `ZKM`
+encrypted form (`classad.go:154`, TODO).
+
+## 2.5 Serialization Options
+
+The following sender options change the wire image and therefore must be
+consistent with the receiver's expectations (`classad_oldnew.h:36-80`):
+
+| Option | Effect on the wire |
+|---|---|
+| `NO_PRIVATE` | private attributes omitted |
+| `NO_TYPES` | trailing `MyType`/`TargetType` strings omitted (receiver must use the matching option) |
+| `SERVER_TIME` | prepends the `ServerTime` attribute (§2.3) |
+| `NON_BLOCKING` | sender-side buffering only; no wire change |
+| whitelist | only listed attributes (plus, by default, attributes referenced by their expressions) are serialized |
+
+Receiver-side options (`GET_CLASSAD_FAST`, `LAZY_PARSE`, `NO_CACHE`,
+`NO_CLEAR`) affect only local parsing behavior.
+
+## 2.6 Pre-Trust ClassAds: the "POD" Form
+
+During the security handshake (Chapter 4), ClassAds are exchanged before
+the peer is authenticated. For this purpose the C++ implementation
+provides `getPODClassAd` ("plain old data",
+`classad_oldnew.cpp:114-199`), which accepts the same wire format but
+with a restricted grammar:
+
+- at most **100** attributes;
+- attribute values MUST be literals (booleans, integers, reals,
+  strings) — expressions, lists, nested ads, and function calls are
+  rejected.
+
+Handshake implementations MUST apply equivalent restrictions when
+parsing pre-authentication ads; the Go implementation enforces size
+bounds via `GetClassAdWithMaxSize` (`classad.go:197-287`).
+
+## 2.7 Worked Example: A Machine Ad
+
+A slot ad as a collector might return it, with non-empty type strings
+and a mix of value kinds:
+
+```
+Name         = "slot1@worker-01.example.net"
+OpSys        = "LINUX"
+Memory       = 2048
+Requirements = (Memory >= 1024) && (Cpus > 0)
+```
+
+serializes (plaintext channel) as:
+
+```
+00 00 00 00 00 00 00 04                           numExprs = 4
+4E 61 6D 65 20 3D 20 22 73 6C 6F 74 31 40 …  22 00
+                    "Name = \"slot1@worker-01.example.net\"\0"
+4F 70 53 79 73 20 3D 20 22 4C 49 4E 55 58 22 00
+                    "OpSys = \"LINUX\"\0"
+4D 65 6D 6F 72 79 20 3D 20 32 30 34 38 00
+                    "Memory = 2048\0"
+52 65 71 75 69 72 65 6D 65 6E 74 73 20 3D 20 28 …  29 00
+                    "Requirements = (Memory >= 1024) && (Cpus > 0)\0"
+4D 61 63 68 69 6E 65 00                           MyType = "Machine"
+4A 6F 62 00                                       TargetType = "Job"
+```
+
+Every attribute — including the integer and the boolean expression — is
+carried as expression *text* inside a CEDAR string; the quotes around
+`slot1@…` and `LINUX` are part of that text (ClassAd string literals),
+while `2048` and the `Requirements` expression are unquoted.
+
+The same ad including a V1 secret attribute `ClaimId` on a stream that
+holds a key but has bulk encryption off (§2.4) would carry `numExprs = 5`
+and, in place of the fifth attribute string:
+
+```
+5A 4B 4D 00                                       marker string "ZKM"
+00 00 00 00 00 00 00 2C                           secret length = 44 (example)
+xx × 44                                           ciphertext of
+                                                  "ClaimId = \"<10.0.0.17:9618>#1719…#42…\"\0"
+```
+
+— i.e. the secret is a length-prefixed encrypted string (§1.3.4), and
+the `ZKM` marker occupies the attribute's slot in the count.
+
+## 2.8 Other Composite Values
+
+CEDAR has no other framed container types. Ad-hoc composites in the
+protocols of Chapters 3–5 are built directly from primitives, e.g.
+"length integer followed by raw bytes" for cryptographic material, or
+comma/space-separated items inside a single string (method lists,
+`ValidCommands`, CCB contact lists). ClassAd *lists of ads* are sent as
+an integer count followed by that many serialized ClassAds, typically
+with a leading command integer (collector query responses).
+
+There is no compression at any CEDAR layer.

--- a/cedar-rfc/03-transport.md
+++ b/cedar-rfc/03-transport.md
@@ -1,0 +1,333 @@
+# Chapter 3. Transport over TCP: Addresses, Shared Port, and CCB
+
+A CEDAR endpoint is named by a textual address (the *sinful string*).
+Reaching the daemon behind that address may involve up to three
+mechanisms, composable with one another:
+
+1. a **direct TCP connection** to the given host and port;
+2. the **Shared Port** protocol, when many daemons on one host share a
+   single listening port (`sock=` parameter);
+3. the **Condor Connection Broker (CCB)**, when the daemon cannot accept
+   inbound connections at all and instead connects *out* to a broker
+   (`ccbid=` parameter).
+
+Implementations: `src/condor_utils/condor_sinful.cpp`,
+`src/condor_io/shared_port_{client,server}.cpp`, `src/ccb/` (C++);
+`golang-cedar/addresses/`, `golang-cedar/client/sharedport/`,
+`golang-cedar/ccb/`, `golang-ccb/` (Go).
+
+## 3.1 Sinful Strings
+
+```
+sinful  := "<" address [ ":" port ] [ "?" params ] ">"
+address := IPv4-literal | hostname | "[" IPv6-literal "]"
+params  := param *( ("&" | ";") param )
+param   := key "=" value          ; value is percent-encoded
+```
+
+Examples:
+
+```
+<128.104.100.22:9618>
+<[2607:f388::1]:9618?alias=cm.example.edu>
+<128.104.100.22:9618?sock=schedd_1234&PrivNet=cluster>
+<192.0.2.1:9618?ccbid=203.0.113.5:9618%23742&sock=startd>
+```
+
+Percent-encoding covers all octets except alphanumerics and
+`. _ - : # [ ] +`; `%XX` is a two-hex-digit escape and `+` is a literal
+plus (path-style, not form-style, decoding).
+(`condor_sinful.cpp:194-248`, `addresses/sinful.go:143-163`)
+
+Recognized parameters:
+
+| Key | Meaning |
+|---|---|
+| `sock` | shared-port identifier of the daemon behind a shared port (§3.3) |
+| `ccbid` | space-separated list of CCB contacts, each `broker-address#ccbid` (§3.4); presence means "connect via CCB" |
+| `addrs` | additional literal addresses: `ip-port` pairs joined by `+`, e.g. `addrs=192.0.2.1-9618+[2001:db8::1]-9618`; used for dual-stack IPv4/IPv6 |
+| `alias` | hostname alias, used for certificate/host verification |
+| `PrivAddr` | alternative (percent-encoded) sinful string usable within the named private network |
+| `PrivNet` | private-network name qualifying `PrivAddr` |
+| `noUDP` | flag: the daemon does not accept UDP |
+
+### 3.1.1 Address Selection
+
+A client resolves a sinful string as follows
+(`golang-cedar/client/client.go:99-168`, `src/condor_io/sock.cpp`
+`special_connect`):
+
+1. If `ccbid` is present (and the client is not on the daemon's private
+   network), connect via CCB (§3.4).
+2. Otherwise, if `sock` is present, connect to the host/port and run the
+   Shared Port protocol (§3.3).
+3. Otherwise, connect directly. When `addrs` lists multiple address
+   families, the C++ client tries candidates in configured preference
+   order; the Go client races IPv6 and IPv4 ("happy eyeballs") with a
+   150 ms fallback delay.
+
+A daemon on the same host as a shared-port daemon may combine cases:
+CCB brokers and their registered daemons are themselves frequently
+behind shared ports, in which case the `ccbid` broker address or the
+reverse connection target may in turn contain `sock=`.
+
+## 3.2 Direct TCP Connections
+
+There is no preamble, banner, or version exchange at the transport
+level. The first bytes sent by the client are a CEDAR frame whose
+payload begins with a command integer (Chapter 4). Version and feature
+negotiation happen inside the command protocol.
+
+## 3.3 The Shared Port Protocol
+
+One daemon per host (`condor_shared_port`) owns the well-known TCP port
+and hands accepted connections to the intended local daemon over a UNIX
+domain socket. Each local daemon registers under a **shared port ID**
+(the `sock=` value; matching `[A-Za-z0-9._-]+`).
+
+### 3.3.1 Client → Shared Port Daemon
+
+Immediately after connecting, the client sends one CEDAR message
+(`shared_port_client.cpp:100-176`,
+`client/sharedport/sharedport.go:113-150`):
+
+```
+int64   SHARED_PORT_CONNECT (= 75)
+string  shared_port_id            ; e.g. "schedd_1234"
+string  client_name               ; free-form, for logging only
+int64   deadline                  ; seconds the client will wait; -1 = none
+int64   more_args                 ; 0 (reserved for extensions)
+<end of message>
+```
+
+There is **no reply**. On success, the next bytes the client sends and
+receives travel to and from the target daemon; on failure the shared
+port daemon simply closes the connection. If `more_args` is nonzero, a
+receiver MUST read and discard that many additional values (currently
+always 0).
+
+The special ID `"self"` addresses the shared port daemon itself.
+
+Because the target daemon never sees the `SHARED_PORT_CONNECT` message,
+a client that maintains the pre-encryption transcript digest of §1.4.2
+MUST reset the digest after sending this message (unless connecting to
+`"self"`), so that both ends of the eventual daemon-to-client channel
+digest the same bytes (`shared_port_client.cpp:168-172`).
+
+### 3.3.2 Shared Port Daemon → Target Daemon (Host-Local)
+
+The handoff is host-local and OS-specific rather than a network
+protocol; it is described for completeness
+(`shared_port_endpoint.cpp`, `client/sharedport/endpoint_protocol.go`):
+the shared port daemon connects to the target's UNIX domain socket,
+sends the one-value CEDAR message
+
+```
+int64   SHARED_PORT_PASS_SOCK (= 76)
+<end of message>
+```
+
+and then transfers the connected TCP file descriptor with
+`sendmsg(2)`/`SCM_RIGHTS` (one dummy payload byte). No acknowledgment
+is sent.
+
+## 3.4 The Condor Connection Broker (CCB)
+
+CCB inverts connection direction for daemons that can make outbound
+connections but not accept inbound ones. Three parties participate:
+
+- the **target daemon** (e.g. a startd behind NAT), which registers with
+  a broker and keeps a persistent TCP connection to it;
+- the **broker** (CCB server, usually co-located with the collector);
+- the **client** (e.g. a schedd) that wants to reach the target.
+
+All CCB payloads are ClassAds (Chapter 2), sent over ordinary CEDAR
+command connections with the usual security handshake (Chapter 4).
+Command numbers: `CCB_REGISTER` = 67, `CCB_REQUEST` = 68,
+`CCB_REVERSE_CONNECT` = 69 (`condor_commands.h:885-889`,
+`golang-cedar/commands/commands.go:222-224`).
+
+### 3.4.1 Registration
+
+The target daemon sends `CCB_REGISTER` with:
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `Name` | string | daemon name (logging only) |
+| `CCBID` | string | (reconnect only) previously assigned contact |
+| `ClaimId` | string | (reconnect only) reconnect cookie from prior registration |
+
+The broker replies on the same connection with:
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `CCBID` | string | contact of the form `broker-address#id`, e.g. `203.0.113.5:9618#742` — note the broker address carries **no** angle brackets; `id` is a decimal unsigned integer |
+| `ClaimId` | string | reconnect cookie: 40 hex characters (20 random bytes) |
+| `Command` | int | echo of `CCB_REGISTER` |
+
+The daemon advertises the returned contact(s) in the `ccbid=` parameter
+of its sinful string. The TCP connection is left open; the broker sends
+periodic keep-alive messages (ClassAds containing `Command = 441`
+(`ALIVE`)) and uses this connection to deliver connect requests. If the
+connection breaks, the daemon re-registers presenting its `CCBID` and
+`ClaimId` to retain the same contact string.
+(`ccb_server.cpp:449-527`, `golang-ccb/server.go:112-250`)
+
+### 3.4.2 Connection Request and Reverse Connect
+
+```
+ Client                        Broker                     Target daemon
+   |                             |     (persistent conn)      |
+   |--- CCB_REQUEST ad --------->|                            |
+   |                             |--- request ad ------------>|
+   |                             |                            |
+   |<========================== TCP connect (reverse) ========|
+   |<-- CCB_REVERSE_CONNECT ad --|---(sent by target)         |
+   |                             |<-- result ad --------------|
+   |<-- reply ad ----------------|                            |
+   |                             |                            |
+   |=== CEDAR command protocol proceeds on reversed socket ===|
+```
+
+**Step 1.** The client, listening on its own address, sends
+`CCB_REQUEST` to the broker:
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `CCBID` | string | target's contact, `broker-address#id` |
+| `MyAddress` | string | client's sinful string, to which the target should connect back |
+| `ClaimId` | string | **connect id**: 40 fresh random hex characters |
+| `Name` | string | client name (logging) |
+
+**Step 2.** The broker forwards a request ad to the target over the
+registration connection, adding `Command = CCB_REQUEST` and a broker-
+assigned decimal `RequestID` (string).
+
+**Step 3.** The target connects to `MyAddress` (a normal CEDAR
+connection, possibly itself via shared port) and sends, as its first
+command, `CCB_REVERSE_CONNECT` (69) followed immediately by a ClassAd —
+no security handshake precedes this command:
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `ClaimId` | string | the connect id from the request — proves this connection answers the client's request |
+| `RequestID` | string | broker request id |
+| `MyAddress` | string | target's own address |
+
+The client MUST verify that `ClaimId` equals the connect id it generated
+in step 1 and MUST otherwise discard the connection.
+
+**Step 4.** The target reports the outcome to the broker (ad with
+`RequestID`, `ClaimId`, `Result` (bool), and `ErrorString` on failure);
+the broker relays `Result`/`ErrorString` to the waiting client.
+
+**Step 5.** The client now treats the reversed socket as if it had
+dialed it: it initiates the ordinary command protocol of Chapter 4
+(including authentication) with the roles it originally intended —
+the *client* remains the security-handshake client even though the TCP
+connection was accepted, not dialed.
+
+Multiple `ccbid` contacts (space-separated) may be listed in a sinful
+string when a daemon registered with several brokers; clients try them
+in order.
+
+### 3.4.3 Authorization
+
+Registration requires the broker's `DAEMON`-level authorization;
+connection requests require `READ`. The connect id in `ClaimId` is the
+only credential linking the reverse connection to the request, so it
+MUST be generated from a cryptographically secure random source and
+MUST be sent only over channels whose confidentiality matches the
+deployment's threat model (the broker necessarily learns it).
+
+### 3.4.4 Worked Example
+
+A startd on `worker-01` (private address `10.0.0.17`, behind NAT)
+registers with a broker at `203.0.113.5:9618`; later a schedd at
+`198.51.100.7:9618` connects to it. The ads below are shown in ClassAd
+text; on the wire each is serialized per Chapter 2.
+
+**Registration.** Startd → broker, command `CCB_REGISTER` (67):
+
+```
+[ Name = "startd worker-01.example.net" ]
+```
+
+Broker → startd, on the same (now persistent) connection:
+
+```
+[ CCBID   = "203.0.113.5:9618#742";
+  ClaimId = "8f3a5b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a";
+  Command = 67 ]
+```
+
+The startd then advertises itself to the collector with a sinful string
+carrying the contact (`#` percent-encoded as `%23`):
+
+```
+<10.0.0.17:9618?ccbid=203.0.113.5:9618%23742&addrs=10.0.0.17-9618>
+```
+
+If the registration connection later breaks, the startd re-registers
+sending all three of `Name`, `CCBID`, and `ClaimId` to keep contact
+`742`.
+
+**Connection request.** The schedd, wanting to reach the startd,
+listens on its own address, generates a fresh connect id, and sends
+`CCB_REQUEST` (68) to the broker:
+
+```
+[ CCBID     = "203.0.113.5:9618#742";
+  MyAddress = "<198.51.100.7:9618?addrs=198.51.100.7-9618>";
+  ClaimId   = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678";
+  Name      = "schedd submit.example.net" ]
+```
+
+The broker forwards over the registration connection:
+
+```
+[ Command   = 68;
+  MyAddress = "<198.51.100.7:9618?addrs=198.51.100.7-9618>";
+  ClaimId   = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678";
+  RequestID = "3151";
+  Name      = "schedd submit.example.net" ]
+```
+
+**Reverse connect.** The startd dials `198.51.100.7:9618` and sends, as
+the first command on that socket, `CCB_REVERSE_CONNECT` (69) followed by:
+
+```
+[ ClaimId   = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678";
+  RequestID = "3151";
+  MyAddress = "<10.0.0.17:9618?ccbid=203.0.113.5:9618%23742&addrs=10.0.0.17-9618>" ]
+```
+
+The schedd checks `ClaimId` against the connect id it generated — a
+match proves this inbound connection answers its request. The startd
+reports back to the broker:
+
+```
+[ Result    = true;
+  RequestID = "3151";
+  ClaimId   = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678" ]
+```
+
+and the broker relays the outcome to the schedd's waiting `CCB_REQUEST`:
+
+```
+[ Result = true ]
+```
+
+(on failure: `[ Result = false; ErrorString = "..." ]`). The schedd now
+runs the normal command protocol (Chapter 4) over the reversed socket,
+acting as the security-handshake client.
+
+## 3.5 Implementation Differences
+
+| Aspect | C++ | Go |
+|---|---|---|
+| Shared port daemon (server side) | yes | no (client-side protocol only) |
+| CCB broker | yes | yes (`golang-ccb`), adds an experimental proxy/streaming mode (`CCBStreamingRequired`/`ProxyMode` attributes) not present in C++ |
+| Broker reconnect-cookie persistence | on disk | pluggable `ReconnectStore` interface |
+| Dual-stack dialing | ordered candidate list | happy-eyeballs race, 150 ms fallback |
+| UDP addressing (`noUDP` relevance) | yes | UDP unsupported |

--- a/cedar-rfc/04-command-protocol.md
+++ b/cedar-rfc/04-command-protocol.md
@@ -1,0 +1,339 @@
+# Chapter 4. The Command Protocol and Security Negotiation
+
+Every CEDAR interaction is a **command**: the client sends an integer
+identifying the requested operation, then a command-specific dialogue
+follows. Modern clients do not send application commands directly;
+they wrap them in the `DC_AUTHENTICATE` handshake, which negotiates
+security policy, authenticates the peers, establishes an AES-256-GCM
+channel key, and creates a resumable **security session** — and only
+then dispatches the real command.
+
+Implementations: `src/condor_daemon_core.V6/daemon_command.cpp` and
+`src/condor_io/condor_secman.cpp` (C++);
+`golang-cedar/security/auth.go` and
+`golang-cedar/security/session_cache.go` (Go).
+
+## 4.1 Command Integers
+
+A command is a CEDAR integer (8 bytes on the wire, §1.3.1). Numbers are
+assigned from a central registry (`condor_commands.h`,
+`golang-cedar/commands/commands.go`). Notable values and ranges:
+
+| Value / range | Purpose |
+|---|---|
+| 0–99 | collector: `UPDATE_STARTD_AD` = 0, `QUERY_STARTD_ADS` = 5, `QUERY_SCHEDD_ADS` = 6, … |
+| 67–69 | CCB: register / request / reverse-connect (§3.4) |
+| 75, 76 | shared port: connect / pass-socket (§3.3) |
+| 400–499 | schedd/negotiator (`SCHED_VERS` base) |
+| 441 | `ALIVE` keep-alive |
+| 1111, 1112 | schedd queue management (`QMGMT_READ_CMD`, `QMGMT_WRITE_CMD`) |
+| 60000–60099 | DaemonCore: `DC_AUTHENTICATE` = **60010**, `DC_NOP` = 60011, `DC_NOP_READ` = 60020, `DC_NOP_WRITE` = 60021, `DC_SEC_QUERY` = 60040, … |
+| 61000+ | file transfer |
+| 75000+ | credd |
+
+Each registered command has an associated **authorization level**
+(READ, WRITE, DAEMON, ADMINISTRATOR, NEGOTIATOR, …) that the server
+enforces after authentication.
+
+## 4.2 Connection Outline
+
+```
+Client                                                     Server
+  | ---- int64 DC_AUTHENTICATE (60010) ------------------->  |
+  | ---- ClassAd: client security policy ---- <EOM> ------>  |   cleartext
+  | <--- ClassAd: server security policy ---- <EOM> ------   |   cleartext
+  |                                                          |
+  | <=== authentication method loop (Chapter 5) ==========>  |   cleartext*
+  |                                                          |
+  |      [both sides derive/obtain 32-byte session key]      |
+  |      [AES-256-GCM enabled; transcript digests bound]     |
+  |                                                          |
+  | <--- ClassAd: post-auth response --------- <EOM> ------  |   encrypted
+  |                                                          |
+  | ---- real command payload ---------------------------->  |   encrypted
+```
+
+\* individual mechanisms may tunnel their own cryptography (e.g. TLS)
+inside this phase.
+
+A *legacy* client may still send a bare application command integer with
+no `DC_AUTHENTICATE` wrapper; the connection then proceeds without
+authentication or encryption, subject to server policy. New
+implementations MUST use the wrapped form.
+
+## 4.3 The Client Security Policy Ad
+
+The ad following `DC_AUTHENTICATE` is a "POD" ClassAd (§2.6) carrying
+(`auth.go:759-830`, attribute names from
+`condor_attributes.h:1038-1089`):
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `Command` | int | the real command the client intends to execute |
+| `AuthCommand` | int | for `DC_SEC_QUERY`: the command whose authorization is being probed |
+| `AuthMethods` | string | comma-separated authentication methods offered, in preference order, e.g. `"IDTOKENS,SSL,FS"` |
+| `CryptoMethods` | string | crypto methods offered, e.g. `"AES"` (legacy names may also appear; out of scope) |
+| `Authentication` | string | `REQUIRED` \| `PREFERRED` \| `OPTIONAL` \| `NEVER` |
+| `Encryption` | string | same four-valued scale |
+| `Integrity` | string | same four-valued scale (with AES-GCM, integrity is inherent in encryption) |
+| `Enact` | string | `NO` during negotiation |
+| `NewSession` | string | `YES` — full handshake requested |
+| `SessionDuration` | int | requested session lifetime, seconds |
+| `SessionLease` | int | requested lease, seconds |
+| `ECDHPublicKey` | string | base64 of the client's ephemeral ECDH P-256 public key (65-byte uncompressed point, leading `0x04`) |
+| `NegotiatedSession` | bool | `true` (marks the modern protocol) |
+| `RemoteVersion` | string | client's version string, `"$CondorVersion: …"` |
+| `TrustDomain` | string | client's token trust domain |
+| `Subsystem`, `ServerPid`, `Sid`, … | | informational |
+
+## 4.4 The Server Response Ad
+
+The server reconciles the client's ad with its own policy and replies
+(cleartext) with (`auth.go:930-997`):
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `AuthMethodsList` | string | full list of methods the server can accept, in server preference order |
+| `AuthMethods` | string | single selected method (kept for pre-list peers) |
+| `CryptoMethodsList` / `CryptoMethods` | string | ditto for crypto |
+| `Authentication` | string | `YES` \| `NO` — will authentication occur |
+| `Encryption` | string | `YES` \| `NO` |
+| `Integrity` | string | `YES` \| `NO` |
+| `Enact` | string | `YES` — parameters are final |
+| `ECDHPublicKey` | string | server's ephemeral P-256 public key |
+| `SessionDuration`, `SessionLease` | int | server's decision |
+| `RemoteVersion`, `TrustDomain` | string | server's values |
+
+Clients MUST prefer `AuthMethodsList`/`CryptoMethodsList` when present
+and fall back to the singular attributes for older peers
+(`auth.go:832-879`).
+
+**Policy reconciliation.** Each feature (authentication, encryption,
+integrity) is decided from the two four-valued preferences: if either
+side says `NEVER` while the other says `REQUIRED`, negotiation fails;
+`NEVER` beats `OPTIONAL`/`PREFERRED`; the feature is enabled iff at
+least one side requires it or both prefer it. The method actually used
+is the first entry of the *server's* preference list also offered by the
+client (`auth.go:1293-1399`, `condor_secman.cpp`
+`ReconcileSecurityPolicyAds`).
+
+## 4.5 Authentication Phase
+
+If authentication was enabled, the negotiation of Chapter 5 now runs:
+an exchange of method bitmasks and mechanism-specific sub-protocols that
+yields (a) a mutually authenticated identity for the client and (b),
+for most mechanisms, a mechanism-derived key. This phase is still
+carried in cleartext CEDAR frames unless the mechanism itself provides
+cryptography (TLS-based methods).
+
+## 4.6 Key Agreement and Channel Activation
+
+When both sides advertised `ECDHPublicKey` and negotiated the `AES`
+crypto method, the channel key is derived by ephemeral Elliptic-Curve
+Diffie-Hellman over P-256 followed by HKDF-SHA256
+(`auth.go:1534-1615`):
+
+```
+shared_secret = ECDH(own_private, peer_public)          // P-256
+key           = HKDF-SHA256(ikm  = shared_secret,
+                            salt = "htcondor",
+                            info = "keygen",
+                            len  = 32)
+```
+
+The 32-byte key becomes the AES-256-GCM key for the frame protection of
+§1.4. Public keys are the raw 65-byte uncompressed points, base64
+encoded, exchanged inside the policy ads of §§4.3–4.4; the Go
+implementation additionally accepts DER-encoded points for
+compatibility.
+
+Because the ECDH exchange itself is unauthenticated, its result is
+trustworthy only in combination with (a) the authentication phase and
+(b) the transcript binding of §1.4.2, which folds the byte-exact
+handshake (including both public keys and the negotiated parameters)
+into the AAD of the first encrypted frame in each direction. A
+downgrade or key-substitution attack therefore causes the first
+encrypted frame to fail authentication.
+
+For legacy peers without ECDH support, the mechanism-derived key from
+the authentication phase is transported by the mechanism's own key
+exchange (§5.7) and used directly; details of the legacy ciphers keyed
+this way are out of scope.
+
+After key establishment both sides enable encryption; **everything from
+the post-auth ad onward is inside AES-GCM protected frames**, including
+the real command's entire dialogue.
+
+## 4.7 The Post-Auth Response Ad
+
+The server sends one final (encrypted) ad (`auth.go:1000-1063`):
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `ReturnCode` | string | `"AUTHORIZED"` on success |
+| `User` | string | the client's canonical identity as mapped by the server, `user@domain` |
+| `Sid` | string | the new session's identifier |
+| `ValidCommands` | string | comma-separated command integers this session may execute without re-authenticating |
+| `SessionDuration` | int | granted lifetime, seconds (typical default 3600) |
+| `SessionLease` | int | granted lease, seconds (typical default 1800) |
+
+The client then proceeds with the payload of the command named in its
+policy ad's `Command` attribute, exactly as if it had sent that command
+integer on a raw connection.
+
+## 4.8 Security Sessions and Resumption
+
+Both sides cache the negotiated state as a **session**
+(`session_cache.go:19-31`): the session id, the peer address, the key
+(`KeyInfo`: 32 key bytes + protocol name, e.g. `"AES"`), a policy
+snapshot (negotiated method, the authenticated `User`, peer version),
+an expiration (`SessionDuration`) and a lease. Clients index sessions
+by `(peer address, command)` using `ValidCommands`. A session whose
+lease keeps being renewed by use remains valid until its duration
+expires.
+
+**Resumption.** To reuse a session on a new TCP connection, the client
+sends `DC_AUTHENTICATE` with a short ad:
+
+```
+Command        = <real command>
+UseSession     = "YES"
+Sid            = "<cached session id>"
+ResumeResponse = true
+RemoteVersion  = "..."
+```
+
+If the server still holds the session it replies
+`ReturnCode = "AUTHORIZED"` (with the `Sid`), both sides install the
+cached key, enable AES-GCM immediately, and the command proceeds — no
+authentication loop, no ECDH. If not, it replies
+`ReturnCode = "SID_NOT_FOUND"`; the client MUST discard its cached
+session and restart with a full `NewSession` handshake
+(`auth.go:1184-1215, 604-618`).
+
+Sessions may also be *injected* out of band: a parent daemon passes
+sessions to children via the `CONDOR_PRIVATE_INHERIT` environment (both
+implementations), and higher-level protocols (e.g. the negotiator
+handing a schedd a claim) embed session keys in ClassAd secrets. Such
+sessions behave exactly like negotiated ones on the wire.
+
+There is no explicit invalidation command in the current protocol
+(`DC_INVALIDATE_KEY` exists in the historical registry but is unused);
+stale sessions are handled by the `SID_NOT_FOUND` fallback.
+
+## 4.9 UDP Commands (C++ Only)
+
+Over UDP, there is no room for a handshake: a datagram carries a
+cleartext session id in its extension header (§1.6), and the payload is
+protected with the keys of that previously established (over TCP)
+session. A datagram naming an unknown session is dropped. The Go
+implementation omits UDP entirely.
+
+## 4.10 `DC_SEC_QUERY`
+
+`DC_SEC_QUERY` (60040) is a diagnostic command: the client runs the
+normal handshake with `AuthCommand` naming a target command, and the
+server answers whether the authenticated identity would be authorized
+for it, without executing anything.
+
+## 4.11 Worked Example
+
+A `condor_status`-style client queries a collector for slot ads
+(`QUERY_STARTD_ADS` = 5). Ads are shown as ClassAd text; on the wire
+each is serialized per Chapter 2 inside the frames of Chapter 1.
+
+**1. Client → server** (cleartext): the integer `60010`
+(`DC_AUTHENTICATE`), then the policy ad:
+
+```
+[ Command            = 5;
+  AuthMethods        = "IDTOKENS,FS";
+  CryptoMethods      = "AES";
+  Authentication     = "REQUIRED";
+  Encryption         = "PREFERRED";
+  Integrity          = "PREFERRED";
+  Enact              = "NO";
+  NewSession         = "YES";
+  NegotiatedSession  = true;
+  SessionDuration    = 3600;
+  SessionLease       = 1800;
+  ECDHPublicKey      = "BGb2…kA==";        # base64, 65-byte P-256 point
+  RemoteVersion      = "$CondorVersion: 25.4.0 2026-06-01 $";
+  TrustDomain        = "example.net";
+  Subsystem          = "TOOL" ]
+```
+
+**2. Server → client** (cleartext), after reconciling with its own
+policy (server prefers SSL but accepts IDTOKENS; requires
+authentication and encryption):
+
+```
+[ AuthMethodsList    = "SSL,IDTOKENS,FS";
+  AuthMethods        = "SSL";
+  CryptoMethodsList  = "AES";
+  CryptoMethods      = "AES";
+  Authentication     = "YES";
+  Encryption         = "YES";
+  Integrity          = "YES";
+  Enact              = "YES";
+  SessionDuration    = 3600;
+  SessionLease       = 1800;
+  ECDHPublicKey      = "BJ9x…Qw==";
+  RemoteVersion      = "$CondorVersion: 25.4.0 2026-06-01 $";
+  TrustDomain        = "example.net" ]
+```
+
+**3. Authentication loop** (cleartext): the client offers
+IDTOKENS + FS, the server selects IDTOKENS, and the AKEP2 exchange
+authenticates both parties — see the worked example in §5.9.
+
+**4. Key agreement:** both sides compute
+`HKDF-SHA256(ECDH(priv, peer_pub), "htcondor", "keygen")` → 32-byte
+AES-256-GCM key, and enable frame encryption. The first encrypted frame
+in each direction carries the transcript-digest AAD of §1.4.2, sealing
+steps 1–3 against tampering.
+
+**5. Server → client** (encrypted), the post-auth ad:
+
+```
+[ ReturnCode      = "AUTHORIZED";
+  User            = "bbockelm@example.net";
+  Sid             = "worker:3145:1782115200:42";
+  ValidCommands   = "5,6,50,51";
+  SessionDuration = 3600;
+  SessionLease    = 1800 ]
+```
+
+**6. The real command proceeds** (encrypted): the client does **not**
+resend the command integer — the server already dispatched on
+`Command = 5` — it sends the query's payload directly (for this command,
+a constraint ClassAd), and the collector streams back matching machine
+ads.
+
+**Resumption.** For its next query the client opens a new TCP
+connection and sends `60010` plus only:
+
+```
+[ Command        = 5;
+  UseSession     = "YES";
+  Sid            = "worker:3145:1782115200:42";
+  ResumeResponse = true;
+  RemoteVersion  = "$CondorVersion: 25.4.0 2026-06-01 $" ]
+```
+
+The server finds the session, replies
+`[ ReturnCode = "AUTHORIZED"; Sid = "worker:3145:1782115200:42" ]`,
+both sides install the cached AES key and enable encryption at once,
+and step 6 repeats with no authentication or ECDH. Had the server
+restarted, the reply would be `[ ReturnCode = "SID_NOT_FOUND" ]` and
+the client would fall back to the full handshake above.
+
+## 4.12 Implementation Differences
+
+| Aspect | C++ | Go |
+|---|---|---|
+| UDP command protocol | yes | no |
+| Legacy MAC/integrity modes | yes | integrity only via AES-GCM |
+| Session persistence | in-memory + daemon inheritance | in-memory + inheritance (`SetInherited`) |
+| Policy configuration | extensive `SEC_*` knobs per access level | programmatic `SecurityConfig` |
+| Post-auth authorization mapping | unified map file + per-command auth levels | pluggable `PostAuthPolicy` callback |

--- a/cedar-rfc/05-authentication.md
+++ b/cedar-rfc/05-authentication.md
@@ -1,0 +1,472 @@
+# Chapter 5. Authentication Protocols
+
+This chapter specifies the authentication phase of the command protocol
+(§4.5): the method negotiation loop and the individual mechanisms.
+Focus is on the mechanisms implemented in **both** the C++ and Go
+codebases: **TOKEN/IDTOKENS** and **PASSWORD** (a shared AKEP2 core),
+**SSL**, **SCITOKENS**, **FS**/**FS_REMOTE**, and **CLAIMTOBE**.
+
+Implementations: `src/condor_io/authentication.cpp` and
+`src/condor_io/condor_auth_*.cpp` (C++);
+`golang-cedar/security/{auth,token_auth,ssl_auth,fs_auth}.go` (Go).
+
+## 5.1 Method Identifiers
+
+Methods are named by strings in the policy ads (§4.3) and by bit values
+in the negotiation loop (`condor_auth.h`, `auth.go:61-78`):
+
+| Name | Bit | In C++ | In Go |
+|---|---:|---|---|
+| `CLAIMTOBE` | 2 | yes | yes |
+| `FS` | 4 | yes | yes |
+| `FS_REMOTE` | 8 | yes | yes |
+| `NTSSPI` | 16 | Windows only | no |
+| `KERBEROS` | 64 | yes | no |
+| `ANONYMOUS` | 128 | yes | no |
+| `SSL` | 256 | yes | yes |
+| `PASSWORD` | 512 | yes | yes |
+| `MUNGE` | 1024 | yes | no |
+| `TOKEN` / `IDTOKENS` | 2048 | yes | yes |
+| `SCITOKENS` | 4096 | yes | yes |
+
+## 5.2 The Method Negotiation Loop
+
+After the policy ads are exchanged, the client and server agree on a
+mechanism by exchanging integers
+(`authentication.cpp:949-1098`, `auth.go:1811-2038`):
+
+```
+repeat:
+  Client -> Server : int64 bitmask of methods the client can still try   <EOM>
+  Server -> Client : int64 single selected method bit, or 0              <EOM>
+```
+
+- The client's first bitmask is the OR of the methods it offered that
+  also appear in the server's list (and whose local prerequisites —
+  credentials, key files — are satisfied).
+- The server picks the **first method in its own preference order**
+  whose bit is set, and echoes exactly that bit. `0` means "nothing
+  acceptable" and aborts authentication.
+- The selected mechanism's sub-protocol (§§5.3–5.6) then runs. On
+  failure, the client clears that method's bit and loops; sending a
+  bitmask of `0` abandons authentication. On success the loop ends.
+
+The result of a successful mechanism is the client's **authenticated
+name** (mechanism-specific, e.g. a certificate subject or token
+subject). The server maps it to a canonical `user@domain` via its map
+file/policy; only the mapped result is wire-visible, in the post-auth
+ad's `User` attribute (§4.7).
+
+## 5.3 TOKEN / IDTOKENS and PASSWORD (AKEP2)
+
+`PASSWORD` (protocol version 1) and `TOKEN` (version 2) share one
+sub-protocol: AKEP2 (Bellare–Rogaway Authenticated Key Exchange
+Protocol 2), instantiated with HMAC-SHA256
+(`condor_auth_passwd.cpp:57-98`, `token_auth.go`). They differ only in
+where the shared secret comes from:
+
+- **PASSWORD:** both sides hold the *pool password*; the secret is the
+  password concatenated with itself.
+- **TOKEN:** the client holds an **IDTOKEN** — a JWT signed with
+  HMAC-SHA-256/384/512 — and the server holds the *pool signing key*
+  from which the JWT's signature can be recomputed. The JWT's claims:
+  `sub` (client identity), `iss` (trust domain), `iat`, optional `exp`,
+  `jti`, optional `scope` (authorization limits), and header `kid`
+  naming the signing key. The signing key for `kid` is stretched as
+  `jwt_key = HKDF-SHA256(master_key, salt="htcondor", info="master jwt")`
+  and the JWT signature is `HMAC(header.payload, jwt_key)`.
+
+### 5.3.1 Key Derivation
+
+Let `S` be the shared secret (doubled pool password, or the JWT
+signature). Two 256-byte protocol constants `seed_ka`, `seed_kb` are
+fixed by the implementations (`condor_auth_passwd.cpp:1077-1140`,
+`token_auth.go:513-540`). For TOKEN, let `T` be the transmitted token
+content `base64url(header) "." base64url(payload)` (no signature).
+
+```
+version 1 (PASSWORD):  K  = HMAC-SHA256(seed_ka, S)
+                       K' = HMAC-SHA256(seed_kb, S)
+version 2 (TOKEN):     K  = HKDF-SHA256(ikm=S, salt=seed_ka || T, info="master ka", len=32)
+                       K' = HKDF-SHA256(ikm=S, salt=seed_kb || T, info="master kb", len=32)
+```
+
+`K` keys the AKEP2 MACs; `K'` keys the session-key derivation.
+
+### 5.3.2 Message Exchange
+
+Let `A` be the client identity string (e.g. `user@trust.domain`), `B`
+the server identity (`condor@trust.domain`), and `rA`, `rB` 256-byte
+random nonces. Every variable-length field is sent as an integer length
+followed by the bytes. Three CEDAR messages
+(`condor_auth_passwd.cpp:2932-3128`, `token_auth.go:544-799`):
+
+```
+Msg 1  Client -> Server:
+    int64  status            ; 0 = AUTH_PW_A_OK, -1 = error
+    int64  len(A),  bytes A
+    string T                  ; version 2 only: JWT header.payload
+    int64  len(rA), bytes rA
+    <EOM>
+
+Msg 2  Server -> Client:
+    int64  status
+    int64  len(A),  bytes A       ; echo
+    int64  len(B),  bytes B
+    int64  len(rA), bytes rA      ; echo
+    int64  len(rB), bytes rB
+    int64  len(mac1), bytes mac1  ; mac1 = HMAC-SHA256(K, B || A || rA || rB)
+    <EOM>
+
+Msg 3  Client -> Server:
+    int64  status
+    int64  len(A),  bytes A       ; echo
+    int64  len(rB), bytes rB      ; echo
+    int64  len(mac2), bytes mac2  ; mac2 = HMAC-SHA256(K, A || rB)
+    <EOM>
+```
+
+The client verifies `mac1` (proving the server knows `K`, hence the
+password / signing key) before sending Msg 3; the server verifies
+`mac2` (proving the client knows `K`, hence for TOKEN a validly signed
+JWT — the server recomputed the signature from `T` and its `kid`).
+Either side aborts by sending a negative `status`. The server
+additionally validates the JWT claims: `iss` must match its trust
+domain, `exp` must not have passed, and `sub` becomes the authenticated
+name (subject to `scope` restrictions).
+
+### 5.3.3 Session Key
+
+Both sides derive the mechanism session key `W` from `rB`:
+
+```
+version 1:  W = HMAC-SHA256(K', rB)
+version 2:  W = HKDF-SHA256(ikm=rB, salt=K', info="session key", len=32)
+```
+
+(`condor_auth_passwd.cpp:3218-3226`, `token_auth.go:796-850`.) `W`
+seeds the channel key when ECDH (§4.6) is not in use; with ECDH, the
+ECDH-derived key takes precedence for the channel while `W` still
+authenticates the mechanism's key-exchange step (§5.7).
+
+## 5.4 SSL and SCITOKENS
+
+`SSL` authenticates with X.509 certificates over TLS; `SCITOKENS`
+reuses the same TLS machinery but authenticates the *client* with a
+bearer JWT (a SciToken) instead of a client certificate.
+
+The mechanism runs in up to four phases, each a sequence of strictly
+alternating CEDAR messages: (1) an initial status share, (2) the TLS
+handshake, (3) transport of a 256-byte session key, and (4) — SCITOKENS
+only — transfer of the token. Certificate verification happens locally
+between phases 2 and 3.
+
+### 5.4.1 Message Form and Status Codes
+
+TLS bytes are **not** written raw to the socket; they are ferried
+inside CEDAR messages so that the framing layer (and its transcript
+digest, §1.4.2) stays consistent. Apart from the one-integer messages
+of phase 1, every message during SSL authentication has the form
+(`condor_auth_ssl.cpp:1527-1560`; the `net.Conn` adapter
+`CEDARTLSConnection`, `ssl_auth.go:361`):
+
+```
+int64  status         ; sender's current state, see below
+int64  len            ; may be 0
+bytes  raw TLS record data (len bytes)
+<EOM>
+```
+
+Status codes (`condor_auth_ssl.h:31-38`, `ssl_auth.go:33-44`):
+
+| Value | Name | Meaning |
+|---:|---|---|
+| −1 | `ERROR` | local failure; a receiver treats it like `QUITTING` |
+| 0 | `A_OK` | setup succeeded (phase 1 only) |
+| 1 | `SENDING` | this side's TLS engine has more to write for the current phase |
+| 2 | `RECEIVING` | this side's TLS engine is waiting for peer data |
+| 3 | `QUITTING` | fatal: abandon the mechanism (the method loop of §5.2 may try another) |
+| 4 | `HOLDING` | this side has locally completed the current phase and is standing by |
+
+Within each phase, messages alternate in a fixed direction order (who
+starts is fixed per phase, below). Every message carries the sender's
+current status, so each side always knows the peer's state; **a phase
+ends when both sides are in `HOLDING`**, and either side saying
+`QUITTING` (or `ERROR`) aborts the mechanism. Receivers MUST bound
+buffered TLS data (both implementations cap it at 1 MiB,
+`AUTH_SSL_BUF_SIZE`).
+
+### 5.4.2 Phase 1: Status Share
+
+Each side reports whether its local setup (TLS library, contexts,
+credential loading) succeeded, as a bare one-integer message — the
+server first:
+
+```
+Server -> Client : int64 status   <EOM>
+Client -> Server : int64 status   <EOM>
+```
+
+Both MUST be `A_OK` (0) to continue (`condor_auth_ssl.cpp:1486-1524`,
+`ssl_auth.go:198-243`).
+
+### 5.4.3 Phase 2: TLS Handshake
+
+The **client sends first**. Each side drives its TLS engine (client
+handshake / server handshake) against memory buffers, then sends
+whatever records the engine produced, with status `RECEIVING`/`SENDING`
+while the engine reports the handshake incomplete, or `HOLDING` once
+the engine reports success; received bytes are fed back into the
+engine. `len = 0` messages are legal and common — e.g. the server's
+final message when TLS itself finished with the client's `Finished`
+record but the server must still announce `HOLDING`. A fatal TLS
+error (bad certificate, protocol mismatch) becomes `QUITTING`. Both
+implementations require TLS 1.2 or newer.
+
+**Certificate verification.** After the handshake phase completes, each
+side checks the peer certificate. The client MUST verify the server's
+chain against its CA bundle and match the hostname (CN or
+subjectAltName, wildcards allowed) against the connected address or the
+`alias=` from the sinful string (`condor_auth_ssl.cpp:71-136`). In SSL
+mode the server requests (and deployment policy may require) a client
+certificate; in SCITOKENS mode the client typically presents none. A
+side whose verification fails does not abort abruptly: it stays in the
+message rhythm and reports `QUITTING` in its next message (the client,
+whose next phase-3 step is a receive, first reads and discards the
+server's key message, then sends `QUITTING`;
+`condor_auth_ssl.cpp:570-587`).
+
+### 5.4.4 Phase 3: Session-Key Transport
+
+The **server sends first**. The server generates 256 random bytes
+(`AUTH_SSL_SESSION_KEY_LEN`) and writes them through the TLS engine;
+the TLS records appear in the usual `[status, len, bytes]` messages.
+The client reads until its engine yields the 256 bytes, then goes
+`HOLDING` (typically one round trip: `S->C [HOLDING, key record]`,
+`C->S [HOLDING, 0]`). This value is the **mechanism key**: it wraps
+the key-exchange step of §5.7, and for legacy peers seeds the channel
+key; when ECDH (§4.6) is in use the channel key comes from ECDH
+instead, but this phase still runs.
+
+### 5.4.5 Phase 4 (SCITOKENS): Token Transfer
+
+The **client sends first**. Inside the TLS channel the client writes
+
+```
+uint32  token length (big-endian, 4 bytes — not a CEDAR int)
+bytes   the SciToken (a serialized JWT)
+```
+
+(`condor_auth_ssl.cpp:658-675`). The server peeks the length, rejects
+zero, reads exactly `4 + length` bytes, and validates the JWT: the
+signature against the issuer's published keys, `iss`, `exp`, audience,
+and scopes — and immediately attempts to *map* the token identity
+(`iss`,`sub`) to a canonical user. Validation or mapping failure makes
+the server answer `QUITTING` — which is how the client learns its token
+was rejected; success is `HOLDING` and the usual both-`HOLDING` rule
+ends the phase (`condor_auth_ssl.cpp:996-1120`).
+
+### 5.4.6 Identity
+
+- **SSL mode:** the authenticated name is the client certificate's
+  subject DN (or an anonymous placeholder if policy allowed no client
+  certificate), mapped by the server's map file.
+- **SCITOKENS mode:** the authenticated name derives from the token's
+  `iss` and `sub`; the TLS-level client identity is ignored.
+
+After phase 3/4 the TLS engines are discarded; the mechanism key and
+the §5.7 exchange feed the CEDAR channel protection of §4.6.
+
+### 5.4.7 Worked Example
+
+A SCITOKENS authentication, one line per CEDAR message
+(`[status, len]`; TLS byte counts illustrative):
+
+```
+Phase 1 — status share
+  S -> C : [0]                       server setup OK
+  C -> S : [0]                       client setup OK
+
+Phase 2 — TLS handshake (client first)
+  C -> S : [2, 289]   ClientHello                       client: RECEIVING
+  S -> C : [2, 1620]  ServerHello…ServerHelloDone       server: RECEIVING
+  C -> S : [4, 133]   …Finished; client engine done  -> client: HOLDING
+  S -> C : [4, 51]    …Finished; server engine done  -> server: HOLDING
+                      both HOLDING -> phase over
+  (client verifies server chain + hostname; server notes no client cert)
+
+Phase 3 — session key (server first)
+  S -> C : [4, 285]   TLS record: 256-byte random key   server: HOLDING
+  C -> S : [4, 0]     key read                       -> client: HOLDING
+
+Phase 4 — SciToken (client first)
+  C -> S : [4, N]     TLS record: uint32 len ‖ JWT      client: HOLDING
+  S -> C : [4, 0]     token valid, identity mapped   -> server: HOLDING
+```
+
+The server then knows the client as e.g.
+`https://cms-auth.web.cern.ch,bbockelm` → mapped user
+`cmsuser@example.net`, the §5.7 exchange runs (wrapped with the
+256-byte key), and the post-auth ad of §4.7 reports the mapped user.
+
+Had the token been expired, the last message would instead be
+`S -> C : [3, 0]` (`QUITTING`); the client would clear the SCITOKENS
+bit and re-enter the method loop of §5.2.
+
+## 5.5 FS and FS_REMOTE
+
+Filesystem authentication proves that client and server run as the same
+identity on a shared filesystem: only that user (or root) can create a
+directory the server can verify ownership of. It provides no key
+material and no protection against a network man-in-the-middle; it is
+meant for same-host connections (`FS`) or hosts sharing a trusted
+network filesystem (`FS_REMOTE`).
+
+```
+Msg 1  Server -> Client:  string path        <EOM>
+Msg 2  Client -> Server:  int64  status      <EOM>   ; 0 = mkdir succeeded
+Msg 3  Server -> Client:  int64  result      <EOM>   ; 0 = ownership verified
+```
+
+(`condor_auth_fs.cpp:39-240`, `fs_auth.go:84-280`.)
+
+- The server chooses a unique path under `/tmp` (FS; form
+  `FS_<random>`) or under the configured shared directory (FS_REMOTE;
+  form `FS_REMOTE_<host>_<pid>_<random>`); an empty string signals
+  server-side failure.
+- The client creates the directory with mode 0700 and reports status.
+- The server `lstat`s the path, verifies it is a directory owned by the
+  claimed uid (and not a symlink), reports the result, and both sides
+  remove it. The authenticated name is the client's local username.
+
+The Go implementation hardens the client against a malicious server by
+validating the proposed path: it must be a direct child of the expected
+base directory and its leaf must match `^FS_[A-Za-z0-9]{1,16}$` (FS) or
+`^FS_REMOTE_[A-Za-z0-9._\-]+_[0-9]+_[A-Za-z0-9]{1,16}$` (FS_REMOTE)
+(`fs_auth.go:71-82`). Clients SHOULD apply such validation; without it
+a hostile server can probe or create directories at arbitrary
+client-writable locations.
+
+## 5.6 CLAIMTOBE
+
+The client simply asserts an identity; nothing is verified and no key
+is produced. Both implementations support it for testing and for
+deliberately unauthenticated read-only setups. It MUST NOT be enabled
+where authentication has security value.
+
+## 5.7 Mechanism Key Exchange
+
+After a mechanism succeeds, and before the channel switches to the
+negotiated key, the legacy key-exchange step runs
+(`authentication.cpp:852-941`, mirrored in Go):
+
+```
+Server -> Client : int64 hasKey (0|1)   <EOM>
+if hasKey == 1:
+  Server -> Client :
+      int64  keyLength      ; plaintext key bytes
+      int64  protocol       ; crypto protocol enum
+      int64  duration
+      int64  wrappedLen
+      bytes  wrapped key (wrappedLen bytes)
+      <EOM>
+```
+
+The key is "wrapped" (encrypted) with a cipher keyed by the mechanism's
+own derived key: `W` for the AKEP2 mechanisms (§5.3.3), or the 256-byte
+session key transported through TLS for SSL/SCITOKENS (§5.4.4). When
+ECDH key agreement (§4.6) is in effect, this step is either skipped
+(`hasKey = 0`) or its result is superseded by the ECDH-derived
+AES-256-GCM key; the message flow is retained for compatibility.
+
+## 5.8 Security Considerations
+
+- **Downgrade resistance.** The negotiation loop and policy ads are
+  cleartext; their integrity rests entirely on the transcript binding
+  of §1.4.2 (when encryption is enacted) and on the mechanisms' mutual
+  authentication. If policy permits `Encryption = NEVER` *and* a
+  keyless mechanism (FS, CLAIMTOBE), an active attacker can strip
+  stronger options; deployments requiring security MUST set
+  authentication and encryption to `REQUIRED`.
+- **IDTOKEN theft.** IDTOKENs are bearer-like: possession of the JWT
+  (whose signature is the AKEP2 secret) suffices to authenticate.
+  Tokens SHOULD carry `exp` and narrow `scope`/`sub` claims.
+- **FS path trust.** See §5.5; validate server-supplied paths.
+- **CCB interaction.** On a CCB-reversed connection (§3.4), the
+  security handshake runs with the original client as the handshake
+  client; the `CCB_REVERSE_CONNECT` hello itself is unauthenticated and
+  is trusted only via the random connect id.
+- **Randomness.** Nonces (`rA`, `rB`), connect ids, session ids, and
+  ECDH keys MUST come from a cryptographically secure RNG.
+
+## 5.9 Worked Example: Negotiation, IDTOKENS, Post-Auth
+
+Continuing the example of §4.11: the client offered
+`AuthMethods = "IDTOKENS,FS"`, the server's list is `"SSL,IDTOKENS,FS"`.
+
+**Method negotiation.** The client's usable set is the intersection
+{IDTOKENS, FS} = bits 2048 | 4:
+
+```
+Client -> Server : 2052              ; TOKEN(2048) | FS(4)
+Server -> Client : 2048              ; first of "SSL,IDTOKENS,FS" in the mask:
+                                     ; SSL(256) absent -> TOKEN selected
+```
+
+**IDTOKENS (AKEP2).** The client holds the IDTOKEN
+
+```
+header : { "alg": "HS256", "kid": "POOL" }
+payload: { "sub": "bbockelm@example.net", "iss": "example.net",
+           "iat": 1750000000, "jti": "d3adb33f…" }
+```
+
+and sends **Msg 1** with `status = 0`,
+`A = "bbockelm@example.net"`,
+`T = base64url(header) "." base64url(payload)` (signature omitted), and
+a fresh 256-byte nonce `rA`.
+
+The server looks up signing key `POOL`, recomputes
+`sig = HMAC-SHA256(T, HKDF(pool_key, "htcondor", "master jwt"))`,
+derives `K`/`K'` from `sig` and `T` (§5.3.1), checks the claims
+(`iss` matches its trust domain; no `exp` present), and answers
+**Msg 2** with `B = "condor@example.net"`, its nonce `rB`, and
+`mac1 = HMAC-SHA256(K, B‖A‖rA‖rB)`.
+
+The client, holding the complete JWT, derives the same `K`/`K'`
+directly from the token's signature, verifies `mac1` — proof the server
+knows the pool key — and sends **Msg 3** with
+`mac2 = HMAC-SHA256(K, A‖rB)`. The server verifies `mac2` — proof the
+client holds a validly signed token — and the authenticated name is the
+token's `sub`, which the server's map file maps to canonical
+`bbockelm@example.net`.
+
+Both sides derive `W = HKDF-SHA256(rB, salt=K', "session key")`; the
+mechanism key exchange (§5.7) then runs (`hasKey = 0` here, since the
+ECDH agreement of §4.6 supplies the channel key), encryption switches
+on, and the server issues the post-auth ad shown in §4.11 step 5 with
+`User = "bbockelm@example.net"`.
+
+**Failure and fallback.** Had the token been rejected (say, an unknown
+`kid`), the server would send a failing `status` inside the AKEP2
+exchange; the client clears the TOKEN bit and the loop continues:
+
+```
+Client -> Server : 4                 ; only FS remains
+Server -> Client : 4                 ; FS selected
+     …  FS sub-protocol (§5.5) runs …
+```
+
+and if that too failed, `Client -> Server : 0` abandons authentication —
+which, with `Authentication = "REQUIRED"` on either side, fails the
+whole command.
+
+## 5.10 Implementation Differences
+
+| Aspect | C++ | Go |
+|---|---|---|
+| Methods beyond the common set | KERBEROS, MUNGE, NTSSPI, ANONYMOUS | not implemented |
+| SCITOKENS validation | via libscitokens + mapfile | native JWT validation |
+| Post-auth mapping | unified map file (`CERTIFICATE_MAPFILE`) | `PostAuthPolicy` callback |
+| FS path validation | trusts server path | regex + base-directory checks |
+| PASSWORD | distinct v1 protocol | AKEP2 core shared with TOKEN |

--- a/cedar-rfc/README.md
+++ b/cedar-rfc/README.md
@@ -1,0 +1,77 @@
+# The CEDAR Protocol
+
+**Status:** Draft
+**Editors:** Derived from the HTCondor C++ implementation and the Go
+implementation in `golang-cedar` / `golang-classads` / `golang-ccb`.
+
+## Abstract
+
+CEDAR is the wire protocol used by all components of the HTCondor
+distributed high-throughput computing system. It provides message-oriented
+communication over TCP (and, in the C++ implementation, UDP), a portable
+serialization format for primitive values and ClassAds, connection routing
+through a shared listening port and through the Condor Connection Broker
+(CCB) for daemons behind NATs and firewalls, and a command protocol with
+integrated authentication, encryption, and integrity protection.
+
+This document specifies CEDAR as implemented by two independent codebases:
+the reference C++ implementation in HTCondor (`src/condor_io` and related
+directories) and the Go implementation (`golang-cedar` and companion
+modules). Where the two implementations differ, the difference is noted.
+Per the scope of this document, channel encryption and integrity are
+described only for the modern AES-256-GCM mechanism; the legacy Blowfish
+and Triple-DES ciphers and the standalone per-frame MAC ("MD") mode are
+mentioned only where their existence affects the wire format.
+
+## Table of Contents
+
+1. [Message Framing and Primitive Encodings](01-message-framing.md)
+   — streams, messages, frames, the 5-byte frame header, encodings for
+   integers, floating-point values, strings, and byte arrays, and the
+   AES-256-GCM frame protection mechanism.
+2. [Serialization of Complex Objects](02-serialization.md)
+   — the on-the-wire representation of ClassAds (`putClassAd` /
+   `getClassAd`), secret attributes, and the restricted "POD" ClassAd
+   used before a channel is trusted.
+3. [Transport over TCP: Addresses, Shared Port, and CCB](03-transport.md)
+   — the *sinful string* address format, direct TCP connection
+   establishment, the Shared Port protocol, and the Condor Connection
+   Broker reverse-connection protocol.
+4. [The Command Protocol and Security Negotiation](04-command-protocol.md)
+   — command integers, the `DC_AUTHENTICATE` wrapper, the security
+   policy handshake, ECDH key agreement, activation of AES-GCM channel
+   protection, and security session caching and resumption.
+5. [Authentication Protocols](05-authentication.md)
+   — the method negotiation loop and the individual mechanisms
+   implemented in both codebases: TOKEN/IDTOKENS and PASSWORD (AKEP2),
+   SSL, SCITOKENS, FS/FS_REMOTE, and CLAIMTOBE.
+
+## Conventions and Terminology
+
+The key words **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and
+**MAY** are to be interpreted as described in RFC 2119.
+
+- **Stream** — a bidirectional byte channel between two endpoints,
+  normally a TCP connection (called a *ReliSock* in the C++ code).
+- **Frame** (also *packet* in the C++ code) — the unit of framing on a
+  stream: a fixed header followed by a payload.
+- **Message** — a logical unit of application data, carried as one or
+  more frames; the last frame of a message is marked by an end-of-message
+  flag. Called *end_of_message()* / `FinishMessage()` boundaries in the
+  implementations.
+- **Command** — an integer identifying the operation a client requests of
+  a daemon; the first datum of the first message on a connection.
+- **ClassAd** — HTCondor's schema-free attribute/expression record; the
+  standard composite data structure carried over CEDAR.
+- **Sinful string** — HTCondor's textual address format,
+  `<host:port?params>`.
+- **Daemon** — a CEDAR server process. **Client** — the connecting party
+  (which may itself be a daemon).
+
+All multi-byte integers on the wire are transmitted in **network byte
+order (big-endian)**. Byte layouts in this document are drawn with offset
+0 transmitted first.
+
+Source references use the form `path:line` and refer to the C++ tree at
+`htcondor/` and the Go trees at `golang-cedar/`, `golang-ccb/`, and
+`golang-classads/`.


### PR DESCRIPTION
Squeeze as much of the semantics out of the Go and C++ implementations so we have a more human-friendly description of CEDAR protocol.