### PR TITLE
HTCONDOR-3247: Enforce HISTORY_HELPER_MAX_CONCURRENCY

### DIFF
--- a/src/condor_utils/history_queue.cpp
+++ b/src/condor_utils/history_queue.cpp
@@ -138,8 +138,8 @@ int HistoryHelperQueue::command_handler(int cmd, Stream* stream)
 	}
 
 	if (m_requests >= m_max_concurrency) {
-		if ((int)m_queue.size() > m_max_requests) {
-			return sendHistoryErrorAd(stream, 9, "Cowardly refusing to queue more than 1000 requests.");
+		if (m_queue.size() >= static_cast<size_t>(m_max_requests)) {
+			return sendHistoryErrorAd(stream, 9, "Cowardly refusing to queue more than " + std::to_string(m_max_requests) + " requests.");
 		}
 		classad_shared_ptr<Stream> stream_shared(stream);
 		HistoryHelperState state(stream_shared, requirements_str, since_str, proj_str, match_limit, record_src);

--- a/src/condor_utils/history_queue.cpp
+++ b/src/condor_utils/history_queue.cpp
@@ -137,7 +137,7 @@ int HistoryHelperQueue::command_handler(int cmd, Stream* stream)
 		searchDir = false;
 	}
 
-	if (m_requests >= m_max_requests) {
+	if (m_requests >= m_max_concurrency) {
 		if (m_queue.size() > 1000) {
 			return sendHistoryErrorAd(stream, 9, "Cowardly refusing to queue more than 1000 requests.");
 		}
@@ -165,7 +165,7 @@ int HistoryHelperQueue::command_handler(int cmd, Stream* stream)
 
 int HistoryHelperQueue::reaper(int, int) {
 	m_requests--;
-	while ((m_requests < m_max_requests) && m_queue.size() > 0) {
+	while ((m_requests < m_max_concurrency) && m_queue.size() > 0) {
 		auto it = m_queue.begin();
 		launcher(*it);
 		m_queue.erase(it);

--- a/src/condor_utils/history_queue.cpp
+++ b/src/condor_utils/history_queue.cpp
@@ -138,7 +138,7 @@ int HistoryHelperQueue::command_handler(int cmd, Stream* stream)
 	}
 
 	if (m_requests >= m_max_concurrency) {
-		if (m_queue.size() > 1000) {
+		if ((int)m_queue.size() > m_max_requests) {
 			return sendHistoryErrorAd(stream, 9, "Cowardly refusing to queue more than 1000 requests.");
 		}
 		classad_shared_ptr<Stream> stream_shared(stream);


### PR DESCRIPTION
`HISTORY_HELPER_MAX_CONCURRENCY` is stored in `m_max_concurrency` but never used for admission control. Both the admission check and the reaper's refill loop compare the running-helper count against `m_max_requests`, which is `1000`:

- https://github.com/htcondor/htcondor/blob/82c74b5244fd7434f3b5a9e7d69291c796263c94/src/condor_schedd.V6/schedd.cpp#L16685-L16686
- https://github.com/htcondor/htcondor/blob/82c74b5244fd7434f3b5a9e7d69291c796263c94/src/condor_startd.V6/startd_main.cpp#L267

So, up to 1000 helpers can run concurrently and the configured value has no effect unless it is `0`. [Docs](https://htcondor.readthedocs.io/en/lts/admin-manual/configuration-macros.html#HISTORY_HELPER_MAX_CONCURRENCY).

We hit 498 concurrent helpers on a 16-CPU CMS schedd running the default of 50 -> load average ~500, schedd unusable for a few hours.

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check Github Actions successfully run (build and test)
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)