### PR TITLE
(HTCONDOR-3829)  Incorrect disk usage calculations make common files very sad.

### DIFF
--- a/src/condor_starter.V6.1/execute_dir_monitor.cpp
+++ b/src/condor_starter.V6.1/execute_dir_monitor.cpp
@@ -23,12 +23,12 @@
 #include "execute_dir_monitor.h"
 #include "directory.h"
 
-DiskUsage ManualExecDirMonitor::GetDiskUsage() {
+DiskUsage ManualExecDirMonitor::GetDiskUsage(priv_state desired_priv) {
 	DiskUsage du;
 
 	// make sure this computation is done with user priv, since that
 	// is who owns the directory and it may not be world-readable
-	Directory dir(workingDir.c_str(), PRIV_USER);
+	Directory dir(workingDir.c_str(), desired_priv);
 	time_t begin_time = time(nullptr);
 	du.execute_size = dir.GetDirectorySize(&du.file_count);
 	time_t scan_time = time(nullptr) - begin_time;

--- a/src/condor_starter.V6.1/execute_dir_monitor.h
+++ b/src/condor_starter.V6.1/execute_dir_monitor.h
@@ -23,6 +23,7 @@
 #include "condor_sys_types.h"
 #include <string>
 #include <tuple>
+#include "condor_uid.h"
 
 /*
 *	DiskUsage holds the size of the working directory
@@ -47,7 +48,7 @@ public:
 	ExecDirMonitor& operator=(ExecDirMonitor&&) = default;
 	virtual ~ExecDirMonitor() = default;
 
-	virtual DiskUsage GetDiskUsage() = 0;
+	virtual DiskUsage GetDiskUsage(priv_state priv) = 0;
 	bool IsValid() const { return valid; }
 protected:
 	bool valid{true};
@@ -63,7 +64,7 @@ public:
 	ManualExecDirMonitor(const std::string& dir) : workingDir(dir) {
 		valid = workingDir.empty() ? false : true;
 	};
-	virtual DiskUsage GetDiskUsage();
+	virtual DiskUsage GetDiskUsage(priv_state priv = PRIV_USER);
 
 private:
 	std::string workingDir{};
@@ -76,7 +77,7 @@ private:
 class StatExecDirMonitor : public ExecDirMonitor {
 public:
 	StatExecDirMonitor() = default;
-	virtual DiskUsage GetDiskUsage() { return du; };
+	virtual DiskUsage GetDiskUsage(priv_state /* ignored */) { return du; };
 
 	DiskUsage du{};
 };

--- a/src/condor_starter.V6.1/starter.cpp
+++ b/src/condor_starter.V6.1/starter.cpp
@@ -4336,8 +4336,10 @@ Starter::GetDiskUsage(bool exiting) const {
 #endif /* LINUX */
 		}
 
-		if (dirMonitor) { return dirMonitor->GetDiskUsage(); }
-		else { return DiskUsage{0,0}; }
+		if (dirMonitor) { return dirMonitor->GetDiskUsage(PRIV_ROOT); }
+		// Make it possible for the caller to tell the difference between an
+		// empty directory and a failure.
+		else { return DiskUsage{-1,0}; }
 	}
 
 #ifdef LINUX

--- a/src/condor_starter.V6.1/starter_guidance.cpp
+++ b/src/condor_starter.V6.1/starter_guidance.cpp
@@ -537,12 +537,13 @@ Starter::handleJobSetupCommand(
 			context.InsertAttr( ATTR_RESULT, result );
 			context.InsertAttr( ATTR_STAGING_DIR, staging->path().string() );
 
-			const bool EXITING = true;
-			auto usage = s->GetDiskUsage(! EXITING);
+			const bool CORRECTLY = true;
+			auto usage = s->GetDiskUsage(CORRECTLY);
 			// To avoid over-complicating the WithInResourceLimits and
 			// quantize-disk expressions, the size here is in KiB
 			// (the units of `Disk`).
-			long long sizeOnDisk = (usage.execute_size / 1024) + 1;
+			auto sizeOnDisk = (usage.execute_size + 1023) / 1024;
+			dprintf( D_TEST, "cxfer: sizeOnDisk = %ld (KiB)\n", sizeOnDisk );
 			context.InsertAttr( ATTR_SIZE, sizeOnDisk );
 
 			continue_conversation(context);


### PR DESCRIPTION
When asking for how big the data slot is:
- pass the flag that says "get the correct answer";
- and don't deliberately skip the common files.

And while I was in the code:
- if the attempt to determine how big a directory is fails completely, don't return an answer suggesting that it's empty;
- and correctly round the reported size to KiB.

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
