### PR TITLE
HTCONDOR-3830: Fix librarian misrecovering rotation state after a res…

### DIFF
--- a/docs/version-history/v25-version.hist
+++ b/docs/version-history/v25-version.hist
@@ -6,6 +6,14 @@
 
 *** 25.13.0 bugs
 
+- Fixed a bug where the archive librarian could mistake a rotated history
+  file for the still-active one after a daemon restart, if the restart
+  landed before that file was fully read. This caused the file to never be
+  marked as fully read, and if it was later removed from disk, it would be
+  incorrectly renamed with a ``.REMOVED`` suffix and lose its recorded
+  rotation date.
+  :jira:`3830`
+
 *** 25.0.13 bugs
 
 *** 25.12.0 features

--- a/src/archive_librarian/dbHandler.cpp
+++ b/src/archive_librarian/dbHandler.cpp
@@ -954,7 +954,9 @@ bool DBHandler::maybeRecoverStatusAndFiles(std::map<std::string, ArchiveFile>& a
     }
     std::ignore = sqlite3_finalize(stmtS);
 
-    // 3. Recover Files — only non-deleted, non-rotated files (active tracking set)
+    // 3. Recover Files — every file not yet removed from disk (DateOfDeletion IS NULL).
+    //    This is NOT just the active file: a rotated file that hadn't finished being
+    //    read yet at shutdown is also still un-deleted and must be recovered here.
     const char* filesSql =
         "SELECT FileId, FileName, FileInode, FileHash, LastOffset, FullyRead, "
         "AvgRecordSize, RecordsRead "
@@ -978,6 +980,18 @@ bool DBHandler::maybeRecoverStatusAndFiles(std::map<std::string, ArchiveFile>& a
         file.records_read    = sqlite3_column_int64(stmtF, 7);
         file.size            = -1;
         file.last_modified   = 0;
+
+        // The Files table doesn't persist rotation_time in ArchiveFile's string form
+        // (DateOfRotation is a derived Unix timestamp used only for reporting), so
+        // rebuild it from the filename suffix — the same source makeArchiveFile() uses
+        // for freshly discovered files. Leaving this empty for a rotated file would make
+        // update() treat it as the still-active file: it would never be marked
+        // FullyRead on reaching EOF, and if later removed from disk it would be
+        // misrenamed to "<name>.REMOVED" with DateOfRotation reset to 0.
+        auto rotTime = extractRotationTime(fs::path(file.filename).filename().string());
+        if (rotTime) {
+            file.rotation_time = *rotTime;
+        }
 
         archiveFiles[file.filename] = std::move(file);
     }

