### PR TITLE
HTCONDOR-3858: Accept "the execution point" wording in xfer hold reas…

### DIFF
--- a/src/condor_tests/test_xfer_hold_codes.py
+++ b/src/condor_tests/test_xfer_hold_codes.py
@@ -11,11 +11,11 @@
 
 import logging
 import classad
+import re
 from ornithology import *
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
-
 
 @action
 def submitJobInputFailureAP(default_condor):
@@ -163,6 +163,10 @@ def jobCredFailureAP(submitJobCredFailureAP):
    return submitJobCredFailureAP.query()[0]
 
 
+def check_reason_string(reason: str, direction: str, source: str):
+    assert re.search(rf"Transfer {direction} files failure at (?:the )?{source}", reason)
+
+
 class TestXferHoldCodes:
    def test_submit_all(self,
       submitJobInputFailureAP, submitJobOutputFailureAP,
@@ -175,24 +179,24 @@ class TestXferHoldCodes:
 
    def test_jobInputFailureAP(self, jobInputFailureAP):
       assert jobInputFailureAP["HoldReasonCode"] == 13
-      assert "Transfer input files failure at access point" in jobInputFailureAP["HoldReason"] 
+      check_reason_string(jobInputFailureAP["HoldReason"], "input", "access point")
 
 
    def test_jobOutputFailureAP(self, jobOutputFailureAP):
       assert jobOutputFailureAP["HoldReasonCode"] == 12
-      assert "Transfer output files failure at access point" in jobOutputFailureAP["HoldReason"]
+      check_reason_string(jobOutputFailureAP["HoldReason"], "output", "access point")
 
 
    def test_jobInputFailureEP(self, jobInputFailureEP):
       assert jobInputFailureEP["HoldReasonCode"] == 13
       assert jobInputFailureEP["HoldReasonSubCode"] == (1 << 8)
-      assert "Transfer input files failure at execution point" in jobInputFailureEP["HoldReason"]
+      check_reason_string(jobInputFailureEP["HoldReason"], "input", "execution point")
 
 
    def test_jobOutputFailureEP(self, jobOutputFailureEP):
       assert jobOutputFailureEP["HoldReasonCode"] == 12
       assert jobOutputFailureEP["HoldReasonSubCode"] == 2
-      assert "Transfer output files failure at execution point" in jobOutputFailureEP["HoldReason"]
+      check_reason_string(jobOutputFailureEP["HoldReason"], "output", "execution point")
 
 
    def test_jobCredFailureAP(self, jobCredFailureAP):
@@ -203,10 +207,10 @@ class TestXferHoldCodes:
    def test_jobPluginOutputFailureEP(self, jobPluginOutputFailureEP):
       assert jobPluginOutputFailureEP["HoldReasonCode"] == 12
       assert jobPluginOutputFailureEP["HoldReasonSubCode"] == (17 << 8)
-      assert "Transfer output files failure at execution point" in jobPluginOutputFailureEP["HoldReason"]
+      check_reason_string(jobPluginOutputFailureEP["HoldReason"], "output", "execution point")
 
 
    def test_jobPluginInputFailureEP(self, jobPluginInputFailureEP):
       assert jobPluginInputFailureEP["HoldReasonCode"] == 13
       assert jobPluginInputFailureEP["HoldReasonSubCode"] == (17 << 8)
-      assert "Transfer input files failure at execution point" in jobPluginInputFailureEP["HoldReason"]
+      check_reason_string(jobPluginInputFailureEP["HoldReason"], "input", "execution point")


### PR DESCRIPTION
…on test

BaseShadow::improveReasonAttributes silently drops the parsed slot name and falls back to the generic "the execution point" wording whenever "<slot>@<host>" is 50 characters or longer. Update the hold reason assertions to accept both the named-slot and generic forms.

<Insert PR description here, and leave checklist below for code review.>

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check Github Actions successfully run (build and test)
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
