### PR TITLE
HTCONDOR-3836: reclaim disk space during librarian garbage collection

### DIFF
--- a/docs/admin-manual/ap-policy-configuration.rst
+++ b/docs/admin-manual/ap-policy-configuration.rst
@@ -764,6 +764,16 @@ The purpose of the librarian's database is:
 2. To allow client tools to quickly locate a full archived record assuming
    the associated file has not been rotated out.
 
+To enable simply set the following in the configuration
+
+.. code-block:: condor-config
+
+    # Version conditional to prevent older versions from failing
+    # to read configuration
+    if version >= 25.11.0
+        use feature:librarian
+    endif
+
 The following tools will automatically utilize the librarian in certain cases
 when the Access Point is configured with :config:`USING_LIBRARIAN = True`
 

--- a/docs/admin-manual/configuration/librarian.rst
+++ b/docs/admin-manual/configuration/librarian.rst
@@ -44,6 +44,18 @@ enable historical archive record indexing to a database by setting :macro:`use f
     reduce the database size to or below ``1GB`` during garbage collection. Default is
     ``0.8``.
 
+    The database file uses SQLite's incremental auto-vacuum mode so that garbage
+    collection actually shrinks the file on disk, rather than only freeing internal
+    space for reuse. The first time the archive librarian starts against an existing
+    database that predates this mode, it performs a one-time full ``VACUUM`` to convert
+    it; this copies the entire database and can take a while for a large file, but only
+    happens once.
+
+:macro-def:`LIBRARIAN_GC_BACKOFF_SECONDS`
+    An integer value representing how long, in seconds, to wait before retrying garbage
+    collection after a pass that did not reduce the database's file size. Defaults to
+    ``1800`` (30 minutes).
+
 :macro-def:`LIBRARIAN_MAX_JOBS_CACHED`
     An integer value representing the maximum number of job id information to database
     reference id's to cache in memory. Defaults to ``10,000``.

--- a/docs/version-history/v25-version.hist
+++ b/docs/version-history/v25-version.hist
@@ -4,6 +4,10 @@
   :tool:`condor_submit` runs.
   :jira:`3173`
 
+- The Archive Librarian now properly reduces the database size
+  during garbage collection.
+  :jira:`3826`
+
 *** 25.13.0 bugs
 
 *** 25.0.13 bugs

--- a/src/archive_librarian/README.md
+++ b/src/archive_librarian/README.md
@@ -41,7 +41,7 @@ src/condor_utils/
 
 | Callback | Purpose |
 |----------|---------|
-| `main_init` | Calls `librarian.reconfig(true)`, `librarian.initialize()`, registers the periodic `update_timer` |
+| `main_init` | Calls `librarian.reconfig(true)`, `librarian.initialize()` (may run a one-time `VACUUM`, see below), registers the periodic `update_timer` |
 | `main_config` | Calls `librarian.reconfig()` on `condor_reconfig` |
 | `update_timer` | Fires every `LIBRARIAN_UPDATE_INTERVAL` seconds; calls `librarian.update()` |
 | `main_exit` | Calls `DC_Exit(0)` |
@@ -56,7 +56,7 @@ Each timer tick runs `Librarian::update()` in five phases:
 | 1.5 | `reconcileArchiveFiles()` registers new files and detects rotations by comparing inodes (Linux) or first-record hashes (Windows) |
 | 2 | `std::erase_if` removes in-memory entries for files that have left disk; marks them `DateOfDeletion` in the DB; renames unexpectedly removed active files to `<name>.REMOVED` in the DB |
 | 3 | For each unread file, `readJobRecords()` opens (or reuses) a persistent `ArchiveReader`, reads new records incrementally, and calls `dbHandler_.insertJobFileRecords()` to atomically insert records and update the file's offset |
-| 4 | `cleanupDatabaseIfNeeded()` runs garbage collection if the DB exceeds `LIBRARIAN_HIGH_WATER_MARK`; GC deletes the oldest files (and their job records) until the DB shrinks below `LIBRARIAN_LOW_WATER_MARK` |
+| 4 | `cleanupDatabaseIfNeeded()` runs garbage collection if the DB exceeds `LIBRARIAN_HIGH_WATER_MARK`; GC deletes the oldest files (and their job records), then runs `PRAGMA incremental_vacuum` to actually shrink the file. If a pass doesn't reduce the file size, further attempts are skipped for `LIBRARIAN_GC_BACKOFF_SECONDS` |
 | 5 | `writeStatusAndData()` records per-cycle and rolling aggregate metrics |
 
 ### File Reading (`archive_reader.cpp`)
@@ -155,6 +155,17 @@ Schema version is tracked via `PRAGMA user_version` (current: 3).
 Garbage collection (`GC_QUERY_SQL`) targets files where `DateOfDeletion IS NOT NULL`, deletes
 them oldest-first up to the calculated file limit, then cascades to `JobRecords` and `Jobs`.
 
+### Database File Size
+
+The DB uses `auto_vacuum = INCREMENTAL` so that deleted rows shrink the file, not just free
+space for reuse. Since SQLite only applies an `auto_vacuum` mode change on an empty database or
+immediately after a `VACUUM`, `DBHandler::initialize()` detects a non-`INCREMENTAL` mode on
+startup and runs a **one-time full `VACUUM`** to convert it — this copies the whole database and
+can take a while on a large, un-vacuumed file (only happens once; skipped on later restarts).
+Failure to convert (e.g. insufficient free disk space, ~1.1x current file size required) is
+logged but non-fatal and retried on the next restart. After that, each GC pass runs a cheap
+`PRAGMA incremental_vacuum` to keep reclaiming space incrementally.
+
 ---
 
 ## Configuration
@@ -180,6 +191,7 @@ LIBRARIAN_DATABASE = $(LOCAL_DIR)/librarian.db
 | `LIBRARIAN_MAX_DATABASE_SIZE` | `2147483648` (2 GiB) | DB size limit in bytes |
 | `LIBRARIAN_HIGH_WATER_MARK` | `0.97` | Fraction of size limit that triggers GC |
 | `LIBRARIAN_LOW_WATER_MARK` | `0.80` | Fraction of size limit GC targets |
+| `LIBRARIAN_GC_BACKOFF_SECONDS` | `1800` | Seconds to wait before retrying GC after a pass that didn't shrink the DB file |
 
 ---
 

--- a/src/archive_librarian/config.hpp
+++ b/src/archive_librarian/config.hpp
@@ -14,6 +14,7 @@ namespace LibrarianConfigOptions {
 		DBMaxJobCacheSize = 0,                        // Maximum cache size for record JobId -> Job Table Unique Id
 		UpdateInterval,                               // Interval in seconds the librarian should process archive files
 		StatusRetentionSeconds,                       // How long (seconds) to retain Status rows in the DB
+		GCBackoffSeconds,                             // How long to wait before retrying GC after a pass that didn't shrink the DB
 		_SIZE // MUST BE FINAL ITEM
 	};
 
@@ -45,6 +46,7 @@ public:
 		intOpts[static_cast<size_t>(i::DBMaxJobCacheSize)] = 10'000;
 		intOpts[static_cast<size_t>(i::UpdateInterval)] = 5;
 		intOpts[static_cast<size_t>(i::StatusRetentionSeconds)] = 300;
+		intOpts[static_cast<size_t>(i::GCBackoffSeconds)] = 1800;
 		int64Opts[static_cast<size_t>(ll::DBMaxSizeBytes)] = 2LL * 1024 * 1024 * 1024;
 		doubleOpts[static_cast<size_t>(dbl::DBHighWaterMark)] = 0.97;
 		doubleOpts[static_cast<size_t>(dbl::DBLowWaterMark)] = 0.80;

--- a/src/archive_librarian/dbHandler.cpp
+++ b/src/archive_librarian/dbHandler.cpp
@@ -13,7 +13,9 @@
 #include "condor_config.h"
 #include "condor_debug.h"
 #include "condor_attributes.h"
+#include "to_string_si_units.h"
 
+#include <chrono>
 #include <filesystem>
 #include <functional>
 #include <iomanip>
@@ -58,6 +60,12 @@ bool DBHandler::initialize() {
         return false;
     }
 
+    // Retry on lock contention (e.g. a concurrent read-only reader, like a monitoring
+    // script) instead of failing immediately -- matters most for VACUUM below, which
+    // needs exclusive-ish access and would otherwise abort the whole daemon's startup
+    // on a transient conflict.
+    sqlite3_busy_timeout(db_, 30000);
+
 #ifndef _WIN32
     // Best effort set database file permissions (readable by all, writable by librarian).
     // Open with O_NOFOLLOW (safe_open_wrapper, no _follow) so that if the path has been
@@ -91,6 +99,77 @@ bool DBHandler::initialize() {
         dprintf(D_ERROR, "Failed to enable foreign keys: %s\n", errMsg ? errMsg : "Unknown");
         sqlite3_free(errMsg);
         return false;
+    }
+
+    // Lets garbage collection actually shrink the file (see runGarbageCollection()).
+    // The pragma below is a silent no-op on a database that already has rows and a
+    // different auto_vacuum mode -- SQLite only lets auto_vacuum change take effect on
+    // an empty database or immediately after a VACUUM. So detect the current mode and,
+    // if it isn't already INCREMENTAL, do the one-time VACUUM ourselves.
+    constexpr int AUTO_VACUUM_INCREMENTAL = 2;
+    int currentAutoVacuum = -1;
+    {
+        sqlite3_stmt* avStmt = nullptr;
+        if (sqlite3_prepare_v2(db_, "PRAGMA auto_vacuum;", -1, &avStmt, nullptr) == SQLITE_OK
+                && sqlite3_step(avStmt) == SQLITE_ROW) {
+            currentAutoVacuum = sqlite3_column_int(avStmt, 0);
+        }
+        sqlite3_finalize(avStmt);
+    }
+
+    if (currentAutoVacuum != AUTO_VACUUM_INCREMENTAL) {
+        std::error_code spaceEc, sizeEc;
+        auto space  = fs::space(fs::path(config[conf::str::DBPath]).parent_path(), spaceEc);
+        auto dbSize = fs::file_size(config[conf::str::DBPath], sizeEc);
+        if (sizeEc) dbSize = 0;
+        // 1.1x: VACUUM's copy is never larger than dbSize; +10% covers temp overhead.
+        if ( ! spaceEc && space.available < dbSize * 1.1) {
+            dprintf(D_ERROR, "Not enough free disk space to convert database to incremental "
+                    "auto-vacuum (need ~%s, have %s free). Leaving auto_vacuum as-is; "
+                    "garbage collection will not shrink the file until this is resolved.\n",
+                    to_string_byte_units(static_cast<filesize_t>(dbSize * 1.1)).c_str(),
+                    to_string_byte_units(static_cast<filesize_t>(space.available)).c_str());
+        } else {
+            dprintf(D_ALWAYS, "auto_vacuum is not INCREMENTAL (mode %d); converting via a "
+                    "one-time VACUUM. This may take a while for a large database.\n",
+                    currentAutoVacuum);
+
+            // Neither step here is fatal to startup on failure -- worst case we just
+            // retry this conversion on the next restart, same as the insufficient-disk-
+            // space case above. Blocking the whole daemon from starting over a one-time
+            // maintenance operation (e.g. transient lock contention despite the busy
+            // timeout, or a mid-VACUUM disk issue) would be worse than leaving auto_vacuum
+            // as-is for now.
+            rc = sqlite3_exec(db_, "PRAGMA auto_vacuum = INCREMENTAL;", nullptr, nullptr, &errMsg);
+            if (rc != SQLITE_OK) {
+                dprintf(D_ERROR, "Failed to set auto_vacuum pragma: %s. Leaving auto_vacuum as-is; "
+                        "will retry on next restart.\n", errMsg ? errMsg : "Unknown");
+                sqlite3_free(errMsg);
+            } else {
+                auto vacuumStart = std::chrono::steady_clock::now();
+                rc = sqlite3_exec(db_, "VACUUM;", nullptr, nullptr, &errMsg);
+                auto vacuumMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                    std::chrono::steady_clock::now() - vacuumStart).count();
+                if (rc != SQLITE_OK) {
+                    dprintf(D_ERROR, "One-time VACUUM to enable incremental auto-vacuum failed "
+                            "after %lld ms: %s. Leaving auto_vacuum as-is; will retry on next "
+                            "restart.\n", (long long)vacuumMs, errMsg ? errMsg : "Unknown");
+                    sqlite3_free(errMsg);
+                } else {
+                    dprintf(D_ALWAYS, "Database converted to auto_vacuum=INCREMENTAL in %lld ms.\n",
+                            (long long)vacuumMs);
+
+                    // Belt-and-suspenders: re-assert WAL mode in case VACUUM reset it.
+                    rc = sqlite3_exec(db_, "PRAGMA journal_mode=WAL;", nullptr, nullptr, &errMsg);
+                    if (rc != SQLITE_OK) {
+                        dprintf(D_ERROR, "Failed to re-enable WAL journal mode after VACUUM: %s\n",
+                                errMsg ? errMsg : "Unknown");
+                        sqlite3_free(errMsg);
+                        return false;
+                    }
+                }
+            }
+        }
     }
 
     int version = getSchemaVersion();
@@ -998,8 +1077,29 @@ bool DBHandler::maybeRecoverStatusAndFiles(std::map<std::string, ArchiveFile>& a
 // Garbage Collection
 // -------------------------
 
+// Runs a single "SELECT COUNT(*) FROM <table>"-shaped query and returns the scalar
+// result, or -1 if the query couldn't be prepared/stepped.
+static int queryRowCount(sqlite3* db, const char* countSql) {
+    sqlite3_stmt* stmt = nullptr;
+    if (sqlite3_prepare_v2(db, countSql, -1, &stmt, nullptr) != SQLITE_OK) {
+        dprintf(D_ERROR, "queryRowCount: prepare failed for '%s': %s\n", countSql, sqlite3_errmsg(db));
+        return -1;
+    }
+    int result = -1;
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        result = sqlite3_column_int(stmt, 0);
+    } else {
+        dprintf(D_ERROR, "queryRowCount: step failed for '%s': %s\n", countSql, sqlite3_errmsg(db));
+    }
+    sqlite3_finalize(stmt);
+    return result;
+}
+
 bool DBHandler::runGarbageCollection(const std::string& gcQuerySQL, int fileLimit) {
     if ( ! db_) return false;
+
+    dprintf(D_STATUS, "runGarbageCollection: starting; requested file limit=%d\n", fileLimit);
+    auto gcStart = std::chrono::steady_clock::now();
 
     char* errMsg = nullptr;
     if (sqlite3_exec(db_, "BEGIN TRANSACTION;", nullptr, nullptr, &errMsg) != SQLITE_OK) {
@@ -1008,18 +1108,19 @@ bool DBHandler::runGarbageCollection(const std::string& gcQuerySQL, int fileLimi
         return false;
     }
 
-    size_t pos = gcQuerySQL.find(';');
-    if (pos == std::string::npos) {
+    // Statement 1: pick the oldest `fileLimit` files that are eligible for deletion
+    // (DateOfDeletion IS NOT NULL, i.e. already gone from disk -- see markFileDeleted()).
+    size_t pos1 = gcQuerySQL.find(';');
+    if (pos1 == std::string::npos) {
         dprintf(D_ERROR, "Invalid Garbage Collection SQL — no statement terminator\n");
         ROLLBACK_AND_RETURN();
     }
-
-    std::string step1Sql = gcQuerySQL.substr(0, pos + 1);
-    std::string step2Sql = gcQuerySQL.substr(pos + 1);
+    std::string step1Sql = gcQuerySQL.substr(0, pos1 + 1);
 
     sqlite3_stmt* stmt = nullptr;
     if (sqlite3_prepare_v2(db_, step1Sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK) {
-        dprintf(D_ERROR, "Garbage collection prepare step1 failed: %s\n", sqlite3_errmsg(db_));
+        dprintf(D_ERROR, "Garbage collection prepare step1 (select files to delete) failed: %s\n",
+                sqlite3_errmsg(db_));
         ROLLBACK_AND_RETURN();
     }
     if (sqlite3_bind_int(stmt, 1, fileLimit) != SQLITE_OK) {
@@ -1028,17 +1129,60 @@ bool DBHandler::runGarbageCollection(const std::string& gcQuerySQL, int fileLimi
         ROLLBACK_AND_RETURN();
     }
     if (sqlite3_step(stmt) != SQLITE_DONE) {
-        dprintf(D_ERROR, "Garbage collection execute step1 failed: %s\n", sqlite3_errmsg(db_));
+        dprintf(D_ERROR, "Garbage collection execute step1 (select files to delete) failed: %s\n",
+                sqlite3_errmsg(db_));
         std::ignore = sqlite3_finalize(stmt);
         ROLLBACK_AND_RETURN();
     }
     sqlite3_finalize(stmt);
 
+    int filesMatched = queryRowCount(db_, "SELECT COUNT(*) FROM FilesToDelete;");
+    dprintf(D_STATUS, "Garbage collection: %d of %d requested file(s) are eligible for deletion "
+            "(i.e. already marked deleted from disk).\n", filesMatched, fileLimit);
+
+    if (filesMatched <= 0) {
+        // Nothing eligible right now -- drop the temp table we just created so a future
+        // run's "CREATE TEMP TABLE IF NOT EXISTS" doesn't silently reuse this stale,
+        // empty one instead of recomputing against then-current data.
+        sqlite3_exec(db_, "DROP TABLE IF EXISTS FilesToDelete;", nullptr, nullptr, nullptr);
+        if (sqlite3_exec(db_, "COMMIT;", nullptr, nullptr, &errMsg) != SQLITE_OK) {
+            dprintf(D_ERROR, "Garbage collection commit (no-op pass) failed: %s\n", errMsg);
+            sqlite3_free(errMsg);
+            ROLLBACK_AND_RETURN();
+        }
+        dprintf(D_STATUS, "Garbage collection: no files currently eligible for deletion; "
+                "nothing to do this pass.\n");
+        return true;
+    }
+
+    // Statement 2: how many distinct jobs live in those files (informational only --
+    // the cascade delete below recomputes this itself inside the same transaction).
+    size_t pos2 = gcQuerySQL.find(';', pos1 + 1);
+    if (pos2 == std::string::npos) {
+        dprintf(D_ERROR, "Invalid Garbage Collection SQL — missing second statement terminator\n");
+        ROLLBACK_AND_RETURN();
+    }
+    std::string step2Sql = gcQuerySQL.substr(pos1 + 1, pos2 - pos1);
     if (sqlite3_exec(db_, step2Sql.c_str(), nullptr, nullptr, &errMsg) != SQLITE_OK) {
-        dprintf(D_ERROR, "Garbage collection execute step2 failed: %s\n", errMsg);
+        dprintf(D_ERROR, "Garbage collection execute step2 (collect job ids) failed: %s\n", errMsg);
         sqlite3_free(errMsg);
         ROLLBACK_AND_RETURN();
     }
+    int jobsMatched = queryRowCount(db_, "SELECT COUNT(*) FROM JobsToDelete;");
+    dprintf(D_STATUS, "Garbage collection: %d job(s) found across the %d file(s) to be deleted.\n",
+            jobsMatched, filesMatched);
+
+    // Remaining statements: JobListsToCheck, the cascading DELETEs, and the DROP TABLEs.
+    std::string step3Sql = gcQuerySQL.substr(pos2 + 1);
+    if (sqlite3_exec(db_, step3Sql.c_str(), nullptr, nullptr, &errMsg) != SQLITE_OK) {
+        dprintf(D_ERROR, "Garbage collection execute step3 (cascade delete) failed: %s\n", errMsg);
+        sqlite3_free(errMsg);
+        ROLLBACK_AND_RETURN();
+    }
+    // sqlite3_changes() reflects the most recently completed INSERT/UPDATE/DELETE --
+    // DDL (the DROP TABLEs at the end of step3Sql) doesn't touch it, so this is the
+    // row count from "DELETE FROM Files ...", i.e. files actually removed.
+    int filesDeleted = sqlite3_changes(db_);
 
     if (sqlite3_exec(db_, "COMMIT;", nullptr, nullptr, &errMsg) != SQLITE_OK) {
         dprintf(D_ERROR, "Garbage collection commit failed: %s\n", errMsg);
@@ -1046,6 +1190,20 @@ bool DBHandler::runGarbageCollection(const std::string& gcQuerySQL, int fileLimi
         ROLLBACK_AND_RETURN();
     }
 
-    dprintf(D_FULLDEBUG, "Garbage collection successful.\n");
+    // Return the pages just freed by the deletes above to the OS so the file actually
+    // shrinks. Requires auto_vacuum=INCREMENTAL (see initialize()); on a database that
+    // hasn't been VACUUMed since that pragma was added, this is a harmless no-op.
+    // Not fatal on failure -- the row deletions above already committed successfully.
+    if (sqlite3_exec(db_, "PRAGMA incremental_vacuum;", nullptr, nullptr, &errMsg) != SQLITE_OK) {
+        dprintf(D_ERROR, "Incremental vacuum after garbage collection failed: %s\n",
+                errMsg ? errMsg : "Unknown");
+        sqlite3_free(errMsg);
+    }
+
+    auto gcMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - gcStart).count();
+    dprintf(D_STATUS, "Garbage collection successful: deleted %d file(s) (expected %d), "
+            "%d associated job(s), in %lld ms.\n",
+            filesDeleted, filesMatched, jobsMatched, (long long)gcMs);
     return true;
 }

--- a/src/archive_librarian/librarian.cpp
+++ b/src/archive_librarian/librarian.cpp
@@ -6,6 +6,7 @@
 
 #include "librarian.h"
 #include "SavedQueries.h"
+#include "to_string_si_units.h"
 
 #include <algorithm>
 #include <chrono>
@@ -472,7 +473,14 @@ void Librarian::reconcileArchiveFiles(const std::vector<std::string>& archive_fi
 static std::uintmax_t get_database_size(const std::string& db_path) {
     std::error_code ec;
     auto size = std::filesystem::file_size(db_path, ec);
-    return ec ? 0 : size;
+
+    if (ec) {
+        dprintf(D_ERROR, "ERROR: Failed to get database size: %s\n",
+                ec.message().c_str());
+        return 0;
+    }
+
+    return size;
 }
 
 bool Librarian::cleanupDatabaseIfNeeded() {
@@ -482,21 +490,65 @@ bool Librarian::cleanupDatabaseIfNeeded() {
     long long sizeLimit = config[conf::ll::DBMaxSizeBytes];
     size_t highWatermark = static_cast<size_t>(sizeLimit * config[conf::dbl::DBHighWaterMark]);
 
-    if (currentSize > highWatermark) {
-        size_t lowWatermark   = static_cast<size_t>(sizeLimit * config[conf::dbl::DBLowWaterMark]);
-        size_t bytesToDelete  = currentSize - lowWatermark;
-        int numJobsToDelete   = static_cast<int>(
-            std::ceil(static_cast<double>(bytesToDelete) / EstimatedBytesPerJobInDatabase_));
-        int numFilesToDelete = 1;
-        if (EstimatedJobsPerFileInArchive_ > 0) {
-            numFilesToDelete = static_cast<int>(
-                std::ceil(static_cast<double>(numJobsToDelete) / EstimatedJobsPerFileInArchive_));
-        }
+    dprintf(D_FULLDEBUG, "cleanupDatabaseIfNeeded: size=%s, high water mark=%s (limit=%s, fraction=%.2f)\n",
+            to_string_byte_units(currentSize).c_str(), to_string_byte_units(highWatermark).c_str(),
+            to_string_byte_units(sizeLimit).c_str(), config[conf::dbl::DBHighWaterMark]);
 
-        garbageCollected = dbHandler_.runGarbageCollection(SavedQueries::GC_QUERY_SQL, numFilesToDelete);
-        if ( ! garbageCollected) {
-            dprintf(D_ERROR, "Garbage collection attempted but failed.\n");
-        }
+    if (currentSize <= highWatermark) {
+        return false;
+    }
+
+    auto now = std::chrono::steady_clock::now();
+    if (now < nextGCAttempt_) {
+        auto remaining = std::chrono::duration_cast<std::chrono::seconds>(nextGCAttempt_ - now).count();
+        dprintf(D_FULLDEBUG, "Database over the high water mark (%s > %s), but skipping garbage "
+                "collection; a prior pass didn't shrink the file, backing off for another "
+                "%lld more second(s).\n",
+                to_string_byte_units(currentSize).c_str(), to_string_byte_units(highWatermark).c_str(),
+                (long long)remaining);
+        return false;
+    }
+
+    size_t lowWatermark   = static_cast<size_t>(sizeLimit * config[conf::dbl::DBLowWaterMark]);
+    size_t bytesToDelete  = currentSize - lowWatermark;
+    int numJobsToDelete   = static_cast<int>(
+        std::ceil(static_cast<double>(bytesToDelete) / EstimatedBytesPerJobInDatabase_));
+    int numFilesToDelete = 1;
+    if (EstimatedJobsPerFileInArchive_ > 0) {
+        numFilesToDelete = static_cast<int>(
+            std::ceil(static_cast<double>(numJobsToDelete) / EstimatedJobsPerFileInArchive_));
+    }
+
+    dprintf(D_STATUS, "Database over high water mark (%s > %s); starting garbage collection. "
+            "Target: shrink to %s (~%d job(s) across ~%d file(s), est. %.1f bytes/job, "
+            "%d job(s)/file).\n",
+            to_string_byte_units(currentSize).c_str(), to_string_byte_units(highWatermark).c_str(),
+            to_string_byte_units(lowWatermark).c_str(), numJobsToDelete, numFilesToDelete,
+            EstimatedBytesPerJobInDatabase_, EstimatedJobsPerFileInArchive_);
+
+    garbageCollected = dbHandler_.runGarbageCollection(SavedQueries::GC_QUERY_SQL, numFilesToDelete);
+    if ( ! garbageCollected) {
+        dprintf(D_ERROR, "Garbage collection attempted but failed.\n");
+    }
+
+    // Judge success by whether the file actually got smaller, not just whether the
+    // delete transaction committed -- a GC pass can "succeed" with zero eligible rows
+    // (nothing marked deleted yet) or with rows deleted but no space reclaimed (e.g.
+    // incremental_vacuum unavailable). Either way, retrying every single cycle just
+    // burns CPU and writes for no benefit, so back off until it's worth trying again.
+    size_t sizeAfter = get_database_size(config[conf::str::DBPath]);
+    if (sizeAfter >= currentSize) {
+        auto backoff = std::chrono::seconds(config[conf::i::GCBackoffSeconds]);
+        nextGCAttempt_ = now + backoff;
+        dprintf(D_STATUS, "Garbage collection did not reduce database size (%s -> %s); backing "
+                "off further attempts for %lld second(s) (LIBRARIAN_GC_BACKOFF_SECONDS).\n",
+                to_string_byte_units(currentSize).c_str(), to_string_byte_units(sizeAfter).c_str(),
+                (long long)backoff.count());
+    } else {
+        dprintf(D_STATUS, "Garbage collection reduced database size: %s -> %s (%s reclaimed).\n",
+                to_string_byte_units(currentSize).c_str(), to_string_byte_units(sizeAfter).c_str(),
+                to_string_byte_units(currentSize - sizeAfter).c_str());
+        nextGCAttempt_ = {};
     }
 
     return garbageCollected;
@@ -691,6 +743,7 @@ void Librarian::reconfig(bool startup) {
 
     config[i::DBMaxJobCacheSize]          = param_integer("LIBRARIAN_MAX_JOBS_CACHED", 10'000);
     config[i::StatusRetentionSeconds]     = param_integer("LIBRARIAN_STATUS_RETENTION_SECONDS", 300);
+    config[i::GCBackoffSeconds]           = param_integer("LIBRARIAN_GC_BACKOFF_SECONDS", 1800);
 
     param_longlong("LIBRARIAN_MAX_UPDATES_PER_CYCLE", config[ll::MaxRecordsPerUpdate], true,
                    100'000);

--- a/src/archive_librarian/librarian.h
+++ b/src/archive_librarian/librarian.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <map>
 #include <memory>
 #include <string>
@@ -38,6 +39,11 @@ private:
     double EstimatedBytesPerJobInArchive_{0.0};
     int    EstimatedJobsPerFileInArchive_{0};
     double EstimatedBytesPerJobInDatabase_{1024};
+
+    // Set whenever a GC pass fails to shrink the database file (e.g. auto_vacuum
+    // couldn't be enabled, or nothing was eligible for deletion); suppresses further
+    // GC attempts until this time so we don't retry every single cycle for nothing.
+    std::chrono::steady_clock::time_point nextGCAttempt_{};
 
     // update() helpers
     bool readJobRecords(std::vector<ArchiveRecord>& records, const std::string& path, ArchiveFile& info, int64_t limit = -1);


### PR DESCRIPTION
Garbage collection was deleting rows correctly but the database file never shrank: SQLite's default auto_vacuum=NONE leaves freed pages in place for internal reuse rather than returning them to the OS, so the file size (what LIBRARIAN_MAX_DATABASE_SIZE actually guards) stayed pinned at its high-water mark indefinitely.

- DBHandler::initialize() now detects a non-INCREMENTAL auto_vacuum mode and converts via a one-time VACUUM (non-fatal on failure/low disk space; retried on next restart), enabling incremental_vacuum going forward. Also adds a busy timeout so transient lock contention doesn't abort daemon startup.
- runGarbageCollection() runs PRAGMA incremental_vacuum after each cascade delete to actually shrink the file, and logs per-stage progress (files eligible vs. requested, jobs matched, files deleted, elapsed time).
- cleanupDatabaseIfNeeded() now backs off for LIBRARIAN_GC_BACKOFF_SECONDS after a pass that doesn't reduce the file size, instead of retrying every cycle for no benefit.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
