### PR TITLE
condor_adstash: Add NDJSON interface

### DIFF
--- a/docs/man-pages/condor_adstash.rst
+++ b/docs/man-pages/condor_adstash.rst
@@ -15,7 +15,7 @@ Synopsis
 **condor_adstash** [**-\-process_name** *NAME*] [**-\-standalone** ]
 [**-\-sample_interval** *SECONDS*] [**-\-checkpoint_file** *PATH*]
 [**-\-log_file** *PATH*] [**-\-log_level** *LEVEL*]
-[**-\-threads** *THREADS*] [**-\-interface** *{null,elasticsearch,jsonfile}*]
+[**-\-threads** *THREADS*] [**-\-interface** *{null,elasticsearch,jsonfile,jsonlinefile}*]
 [**-\-collectors** *COLLECTORS*] [**-\-schedds** *SCHEDDS*] [**-\-startds** *STARTDS*]
 [**-\-schedd_history** ] [**-\-startd_history** ]
 [**-\-schedd_job_epoch_history** ] [**-\-schedd_transfer_epoch_history** ]
@@ -79,7 +79,7 @@ Options
  **-\-threads** *THREADS*
     Number of parallel threads to use when polling for job ClassAds and when
     pushing documents to Elasticsearch
- **-\-interface** *{null,elasticsearch,opensearch,jsonfile}*
+ **-\-interface** *{null,elasticsearch,opensearch,jsonfile,jsonlinefile}*
     Push ads via the chosen interface
 
 ClassAd source options

--- a/src/condor_scripts/adstash/interfaces/json_line_file.py
+++ b/src/condor_scripts/adstash/interfaces/json_line_file.py
@@ -1,0 +1,55 @@
+# Copyright 2022 HTCondor Team, Computer Sciences Department,
+# University of Wisconsin-Madison, WI.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from pathlib import Path
+
+from adstash.interfaces.json_file import JSONFileInterface as Interface
+
+class JSONFileInterface(Interface):
+    """Append ClassAds to a single file where each ad is a single json line.
+
+    This interface is almost identical to json_file.JSONFileInterface,
+    but appends to the same log file instead of creating a new one each time.
+    Each 'ad' is written without indention (not 'pretty').
+    
+    Most log aggregators watch a log file and expect logs to be separated by a new-line character.
+    Each additional line is then processed as an incoming log to be sent to a database or log server.
+
+    The log file should be rotated by an external tool like: 'logrotate'
+
+    use the following configuration macro:
+    ADSTASH_INTERFACE = jsonlinefile
+    """
+
+    def __init__(self, json_dir=Path.cwd(), log_mappings=True, **kwargs):
+        super().__init__(json_dir, log_mappings, **kwargs)
+
+    def post_ads(self, ads, metadata={}, **kwargs):
+        body = self.make_body(ads, metadata)
+        if len(body) > 0:
+            self.write_mappings(self.log_mappings, self.json_dir, **kwargs)
+
+        json_file = self.json_dir / "adstash_line_file.json"
+        # open the file in 'append' mode
+        with json_file.open("a") as f:
+            for ad in body:
+                # write but do not indent
+                json.dump(ad, f, sort_keys=True)
+                # append newline
+                f.write("\n")
+
+        return {"success": len(body), "error": 0}

--- a/src/condor_scripts/adstash/interfaces/registry.py
+++ b/src/condor_scripts/adstash/interfaces/registry.py
@@ -26,6 +26,9 @@ def opensearch_interface():
 def json_file_interface():
     from adstash.interfaces.json_file import JSONFileInterface
     return JSONFileInterface
+def json_line_file_interface():
+    from adstash.interfaces.json_line_file import JSONFileInterface
+    return JSONFileInterface
 
 
 ADSTASH_INTERFACE_REGISTRY = {
@@ -33,5 +36,6 @@ ADSTASH_INTERFACE_REGISTRY = {
     "elasticsearch": {"class": elasticsearch_interface, "type": "se"},
     "opensearch": {"class": opensearch_interface, "type": "se"},
     "jsonfile": {"class": json_file_interface, "type": "jsonfile"},
+    "jsonlinefile": {"class": json_line_file_interface, "type": "jsonfile"},
 }
 ADSTASH_INTERFACES = list(ADSTASH_INTERFACE_REGISTRY.keys())


### PR DESCRIPTION
Most log aggregators watch a log file and expect logs to be separated by a new-line character. Each additional line is then processed as an incoming log to be sent to a database or log server.

This interface is almost identical to json_file.JSONFileInterface, but appends to the same log file instead of creating a new one each time. Each 'ad' is written without indention (not 'pretty').

# HTCondor Pull Request Checklist for internal reviewers

- [ ] Verify that (GitHub thinks) the merge is clean. If it isn't, and you're confident you can resolve the conflicts, do so. Otherwise, send it back to the original developer.
- [ ] Verify that the related Jira ticket exists and has a target version number and that it is correct.
- [ ] Verify that the Jira ticket is in review status and is assigned to the reviewer.
- [ ] Verify that the Jira ticket (HTCONDOR-xxx) is mentioned at the beginning of the title. Edit it, if not
- [ ] Verify that the branch destination of the PR matches the target version of the ticket
- [ ] Check for correctness of change
- [ ] Check for regression test(s) of new features and bugfixes (if the feature doesn't require root)
- [ ] Check for documentation, if needed  (documentation [build logs](https://app.readthedocs.org/projects/htcondor/builds/))
- [ ] Check for version history, if needed
- [ ] Check BaTLab dashboard for successful build (https://batlab-ap2001.chtc.wisc.edu/results/workspace.php) and test for either the PR or a workspace build by the developer that has the Jira ticket as a comment.
- [ ] Check Github Actions successfully run (build and test)
- [ ] Check that each commit message references the Jira ticket (HTCONDOR-xxx)

## After the above
- Hit the merge button if the pull request is approved and it is not a security patch (security changes require 2 additional reviews)
- If the pull request is approved, take the ticket out of review state
- Assign JIRA Ticket back to the developer
