### PR TITLE
condor_adstash: jsonfile interface(s) set 'json_dir' to 'log_dir' if present in 'kwargs'

### DIFF
--- a/src/condor_scripts/adstash/interfaces/json_file.py
+++ b/src/condor_scripts/adstash/interfaces/json_file.py
@@ -26,7 +26,7 @@ class JSONFileInterface(NullInterface):
 
 
     def __init__(self, json_dir=Path.cwd(), log_mappings=True, **kwargs):
-        self.json_dir = Path(json_dir)
+        self.json_dir = Path(kwargs.get("log_dir", json_dir))
         self.log_mappings = log_mappings
 
 


### PR DESCRIPTION
ADSTASH_JSON_DIR had no effect on the json log location.

- json_dir is loaded into iface_kwargs["log_dir"]: https://github.com/htcondor/htcondor/blob/main/src/condor_scripts/adstash/adstash.py#L78
- The JSONFileInterface is always using the default json_dir=Path.cwd() and never kwargs["log_dir"]: https://github.com/htcondor/htcondor/blob/main/src/condor_scripts/adstash/interfaces/json_file.py#L29


# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check Github Actions successfully run (build and test)
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