--- a/src/archive_librarian/librarian.cpp
+++ b/src/archive_librarian/librarian.cpp
@@ -670,10 +670,9 @@ void Librarian::reconfig(bool startup) {
     config[i::DBMaxJobCacheSize]          = param_integer("LIBRARIAN_MAX_JOBS_CACHED", 10'000);
     config[i::StatusRetentionSeconds]     = param_integer("LIBRARIAN_STATUS_RETENTION_SECONDS", 300);
 
-    param_longlong("LIBRARIAN_MAX_UPDATES_PER_CYCLE", config[ll::MaxRecordsPerUpdate], true,
-                   100'000);
-    param_longlong("LIBRARIAN_MAX_DATABASE_SIZE", config[ll::DBMaxSizeBytes], true,
-                   2LL * 1024 * 1024 * 1024);
+    config[ll::MaxRecordsPerUpdate] = param_longlong("LIBRARIAN_MAX_UPDATES_PER_CYCLE", 100'000);
+    config[ll::DBMaxSizeBytes] = param_longlong("LIBRARIAN_MAX_DATABASE_SIZE",
+                                                 2LL * 1024 * 1024 * 1024);
 
     config[dbl::DBHighWaterMark] = param_double("LIBRARIAN_HIGH_WATER_MARK", 0.97, 0, 1);
     config[dbl::DBLowWaterMark] = param_double("LIBRARIAN_LOW_WATER_MARK", 0.80, 0, 1);

--- a/src/archive_librarian/librarian.cpp
+++ b/src/archive_librarian/librarian.cpp
@@ -58,34 +58,12 @@ static std::string computeFileHash(const std::string& path) {
     return hash;
 }
 
-// Extracts the YYYYMMDDTHHMMSS rotation timestamp from a filename suffix.
-// Returns nullopt when the filename has no rotation suffix.
 // NOTE: findHistoryFiles() gets all archive files and verifies that each
-//       is a rotated archive file in <basename>.YYYYMMDDTHHMMSS format
-// NOTE: rfind used so base filenames containing '.' (e.g. schedd1.history,
-//       foo.bar) are not mistaken for rotated files — the suffix is then
-//       validated: exactly 15 chars, 'T' at index 8, all other chars digits.
-static std::optional<std::string> extractRotationTime(const std::string& filename) {
-    auto pos = filename.rfind(".");
-
-    if (pos == std::string::npos || pos + 1 >= filename.length()) {
-        return std::nullopt;
-    }
-
-    std::string suffix = filename.substr(pos + 1);
-    if (suffix.length() != 15 || suffix[8] != 'T') {
-        return std::nullopt;
-    }
-
-    for (size_t i = 0; i < 15; ++i) {
-        if (i == 8) { continue; }
-        if ( ! std::isdigit(static_cast<unsigned char>(suffix[i]))) {
-            return std::nullopt;
-        }
-    }
-
-    return std::make_optional(suffix);
-}
+//       is a rotated archive file in <basename>.YYYYMMDDTHHMMSS format.
+// NOTE: extractRotationTime() (librarian_types.h) uses rfind so base filenames
+//       containing '.' (e.g. schedd1.history, foo.bar) are not mistaken for
+//       rotated files — the suffix is validated: exactly 15 chars, 'T' at
+//       index 8, all other chars digits.
 
 // Collects disk metadata for path and returns a populated ArchiveFile.
 // Returns nullopt if any required stat / hash step fails.
@@ -575,8 +553,8 @@ bool Librarian::update() {
                 updated.filename = removedName;
                 dbHandler_.updateFileInfo(updated);
             } else if ( ! info.fully_read) {
-                dprintf(D_STATUS, "update: rotated archive '%s' disappeared before being fully read; marking deleted in DB.\n",
-                        path.c_str());
+                dprintf(D_ERROR, "update: rotated archive '%s' disappeared before being fully read; "
+                        "any unread records in it are permanently lost.\n", path.c_str());
             }
 
             dbHandler_.markFileDeleted(info.id, now);

--- a/src/archive_librarian/librarian_types.h
+++ b/src/archive_librarian/librarian_types.h
@@ -1,11 +1,40 @@
 #pragma once
 
+#include <cctype>
 #include <cstdint>
 #include <ctime>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "archive_reader.h"
+
+// Extracts the YYYYMMDDTHHMMSS rotation timestamp from a filename suffix.
+// Returns nullopt when the filename has no rotation suffix.
+// Shared by librarian.cpp (fingerprinting freshly discovered files) and
+// dbHandler.cpp (reconstructing rotation_time for files recovered from the DB,
+// which does not persist DateOfRotation in a form ArchiveFile can reuse directly).
+inline std::optional<std::string> extractRotationTime(const std::string& filename) {
+    auto pos = filename.rfind(".");
+
+    if (pos == std::string::npos || pos + 1 >= filename.length()) {
+        return std::nullopt;
+    }
+
+    std::string suffix = filename.substr(pos + 1);
+    if (suffix.length() != 15 || suffix[8] != 'T') {
+        return std::nullopt;
+    }
+
+    for (size_t i = 0; i < 15; ++i) {
+        if (i == 8) { continue; }
+        if ( ! std::isdigit(static_cast<unsigned char>(suffix[i]))) {
+            return std::nullopt;
+        }
+    }
+
+    return std::make_optional(suffix);
+}
 
 struct ArchiveFile {
     std::unique_ptr<ArchiveReader> reader{};   // Forward reader; open until fully read then reset

--- a/src/condor_tests/CMakeLists.txt
+++ b/src/condor_tests/CMakeLists.txt
@@ -331,6 +331,7 @@ if (BUILD_TESTING)
 
 			if (HAVE_SQLITE3_H)
 				condor_pl_test(test_archive_librarian "Test basic librarian functionality" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
+				condor_pl_test(test_archive_librarian_restart_recovery "Test librarian rotation-time recovery across a daemon restart" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 			endif()
 
 			# Windows doesn't implement common file transfer yet, so jobs can't

--- a/src/condor_tests/test_archive_librarian.py
+++ b/src/condor_tests/test_archive_librarian.py
@@ -25,8 +25,8 @@ NUM_JOBS = 10
 
 DB_POLL_INTERVAL         = 2    # seconds between DB polls
 DB_POLL_TIMEOUT          = 120  # seconds before giving up
-UPDATE_INTERVAL          = 5    # seconds — matches LIBRARIAN_UPDATE_INTERVAL
-STATUS_RETENTION_SECONDS = 10   # seconds — short window to exercise Status pruning in tests
+UPDATE_INTERVAL          = 2    # seconds — matches LIBRARIAN_UPDATE_INTERVAL
+STATUS_RETENTION_SECONDS = 4    # seconds — short window to exercise Status pruning in tests
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -66,6 +66,44 @@ def _safe_job_count(db_path):
         return count
     except sqlite3.OperationalError:
         return 0
+
+
+def _restart_pool_and_wait_for_new_schedd(condor, timeout=60):
+    """
+    Restart every daemon under condor_master (including LIBRARIAN, since it's
+    in DAEMON_LIST) and block until a new SCHEDD process is confirmed alive.
+    SCHEDD's pid is used as the restart signal since condor_who reports it
+    reliably; LIBRARIAN restarts as part of the same condor_restart call.
+    """
+    who = condor.run_command(["condor_who", "-quick"])
+    assert who.returncode == 0, "Failed to query daemon information with condor_who"
+    old_pid = None
+    for line in who.stdout.split("\n"):
+        if line.startswith("SCHEDD_PID"):
+            old_pid = line.split("=")[1]
+            break
+    assert old_pid is not None, "Failed to get schedd pid before restart"
+
+    condor.run_command(["condor_restart", "-fast"])
+
+    start = time.time()
+    while True:
+        assert time.time() - start <= timeout, "Failed to restart condor"
+
+        who = condor.run_command(["condor_who", "-quick"])
+        if who.returncode == 0:
+            alive = False
+            pid = None
+            for line in who.stdout.split("\n"):
+                if line.startswith("SCHEDD_PID"):
+                    pid = line.split("=")[1]
+                elif line.startswith("SCHEDD =") and '"alive"' in line.lower():
+                    alive = True
+
+            if alive and pid is not None and pid != old_pid:
+                return
+
+        time.sleep(1)
 
 
 def _submit_and_wait(condor, log_path, path_to_sleep, count):
@@ -179,39 +217,9 @@ def post_rotation_handle(initial_db_snapshot, condor, test_dir, path_to_sleep):
 
     os.utime(str(rotated_path), None)
 
-    who = condor.run_command(["condor_who", "-quick"])
-    old_pid = None
-    assert who.returncode == 0, "Failed to query daemon information with condor_who"
-
-    for line in who.stdout.split("\n"):
-        if line.startswith("SCHEDD_PID"):
-            old_pid = line.split("=")[1]
-            break
-
-    assert old_pid is not None, "Failed to get schedd pid before restart"
-
-    # Restart the schedd to close file handle to rotated file
-    p = condor.run_command(["condor_restart", "-fast"])
-
-    # Wait for schedd to restart
-    start = time.time()
-    while True:
-        assert time.time() - start <= 60, "Failed to restart condor"
-
-        who = condor.run_command(["condor_who", "-quick"])
-        if who.returncode == 0:
-            alive = False
-            pid = None
-            for line in who.stdout.split("\n"):
-                if line.startswith("SCHEDD_PID"):
-                    pid = line.split("=")[1]
-                elif line.startswith("SCHEDD =") and '"alive"' in line.lower():
-                    alive = True
-
-            if alive and pid is not None and pid != old_pid:
-                break
-
-        time.sleep(1)
+    # Restart the schedd (and, incidentally, every other daemon in DAEMON_LIST)
+    # to close its file handle to the rotated file.
+    _restart_pool_and_wait_for_new_schedd(condor)
 
     handle = _submit_and_wait(condor, test_dir / "job_post_rotation.log", path_to_sleep, 1)
 

--- a/src/condor_tests/test_archive_librarian_restart_recovery.py
+++ b/src/condor_tests/test_archive_librarian_restart_recovery.py
@@ -5,12 +5,15 @@
 #
 # Scenario:
 #   1. Submit ROTATION_RECOVERY_NUM_JOBS jobs into the active history file,
-#      capping the librarian to 1 record/cycle so it can't drain them all
-#      before we rotate.
-#   2. Rotate the history file while records are still unread, and confirm
-#      the librarian recorded the rotation (DateOfRotation set) but hasn't
-#      finished draining it.
-#   3. Restart the whole pool (including LIBRARIAN) in that exact window.
+#      with the librarian's per-cycle record cap pinned to 0 so it cannot
+#      drain any of them yet.
+#   2. Rotate the history file and confirm the librarian recorded the
+#      rotation (DateOfRotation set) without draining it. This is a stable
+#      fixed point, not a timing window: Phase 3 of update() reads zero
+#      records per cycle no matter how many cycles run while the cap is 0,
+#      so there's nothing to race against.
+#   3. Raise the cap back up and restart the whole pool (including
+#      LIBRARIAN) while the rotated file is still fully undrained.
 #   4. Confirm the file eventually reaches FullyRead with no duplicated or
 #      lost records, and that removing it from disk afterwards doesn't
 #      corrupt its recorded name/rotation date.
@@ -42,34 +45,32 @@ def _get_db_path(condor):
         return Path(htcondor2.param["LIBRARIAN_DATABASE"])
 
 
-def _wait_for_db_job_count(condor, expected_count, timeout=DB_POLL_TIMEOUT):
+def _wait_for_active_file_registered(condor, expected_name, timeout=DB_POLL_TIMEOUT):
     """
-    Poll the librarian DB until JobRecords has at least `expected_count` rows,
-    or raise AssertionError on timeout.  Opens a fresh connection each poll so
-    we never observe a stale SQLite cache while the daemon is writing.
+    Poll until a Files row exists for `expected_name` with DateOfRotation
+    still NULL -- i.e. the librarian has run a reconcile cycle and adopted it
+    as the active file. Deliberately does not wait on any JobRecords being
+    read: with LIBRARIAN_MAX_UPDATES_PER_CYCLE pinned to 0, none ever will be
+    before we rotate below.
     """
     db_path = _get_db_path(condor)
     start = time.time()
     while True:
         assert time.time() - start <= timeout, (
-            f"Timed out after {timeout}s waiting for {expected_count} "
-            f"JobRecord(s) in librarian DB (last seen: {_safe_job_count(db_path)})"
+            f"Timed out after {timeout}s waiting for the librarian to "
+            f"register {expected_name!r} as the active archive file"
         )
-        count = _safe_job_count(db_path)
-        if count >= expected_count:
+        try:
+            conn = sqlite3.connect(str(db_path))
+            rows = conn.execute(
+                "SELECT FileName FROM Files WHERE DateOfRotation IS NULL"
+            ).fetchall()
+            conn.close()
+        except sqlite3.OperationalError:
+            rows = []
+        if any(Path(row[0]).name == expected_name for row in rows):
             return
         time.sleep(DB_POLL_INTERVAL)
-
-
-def _safe_job_count(db_path):
-    """Return current JobRecords row count, or 0 if the DB does not yet exist."""
-    try:
-        conn = sqlite3.connect(str(db_path))
-        count = conn.execute("SELECT COUNT(*) FROM JobRecords").fetchone()[0]
-        conn.close()
-        return count
-    except sqlite3.OperationalError:
-        return 0
 
 
 def _restart_pool_and_wait_for_new_schedd(condor, timeout=60):
@@ -172,9 +173,16 @@ def rotation_recovery_config():
         "config": {
             "DAEMON_LIST": "$(DAEMON_LIST) LIBRARIAN",
             "LIBRARIAN_UPDATE_INTERVAL": ROTATION_RECOVERY_UPDATE_INTERVAL,
-            # Cap ingestion to 1 record/cycle so the rotated file below
-            # reliably still has unread records at the moment we restart.
-            "LIBRARIAN_MAX_UPDATES_PER_CYCLE": 1,
+            # Pin ingestion to 0 records/cycle up front. This makes "rotated
+            # but not yet drained" a stable fixed point instead of a narrow
+            # window we'd otherwise have to catch mid-drain: with the cap at
+            # 0, Phase 3 of update() never reads a single record no matter how
+            # many cycles run, so FullyRead is guaranteed to stay 0 until we
+            # deliberately raise the cap back up (see
+            # rotated_file_after_restart). File discovery and rotation
+            # detection (Phase 1/1.5) aren't gated by this cap and keep
+            # running every cycle regardless.
+            "LIBRARIAN_MAX_UPDATES_PER_CYCLE": 0,
         }
     }
 
@@ -188,21 +196,23 @@ def rotation_recovery_condor(rotation_recovery_config, test_dir):
 @action
 def rotated_file_mid_drain(rotation_recovery_condor, test_dir, path_to_sleep):
     """
-    Rotate the active history file while it still has unread records, and
-    confirm the librarian has recorded the rotation (DateOfRotation set) but
-    has not yet finished draining it -- the DB state that must survive a
-    daemon restart intact.
+    Rotate the active history file while ingestion is capped at 0
+    records/cycle, and confirm the librarian recorded the rotation
+    (DateOfRotation set) without draining it -- the DB state that must
+    survive a daemon restart intact. With the cap at 0 this is a stable
+    fixed point rather than a narrow timing window, so there's nothing to
+    race against.
     """
     _submit_and_wait(
         rotation_recovery_condor, test_dir / "rr_job.log", path_to_sleep, ROTATION_RECOVERY_NUM_JOBS
     )
 
-    # Only wait for the *first* record: the 1-record/cycle cap means most of
-    # ROTATION_RECOVERY_NUM_JOBS are still unread by the time we rotate below.
-    _wait_for_db_job_count(rotation_recovery_condor, 1)
-
     with rotation_recovery_condor.use_config():
         history_path = Path(htcondor2.param["HISTORY"])
+
+    # Confirms the librarian has run a reconcile cycle and adopted "history"
+    # as the active file -- not that it has read anything from it.
+    _wait_for_active_file_registered(rotation_recovery_condor, history_path.name)
 
     timestamp = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
     rotated_path = history_path.parent / f"{history_path.name}.{timestamp}"
@@ -228,6 +238,15 @@ def rotated_file_after_restart(rotated_file_mid_drain, rotation_recovery_condor)
     librarian to finish draining it post-restart. Returns the file's final
     Files row: (FileName, DateOfRotation, FullyRead, RecordsRead, DateOfDeletion).
     """
+    # Ingestion was pinned to 0/cycle purely to land rotation in a
+    # deterministically undrained state; raise it back up so the post-restart
+    # librarian actually drains the backlog instead of holding at 0 forever.
+    # condor_restart re-reads the on-disk config file, so editing it here
+    # (rather than e.g. `condor_config_val -rset`, which wouldn't survive a
+    # full daemon restart) is what actually takes effect.
+    with rotation_recovery_condor.config_file.open("a") as f:
+        f.write("\nLIBRARIAN_MAX_UPDATES_PER_CYCLE = 100000\n")
+
     _restart_pool_and_wait_for_new_schedd(rotation_recovery_condor)
 
     db_path = _get_db_path(rotation_recovery_condor)

--- a/src/condor_tests/test_archive_librarian_restart_recovery.py
+++ b/src/condor_tests/test_archive_librarian_restart_recovery.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env pytest
+
+# Regression test for condor_librarian: a daemon restart landing between
+# "rotation detected" and "rotation fully drained".
+#
+# Scenario:
+#   1. Submit ROTATION_RECOVERY_NUM_JOBS jobs into the active history file,
+#      capping the librarian to 1 record/cycle so it can't drain them all
+#      before we rotate.
+#   2. Rotate the history file while records are still unread, and confirm
+#      the librarian recorded the rotation (DateOfRotation set) but hasn't
+#      finished draining it.
+#   3. Restart the whole pool (including LIBRARIAN) in that exact window.
+#   4. Confirm the file eventually reaches FullyRead with no duplicated or
+#      lost records, and that removing it from disk afterwards doesn't
+#      corrupt its recorded name/rotation date.
+
+import datetime
+import os
+from pathlib import Path
+import sqlite3
+import time
+import htcondor2
+
+import pytest
+
+from ornithology import *
+
+DB_POLL_INTERVAL = 2    # seconds between DB polls
+DB_POLL_TIMEOUT  = 120  # seconds before giving up
+
+ROTATION_RECOVERY_NUM_JOBS        = 3
+ROTATION_RECOVERY_UPDATE_INTERVAL = 2  # seconds — matches LIBRARIAN_UPDATE_INTERVAL
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_db_path(condor):
+    """Return the LIBRARIAN_DATABASE path from the running pool config."""
+    with condor.use_config():
+        return Path(htcondor2.param["LIBRARIAN_DATABASE"])
+
+
+def _wait_for_db_job_count(condor, expected_count, timeout=DB_POLL_TIMEOUT):
+    """
+    Poll the librarian DB until JobRecords has at least `expected_count` rows,
+    or raise AssertionError on timeout.  Opens a fresh connection each poll so
+    we never observe a stale SQLite cache while the daemon is writing.
+    """
+    db_path = _get_db_path(condor)
+    start = time.time()
+    while True:
+        assert time.time() - start <= timeout, (
+            f"Timed out after {timeout}s waiting for {expected_count} "
+            f"JobRecord(s) in librarian DB (last seen: {_safe_job_count(db_path)})"
+        )
+        count = _safe_job_count(db_path)
+        if count >= expected_count:
+            return
+        time.sleep(DB_POLL_INTERVAL)
+
+
+def _safe_job_count(db_path):
+    """Return current JobRecords row count, or 0 if the DB does not yet exist."""
+    try:
+        conn = sqlite3.connect(str(db_path))
+        count = conn.execute("SELECT COUNT(*) FROM JobRecords").fetchone()[0]
+        conn.close()
+        return count
+    except sqlite3.OperationalError:
+        return 0
+
+
+def _restart_pool_and_wait_for_new_schedd(condor, timeout=60):
+    """
+    Restart every daemon under condor_master (including LIBRARIAN, since it's
+    in DAEMON_LIST) and block until a new SCHEDD process is confirmed alive.
+    SCHEDD's pid is used as the restart signal since condor_who reports it
+    reliably; LIBRARIAN restarts as part of the same condor_restart call.
+    """
+    who = condor.run_command(["condor_who", "-quick"])
+    assert who.returncode == 0, "Failed to query daemon information with condor_who"
+    old_pid = None
+    for line in who.stdout.split("\n"):
+        if line.startswith("SCHEDD_PID"):
+            old_pid = line.split("=")[1]
+            break
+    assert old_pid is not None, "Failed to get schedd pid before restart"
+
+    condor.run_command(["condor_restart", "-fast"])
+
+    start = time.time()
+    while True:
+        assert time.time() - start <= timeout, "Failed to restart condor"
+
+        who = condor.run_command(["condor_who", "-quick"])
+        if who.returncode == 0:
+            alive = False
+            pid = None
+            for line in who.stdout.split("\n"):
+                if line.startswith("SCHEDD_PID"):
+                    pid = line.split("=")[1]
+                elif line.startswith("SCHEDD =") and '"alive"' in line.lower():
+                    alive = True
+
+            if alive and pid is not None and pid != old_pid:
+                return
+
+        time.sleep(1)
+
+
+def _wait_for_rotation_recorded(condor, fully_read, timeout=DB_POLL_TIMEOUT):
+    """Poll until some Files row has DateOfRotation set and FullyRead == `fully_read` (0 or 1)."""
+    db_path = _get_db_path(condor)
+    start = time.time()
+    while True:
+        assert time.time() - start <= timeout, (
+            f"Timed out waiting for a rotated file with FullyRead={fully_read}"
+        )
+        try:
+            conn = sqlite3.connect(str(db_path))
+            row = conn.execute(
+                r"SELECT FileId FROM Files WHERE DateOfRotation IS NOT NULL AND FullyRead = ?",
+                (fully_read,),
+            ).fetchone()
+            conn.close()
+        except sqlite3.OperationalError:
+            row = None
+        if row is not None:
+            return
+        time.sleep(DB_POLL_INTERVAL)
+
+
+def _submit_and_wait(condor, log_path, path_to_sleep, count):
+    """Submit `count` instant-exit jobs and wait for all to complete."""
+    handle = condor.submit(
+        description={
+            "executable": path_to_sleep,
+            "universe": "vanilla",
+            "arguments": "0",
+            "log": str(log_path),
+        },
+        count=count,
+    )
+    assert handle.wait(
+        condition=ClusterState.all_complete,
+        fail_condition=ClusterState.any_held,
+        timeout=120,
+        verbose=True,
+    ), "Jobs did not complete within the timeout"
+
+    # Wait for ads to be written into archive file
+    with condor.use_config():
+        schedd = htcondor2.Schedd()
+        start = time.time()
+        ads = []
+        while len(ads) != count:
+            assert time.time() - start <= 30, "Failed to see all archived records written"
+            ads = schedd.history(constraint=f"ClusterId=={handle.clusterid}", projection=["ProcId"], match=count)
+
+    return handle
+
+
+# ---------------------------------------------------------------------------
+# Pool configuration + fixtures: restart while a rotated file is mid-drain
+# ---------------------------------------------------------------------------
+
+@config
+def rotation_recovery_config():
+    return {
+        "config": {
+            "DAEMON_LIST": "$(DAEMON_LIST) LIBRARIAN",
+            "LIBRARIAN_UPDATE_INTERVAL": ROTATION_RECOVERY_UPDATE_INTERVAL,
+            # Cap ingestion to 1 record/cycle so the rotated file below
+            # reliably still has unread records at the moment we restart.
+            "LIBRARIAN_MAX_UPDATES_PER_CYCLE": 1,
+        }
+    }
+
+
+@standup
+def rotation_recovery_condor(rotation_recovery_config, test_dir):
+    with Condor(local_dir=test_dir / "condor_rotation_recovery", **rotation_recovery_config) as condor:
+        yield condor
+
+
+@action
+def rotated_file_mid_drain(rotation_recovery_condor, test_dir, path_to_sleep):
+    """
+    Rotate the active history file while it still has unread records, and
+    confirm the librarian has recorded the rotation (DateOfRotation set) but
+    has not yet finished draining it -- the DB state that must survive a
+    daemon restart intact.
+    """
+    _submit_and_wait(
+        rotation_recovery_condor, test_dir / "rr_job.log", path_to_sleep, ROTATION_RECOVERY_NUM_JOBS
+    )
+
+    # Only wait for the *first* record: the 1-record/cycle cap means most of
+    # ROTATION_RECOVERY_NUM_JOBS are still unread by the time we rotate below.
+    _wait_for_db_job_count(rotation_recovery_condor, 1)
+
+    with rotation_recovery_condor.use_config():
+        history_path = Path(htcondor2.param["HISTORY"])
+
+    timestamp = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
+    rotated_path = history_path.parent / f"{history_path.name}.{timestamp}"
+    history_path.rename(rotated_path)
+    os.utime(str(rotated_path), None)
+
+    # NOTE: deliberately no job submitted here. The schedd's file descriptor
+    # for "history" stays open across the rename (POSIX renames don't affect
+    # already-open fds), so any job completed now would be appended to the
+    # just-rotated file's old inode rather than a fresh "history" -- rotation
+    # detection itself doesn't need a new active file to exist on disk; it
+    # matches the rotated path against the in-memory/recovered active entry.
+    _wait_for_rotation_recorded(rotation_recovery_condor, fully_read=0)
+
+    return rotated_path
+
+
+@action
+def rotated_file_after_restart(rotated_file_mid_drain, rotation_recovery_condor):
+    """
+    Restart the whole pool (including LIBRARIAN) while the rotated file from
+    `rotated_file_mid_drain` still has unread records, then wait for the
+    librarian to finish draining it post-restart. Returns the file's final
+    Files row: (FileName, DateOfRotation, FullyRead, RecordsRead, DateOfDeletion).
+    """
+    _restart_pool_and_wait_for_new_schedd(rotation_recovery_condor)
+
+    db_path = _get_db_path(rotation_recovery_condor)
+    start = time.time()
+    row = None
+    while True:
+        assert time.time() - start <= DB_POLL_TIMEOUT, (
+            f"Rotated file never reached FullyRead after librarian restart (last row: {row})"
+        )
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            r"SELECT FileName, DateOfRotation, FullyRead, RecordsRead, DateOfDeletion "
+            r"FROM Files WHERE FileName LIKE ?",
+            (f"%{rotated_file_mid_drain.name}%",),
+        ).fetchone()
+        conn.close()
+        if row is not None and row[2] == 1:
+            return row
+        time.sleep(DB_POLL_INTERVAL)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestLibrarianRestartMidRotation:
+    """
+    Regression coverage for a librarian restart landing between "rotation
+    detected" and "rotation fully drained". Before the fix, recovery wiped
+    ArchiveFile::rotation_time, so the rotated file was mistaken for the
+    still-active file: it never reached FullyRead, and removing it from disk
+    misrenamed it to "<name>.REMOVED" with DateOfRotation reset to 0.
+    """
+
+    def test_rotation_time_survives_restart(self, rotated_file_after_restart):
+        filename, date_of_rotation, fully_read, _, _ = rotated_file_after_restart
+        assert date_of_rotation is not None and date_of_rotation > 0, (
+            "DateOfRotation was lost across a librarian restart -- the rotated "
+            "file was mistaken for the active file on recovery"
+        )
+        assert fully_read == 1, "Rotated file never reached FullyRead after restart"
+        assert not filename.endswith(".REMOVED"), (
+            f"Rotated file name was corrupted to {filename!r}"
+        )
+
+    def test_no_duplicate_or_lost_records(self, rotated_file_after_restart):
+        """RecordsRead must equal exactly the original job count -- no records
+        re-read (duplicated) or skipped across the restart."""
+        _, _, _, records_read, _ = rotated_file_after_restart
+        assert records_read == ROTATION_RECOVERY_NUM_JOBS, (
+            f"Expected exactly {ROTATION_RECOVERY_NUM_JOBS} records read from the "
+            f"rotated file, got {records_read} (duplicate or missed reads across restart)"
+        )
+
+    def test_removal_after_restart_keeps_rotation_metadata(
+        self, rotated_file_mid_drain, rotated_file_after_restart, rotation_recovery_condor
+    ):
+        """
+        Once the rotated file is fully drained and later removed from disk, it
+        must be marked deleted under its real name and rotation date -- not
+        misrenamed as if it were the active file (the symptom seen in production).
+        """
+        rotated_file_mid_drain.unlink()
+
+        db_path = _get_db_path(rotation_recovery_condor)
+        start = time.time()
+        row = None
+        while True:
+            assert time.time() - start <= DB_POLL_TIMEOUT, (
+                f"Deleted rotated file was never marked DateOfDeletion (last row: {row})"
+            )
+            conn = sqlite3.connect(str(db_path))
+            row = conn.execute(
+                r"SELECT FileName, DateOfRotation, DateOfDeletion FROM Files WHERE FileName LIKE ?",
+                (f"%{rotated_file_mid_drain.name}%",),
+            ).fetchone()
+            conn.close()
+            if row is not None and row[2] is not None:
+                break
+            time.sleep(DB_POLL_INTERVAL)
+
+        filename, date_of_rotation, date_of_deletion = row
+        assert date_of_rotation is not None and date_of_rotation > 0, (
+            "DateOfRotation was lost by the time the rotated file was removed from disk"
+        )
+        assert date_of_deletion is not None
+        assert not filename.endswith(".REMOVED"), (
+            f"A rotated file removed from disk was misrenamed to {filename!r} -- "
+            "treated as an unexpectedly-removed active file instead of a rotated one"
+        )


### PR DESCRIPTION
…tart

DBHandler::maybeRecoverStatusAndFiles() rebuilt ArchiveFile state from the DB after a restart but never restored rotation_time, so a rotated file that hadn't finished being read yet was recovered as if it were still the active file. That file could then never be marked FullyRead, and if later removed from disk it was misrenamed to "<name>.REMOVED" with its rotation date reset to 0 -- the exact corruption seen in production. Recovery now reconstructs rotation_time from the filename's timestamp suffix, the same source used when files are first discovered.

Also bump the "rotated archive disappeared before being fully read" log line from D_STATUS to D_ERROR, since it represents a permanent, silent loss of unread records, not routine status.

Added test_archive_librarian_restart_recovery.py, a regression test that restarts the pool while a rotated file is mid-drain. Split out of test_archive_librarian.py into its own ctest target so the two independent Condor pools run concurrently under `ctest -j` rather than sequentially in one pytest process, and tightened that file's hardcoded sleeps to cut its runtime.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
