### PR TITLE
HTCONDOR-3247 Fix long-standing memory leak when there's no

### DIFF
--- a/src/condor_daemon_client/dc_collector.cpp
+++ b/src/condor_daemon_client/dc_collector.cpp
@@ -285,6 +285,12 @@ DCCollector::sendUpdate( int cmd, ClassAd* ad1, DCCollectorAdSequences& adSeq, C
 {
 	if( ! _is_configured ) {
 			// nothing to do, treat it as success...
+			// Still fire the callback so any storage it owns (e.g. the
+			// misc_data captured by the lambda) is reclaimed; every other
+			// return path from sendUpdate invokes the callback exactly once.
+		if (callback) {
+			callback(true, nullptr, nullptr, "", false);
+		}
 		return true;
 	}
 


### PR DESCRIPTION
collector

For several of our update collector callbacks, we rely on the callback to free allocated data.  However, if there's no collector configured, we don't call the callback.  Change the contract to call the callback in this case, where all the existing handlers will do the right thing, and clean up.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
