### PR TITLE
(HTCONDOR-3850)  Evict data slot(s) regardless of clean-up order.

### DIFF
--- a/src/condor_schedd.V6/schedd.cpp
+++ b/src/condor_schedd.V6/schedd.cpp
@@ -11115,7 +11115,7 @@ Scheduler::addMatchToSinful( const std::string & sinful, match_rec * match ) {
 
 bool
 Scheduler::mark_catalog_dead( const std::string & catalogName ) {
-	dprintf( D_ZKM, "mark_catalog_dead(%s)\n", catalogName.c_str() );
+	dprintf( D_TEST, "mark_catalog_dead(%s)\n", catalogName.c_str() );
 
 	if( catalogToTimerMap.contains( catalogName ) ) {
 		dprintf( D_ZKM, "mark_catalog_dead(%s): catalog already dead, ignoring.\n", catalogName.c_str() );
@@ -11168,7 +11168,7 @@ Scheduler::mark_catalog_dead( const std::string & catalogName ) {
 
 bool
 Scheduler::mark_catalog_live( const std::string & catalogName ) {
-	dprintf( D_ZKM, "mark_catalog_live(%s)\n", catalogName.c_str() );
+	dprintf( D_TEST, "mark_catalog_live(%s)\n", catalogName.c_str() );
 
 	if(! catalogToTimerMap.contains(catalogName)) {
 	    dprintf( D_ZKM, "mark_catalog_live(%s): catalog not dead, ignoring.\n", catalogName.c_str() );

--- a/src/condor_schedd.V6/schedd.cpp
+++ b/src/condor_schedd.V6/schedd.cpp
@@ -11157,6 +11157,7 @@ Scheduler::mark_catalog_dead( const std::string & catalogName ) {
 			dprintf( D_ZKM, "mark_catalog_dead(%s): time expired, marking shadow retiring.\n", catalogName.c_str() );
 			(* shadow)->cxfer_state = CXFER_STATE::RETIRING;
 			send_vacate( (* shadow)->match, RELEASE_CLAIM );
+			catalogToTimerMap.erase( catalogName );
 		},
 		"terminate transfer shadow lease"
 	);

--- a/src/condor_schedd.V6/schedd.cpp
+++ b/src/condor_schedd.V6/schedd.cpp
@@ -13581,6 +13581,20 @@ Scheduler::delete_shadow_rec( shadow_rec *rec )
 	// deleted, make sure to delete this shadow's maps.
 	unregister_shadow_catalogs(rec, rec->pid);
 
+	//
+	// The above only does anything if this shadow is a transfer shadow,
+	// which is correct as far as it goes.  However, we only check to see
+	// if this shadow is the last non-transfer shadow in unlinkMrec(), and
+	// sometimes (condor_rm), that means we'll never call unlinkMrec() on
+	// a match record that still has a shadow record, and the checking code
+	// will never trigger.  Since, clearly, the reverse is also true (that
+	// we _do_ call unlinkMrec() with a shadowrec), we just have to do this
+	// in both places.
+	//
+	if( rec->match ) {
+		mark_catalogs_dead_if_last_consumer( rec, rec->match->peer );
+	}
+
 	if ( FindSrecByProcID(rec->job_id) == NULL ) {
 		// add_shadow_rec() wasn't called, do simple cleanup
 		// TODO Failure to spawn a reconnect shadow should probably still
@@ -13726,7 +13740,7 @@ Scheduler::delete_shadow_rec( shadow_rec *rec )
 		rec->match->setStatus( M_CLAIMED );
 	}
 
-	if( rec->keepClaimAttributes &&  rec->match ) {
+	if( rec->keepClaimAttributes && rec->match ) {
 			// We are shutting down and detaching from this claim.
 			// Remove the claim record without sending RELEASE_CLAIM
 			// to the startd.
@@ -14642,7 +14656,6 @@ Scheduler::child_exit(int pid, int status)
 		// We always want to delete the shadow record regardless
 		// of how the job exited
 		delete_shadow_rec( pid );
-
 	}
 
 	//
@@ -17679,7 +17692,6 @@ Scheduler::DelMrec(char const* id)
 	return DelMrec(it->second);
 }
 
-
 int
 Scheduler::DelMrec(match_rec *match) {
 	if (this->unlinkMrec(match) == 0) {
@@ -17729,50 +17741,7 @@ Scheduler::unlinkMrec(match_rec* match)
 		removeMatchFromSinful( match->peer, match );
 	}
 
-	// If every other claim against this match's startd points to a transfer
-	// shadow, then start a timer to release those claims unless another claim
-	// arrives in time.  To avoid a loop, only do this for transfer matches.
-	if( match->shadowRec && match->peer ) {
-		switch( match->shadowRec->cxfer_state ) {
-			case CXFER_STATE::INVALID:
-				break;
-			case CXFER_STATE::MAPPING: {
-				auto matches = getMatchesBySinful( match->peer );
-				if( matches ) {
-					size_t count = 0;
-					for( const auto & match : * matches ) {
-						if( match->shadowRec ) {
-							switch( match->shadowRec->cxfer_state ) {
-								case CXFER_STATE::INVALID:
-								case CXFER_STATE::MAPPING:
-									break;
-								case CXFER_STATE::RETIRING:
-									break;
-								case CXFER_STATE::STAGED:
-								case CXFER_STATE::STAGING:
-									++count;
-							}
-						}
-					}
-
-					if( count == matches->size() ) {
-						for( const auto & match : * matches ) {
-							for( const auto & [name, _] : match->shadowRec->cxfer_catalogs ) {
-								mark_catalog_dead( name );
-							}
-						}
-					}
-				}
-				} break;
-			case CXFER_STATE::STAGING:
-				break;
-			case CXFER_STATE::STAGED:
-				break;
-			case CXFER_STATE::RETIRING:
-				break;
-		}
-	}
-
+	mark_catalogs_dead_if_last_consumer( match->shadowRec, match->peer );
 
 	PROC_ID jobId;
 	jobId.cluster = match->cluster;
@@ -17842,6 +17811,63 @@ Scheduler::unlinkMrec(match_rec* match)
 
 	numMatches--;
 	return 0;
+}
+
+void
+Scheduler::mark_catalogs_dead_if_last_consumer( shadow_rec * shadowRec, char * peer ) {
+	// If every other claim against this match's startd points to a transfer
+	// shadow, then start a timer to release those claims unless another claim
+	// arrives in time.  To avoid a loop, only do this for transfer matches.
+	if( shadowRec && peer ) {
+		switch( shadowRec->cxfer_state ) {
+			case CXFER_STATE::INVALID:
+				break;
+			case CXFER_STATE::MAPPING: {
+				auto matches = getMatchesBySinful( peer );
+				if( matches ) {
+					// This code sees two matches when called from
+					// delete_shadow_rec() because it hasn't unlinked from
+					// its match record yet.  Rather than move the call,
+					// don't include shadowRec in the matches.
+					std::erase_if( * matches,
+						[shadowRec](match_rec * m) -> bool {
+							return m->shadowRec == shadowRec;
+						}
+					);
+
+					size_t count = 0;
+					for( const auto & match : * matches ) {
+						if( match->shadowRec ) {
+							switch( match->shadowRec->cxfer_state ) {
+								case CXFER_STATE::INVALID:
+								case CXFER_STATE::MAPPING:
+									break;
+								case CXFER_STATE::RETIRING:
+									break;
+								case CXFER_STATE::STAGED:
+								case CXFER_STATE::STAGING:
+									++count;
+							}
+						}
+					}
+
+					if( count == matches->size() ) {
+						for( const auto & match : * matches ) {
+							for( const auto & [name, _] : match->shadowRec->cxfer_catalogs ) {
+								mark_catalog_dead( name );
+							}
+						}
+					}
+				}
+				} break;
+			case CXFER_STATE::STAGING:
+				break;
+			case CXFER_STATE::STAGED:
+				break;
+			case CXFER_STATE::RETIRING:
+				break;
+		}
+	}
 }
 
 shadow_rec*

--- a/src/condor_schedd.V6/scheduler.h
+++ b/src/condor_schedd.V6/scheduler.h
@@ -908,6 +908,13 @@ class Scheduler : public Service
 	// Stop the timer, if any, waiting to release the claim.
 	bool mark_catalog_live( const std::string & catalogName );
 
+	// When we delete a match record, we also check to see if the corresponding
+	// shadow is the last shadow to require any particular catalog, so that we
+	// can mark those catalogs dead.  In some cases, the schedd will delete a
+	// shadow record before it deletes the match record, so we need to check
+	// in both places.
+	void mark_catalogs_dead_if_last_consumer( shadow_rec * shadowRec, char * peer );
+
 
 	// After obtaining the final form of a job ad (after transforms), there's
 	// some C++ code we'd like to run to fix a few things up.

--- a/src/condor_tests/CMakeLists.txt
+++ b/src/condor_tests/CMakeLists.txt
@@ -526,6 +526,7 @@ endif()
 			condor_pl_test(test_dagman_multiple_common_containers "Test CIF shadow exit codes" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py;src/condor_tests/libcontainer.py")
 			condor_pl_test(test_cif_shadow_recycle "Test shadow recycling with CIF jobs" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py;src/condor_tests/libcontainer.py")
 			condor_pl_test(test_command_data_slot "Verify the COMMAND_DATA_SLOT's client passes the MATCH session along" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
+			condor_pl_test(test_cif_rm "Do we always remove data slots" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 			condor_pl_test(test_cif_disk_usage "Do we compute disk usage for CIF jobs correctly" "quick;ctest" CTEST DEPENDS "src/condor_tests/ornithology;src/condor_tests/conftest.py")
 		endif()
 

--- a/src/condor_tests/test_cif_rm.py
+++ b/src/condor_tests/test_cif_rm.py
@@ -95,9 +95,10 @@ class TestCIF:
         for slot in results:
             if "data" in slot['Name']:
                 num_data_slots += 0
+        assert num_data_slots == 1
 
         # Wait for KEEP_DATA_CLAIM_IDLE to pass and a little slop.
-        time.sleep(20+1)
+        time.sleep(20+5)
 
         results = the_condor.status(
             ad_type = htcondor2.AdType.Startd,

--- a/src/condor_tests/test_cif_rm.py
+++ b/src/condor_tests/test_cif_rm.py
@@ -94,7 +94,7 @@ class TestCIF:
         num_data_slots = 0
         for slot in results:
             if "data" in slot['Name']:
-                num_data_slots += 0
+                num_data_slots += 1
         assert num_data_slots == 1
 
         # Wait for KEEP_DATA_CLAIM_IDLE to pass and a little slop.

--- a/src/condor_tests/test_cif_rm.py
+++ b/src/condor_tests/test_cif_rm.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env pytest
+
+import time
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+import htcondor2
+from ornithology import (
+    action,
+    ClusterState,
+    Condor,
+)
+
+
+# In this test, we submit a bunch of CIF-enabled jobs, wait for them to get
+# started, and then remove them.  This should set a timer to remove the data
+# slot created for the CIF-enabled jobs, and when that timer fires, release
+# the data slot's claim.  This did not used to happen.
+# -----------------------------------------------------------------------------
+
+
+@action
+def the_condor( test_dir ):
+    local_dir = test_dir / "the_condor.d"
+
+    with Condor(
+        local_dir=local_dir,
+        config={
+            "STARTER_DEBUG":    "D_CATEGORY D_SUB_SECOND D_PID D_TEST",
+            "SHADOW_DEBUG":     "D_CATEGORY D_SUB_SECOND D_PID D_TEST",
+            "SCHEDD_DEBUG":     "D_CATEGORY D_SUB_SECOND D_PID D_TEST",
+
+            "NUM_CPUS":                 4,
+            "KEEP_DATA_CLAIM_IDLE":     20,
+        },
+    ) as the_condor:
+        yield the_condor
+
+
+@action
+def the_common_file( test_dir ):
+    local_dir = test_dir / "the_condor.d"
+    common_file = local_dir / "common-file"
+
+    contents = "1234567890abcdef" * 64 * 128
+    common_file.write_text(contents)
+
+    return common_file
+
+
+@action
+def the_removed_jobs( the_condor, the_common_file ):
+    job_description = {
+        "shell":                    "sleep 3000",
+
+        "universe":                 "vanilla",
+        "should_transfer_files":    "YES",
+        "request_cpus":             1,
+        "request_memory":           1,
+        "request_disk":             1024,
+        "log":                      "the_running_jobs.log.$(ClusterID)",
+        "MY.CommonInputFiles":      f'"{the_common_file.as_posix()}"',
+    }
+
+    job_handle = the_condor.submit(
+        description=job_description,
+        count=8,
+    )
+
+    assert job_handle.wait(
+        timeout=120,
+        condition=ClusterState.running_exactly(4),
+        fail_condition=ClusterState.any_terminal,
+    )
+
+    the_condor.act( htcondor2.JobAction.Remove, job_handle.clusterid )
+
+    return job_handle
+
+
+class TestCIF:
+
+    def test_data_slot_gone(self, the_condor, the_removed_jobs):
+        print()
+        results = the_condor.status(
+            ad_type = htcondor2.AdType.Startd,
+            projection = ['Name', 'Disk'],
+        )
+        print("Immediately after job removal:")
+        print(results)
+
+        num_data_slots = 0
+        for slot in results:
+            if "data" in slot['Name']:
+                num_data_slots += 0
+
+        # Wait for KEEP_DATA_CLAIM_IDLE to pass and a little slop.
+        time.sleep(20+1)
+
+        results = the_condor.status(
+            ad_type = htcondor2.AdType.Startd,
+            projection = ['Name', 'Disk'],
+        )
+        print()
+        print("After waiting KEEP_DATA_CLAIM_IDLE:")
+        print(results)
+
+        assert len(results) == 1
+        assert "data" not in results[0]['Name']

--- a/src/condor_tests/test_cif_rm.py
+++ b/src/condor_tests/test_cif_rm.py
@@ -77,7 +77,20 @@ def the_removed_jobs( the_condor, the_common_file ):
 
     the_condor.act( htcondor2.JobAction.Remove, job_handle.clusterid )
 
-    return job_handle
+    print()
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        # What we're actually waiting for is all of the shadows to die.
+        results = the_condor.query(
+            projection=['ClusterID', 'ProcID', 'JobStatus']
+        )
+        print(time.time())
+        print(results)
+        if len(results) == 0:
+            return job_handle
+        time.sleep(5)
+
+    assert False
 
 
 class TestCIF:


### PR DESCRIPTION
We need to check to see if a data slot is no longer being used (and should therefore trigger a lease timer) both at match record and at shadow record deletion time (because sometimes the latter is deleted before the former and makes the check impossible to perform.)

# HTCondor Pull Request Checklist for internal reviewers

- [x] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [x] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [x] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [x] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [x] Verify that the branch destination of the PR matches the target version of the ticket
- [x] Check for correctness of change
- [x] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [x] Check Github Actions successfully run (build and test)
- [x] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
